### PR TITLE
wip(phase2): diagnose multi-flagella bundling stability

### DIFF
--- a/conf/sim_swim.yaml
+++ b/conf/sim_swim.yaml
@@ -19,7 +19,9 @@ flagella:
   # 初期接線方向:
   # - side_attach: 既定値。菌体側面から横向きに出す従来条件。
   # - posterior_aligned: 診断用。hookは側面付着のまま、べん毛接線を菌体後方へ向ける。
+  # - initial_tangent_vs_rear_deg: 指定時はmodeより優先。0=後方軸, 90=従来side_attach。
   initial_orientation_mode: "side_attach"
+  initial_tangent_vs_rear_deg: null
   n_beads_per_flagellum: 11    # [-] 各べん毛の初期ビーズ数（論文離散化準拠）
   discretization:
     ds_over_b: 0.58            # [-] 隣接間隔 ds/b（Table 1 の L=0.58b 相当）

--- a/conf/sim_swim.yaml
+++ b/conf/sim_swim.yaml
@@ -16,6 +16,10 @@ flagella:
   n_flagella: 3                # [-] べん毛本数（論文条件）
   placement_mode: "uniform"   # 終端層の断面ビーズへ均等に付着
   init_mode: "paper_table1"   # 初期べん毛のsource-of-truth: bond/theta/phi/n_beads
+  # 初期接線方向:
+  # - side_attach: 既定値。菌体側面から横向きに出す従来条件。
+  # - posterior_aligned: 診断用。hookは側面付着のまま、べん毛接線を菌体後方へ向ける。
+  initial_orientation_mode: "side_attach"
   n_beads_per_flagellum: 11    # [-] 各べん毛の初期ビーズ数（論文離散化準拠）
   discretization:
     ds_over_b: 0.58            # [-] 隣接間隔 ds/b（Table 1 の L=0.58b 相当）
@@ -24,7 +28,7 @@ flagella:
   helix_init:
     radius_over_b: 0.25        # [-] 初期ヘリックス半径（直径0.5b）
     pitch_over_b: 2.5          # [-] 初期ヘリックスピッチ
-  # NOTE: base tangent / hook configuration is always side-attach (no toggle flag)
+  # NOTE: posterior_aligned は後方束化を短時間で見るための診断条件。
 
 fluid:
   viscosity_Pa_s: 0.001        # [Pa*s] 水相当
@@ -93,6 +97,7 @@ time:
 
 output_sampling:
   out_all_steps_3d: true       # true: 3D は dt ごと全step保存
+  fps_out_3d: 25.0             # [Hz] out_all_steps_3d=false のときの3D動画出力fps
   fps_out_2d: 25.0             # [Hz] 2D は固定25Hzで間引き
 
 brownian:

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -116,6 +116,8 @@ Phase 2.6では，従来の `flag_phase_rate_hz` と `median(abs(flag_helix_spin
 
 Phase 2.7では，旧P2-7（複数べん毛の非崩壊検証）と旧P2-8（後方束化判定）を統合し，**崩壊せず，かつ後方束化する条件**を探索する。主な探索軸は `n_flagella`, `motor.torque_Nm`, hook初期角度または付着直後の接線方向である。短時間で束化候補を見たい場合は，すべてのべん毛が菌体後方へ向くよう hook 角度・初期姿勢を調整した条件を代表条件に含める。束化は完全な二値判定が難しく，1本だけ独立する部分束化も想定されるため，定量指標は束中心軸への距離，束参加率，独立べん毛数，束軸と菌体軸の角度を候補とし，最終判定には目視レビューも含める。
 
+2026-06-04時点のPhase 2.7診断では，`flagella.initial_tangent_vs_rear_deg` により菌体後方軸からの初期接線角度を `0, 10, 30, 60, 90 deg` で探索し，flagella-flagella repulsion診断も追加した。`10 deg`, `0.5e-20 N m`, `local_spring_scale=1.2` および `10 deg`, `1.0e-20 N m`, `local_spring_scale=2.0` は `duration_s=0.5`, `dt_star=1.0e-4` でshape gateを通過したが，`bundle_participation_ratio=0.0`, `flag_flag_close_pair_count=0` で後方束化は未達だった。一方，より高トルクでは束化前にhook length gateが破綻した。現時点では，形状が保てるトルク帯では `no_bundle_drive`，トルク上昇時は `hook_drift` が支配的な失敗原因である。
+
 Phase 2.8では，崩壊しない多本べん毛条件を使い，遊泳挙動を運動指標で評価する。特に，べん毛束軸と菌体軸がずれた場合に菌体姿勢がどれだけ揺れるかを，body axis の角度変化，angular velocity，姿勢揺らぎ，束軸-body軸角度として定量化する。本数差によって推進量や姿勢安定性がどう変わるかを比較する。長時間実行では `dt_star=1.0e-4` により3D出力枚数が過大になるため，Phase 2.7または2.8の前提整備として `output_sampling.fps_out_3d` を導入し，3D動画保存を間引けるようにする。
 
 ### Phase 2運用フェーズ（A/B/C/D）と現状

--- a/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/review_result.json
+++ b/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/review_result.json
@@ -35,7 +35,7 @@
   "adr_required": false,
   "adr_reason": "今回は診断用初期条件、出力サンプリング、診断指標、sweep toolingの追加であり、物理モデル本体の新しい決定は行っていない。hook破綻対策として物理モデルを変更する場合は別途ADR候補。",
   "commit_type": "diagnostic",
-  "commit_hash": "08ce65e",
+  "commit_hash": "d4702ffc54ea388565e45ec979c27a547f65b3ee",
   "push_status": "pushed",
   "next_actions": [
     "hook破綻を抑える条件を、motor.local_spring_scale, motor.local_hook_scale, hook初期形状, hook spring/bendの役割から切り分ける。",

--- a/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/review_result.json
+++ b/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/review_result.json
@@ -1,0 +1,45 @@
+{
+  "status": "FAIL",
+  "summary": "Phase 2.7の実装基盤として fps_out_3d、posterior_aligned初期条件、束化・遊泳指標、専用torque sweepを追加した。短時間では形状PASSするが、0.5 s代表条件では低トルクでもhook first-failとなり、後方束化も未確認だった。",
+  "blocking_issues": [
+    "n_flagella=3, posterior_aligned, duration_s=0.5, time.dt_star=1.0e-4 で 0.5e-20, 1.0e-20, 2.0e-20 N m がいずれも hook first-fail になる。",
+    "motor.local_spring_scale=1.2 はhook破綻を遅らせるが、0.5e-20 N mでも最終stepで hook_len_rel_err_max=1.0713 となりshape gate未達。",
+    "posterior_alignedで束軸は後方を向くが、bundle_participation_ratio=0.0 のままで後方束化は未確認。"
+  ],
+  "non_blocking_issues": [
+    "0.5 sを多数条件で直接sweepすると計算時間が大きい。短時間screening後に代表条件だけ0.5 sへ伸ばす運用が必要。",
+    "束化分類閾値は初期実装であり、目視レビューと追加データで調整する必要がある。"
+  ],
+  "tests_reviewed": [
+    "uv run ruff check src/sim_swim/model/builder.py src/sim_swim/render/render3d.py src/sim_swim/sim/core.py src/sim_swim/sim/debug_summary.py src/sim_swim/sim/params.py scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py tests/test_model_builder.py tests/test_params.py tests/test_render_state_and_projection.py tests/test_simulation.py tests/test_phase2_7_bundling_sweep.py",
+    "uv run pytest tests/test_phase2_7_bundling_sweep.py tests/test_params.py tests/test_model_builder.py tests/test_simulation.py tests/test_render_state_and_projection.py -k \"phase27 or initial_orientation or posterior_aligned or flagella_base_tangent or output_sampling_fps or select_frames\" -q (15 passed)",
+    "uv run pytest -q (163 passed)",
+    "commit hook: uv run ruff format --check .",
+    "commit hook: uv run ruff check .",
+    "commit hook: uv run pytest -q (163 passed)"
+  ],
+  "user_review_required": true,
+  "user_review_command": "uv run python -m scripts.01_simulate_swimming time.duration_s=0.1 time.dt_star=1.0e-4 flagella.n_flagella=3 flagella.initial_orientation_mode=posterior_aligned motor.torque_Nm=0.5e-20 motor.local_spring_scale=1.2 output_sampling.out_all_steps_3d=false output_sampling.fps_out_3d=25 render.save_frames_2d=false render.save_frames_3d=true",
+  "user_review_outputs": [
+    "outputs/2026-06-03/203936/render/swim3d.mp4",
+    "outputs/2026-06-03/203936/render/swim3d_final.png",
+    "outputs/2026-06-03/203936/sim/step_summary.csv",
+    "outputs/phase2_7_bundling_sweep/2026-06-03_n3_dt1e4_dur0p02/phase2_7_bundling_sweep_summary.csv",
+    "outputs/phase2_7_bundling_sweep/2026-06-03_n3_posterior_torque0p5e20_spring1p2_dur0p5/phase2_7_bundling_sweep_summary.csv"
+  ],
+  "user_review_points": [
+    "posterior_alignedで初期べん毛が菌体後方を向いているか。",
+    "0.1 s動画で後方束化に見える接近があるか。自動指標ではbundle_participation_ratio=0.0。",
+    "菌体の推進や姿勢変化が視覚的に不自然でないか。"
+  ],
+  "adr_required": false,
+  "adr_reason": "今回は診断用初期条件、出力サンプリング、診断指標、sweep toolingの追加であり、物理モデル本体の新しい決定は行っていない。hook破綻対策として物理モデルを変更する場合は別途ADR候補。",
+  "commit_type": "diagnostic",
+  "commit_hash": "08ce65e",
+  "push_status": "pushed",
+  "next_actions": [
+    "hook破綻を抑える条件を、motor.local_spring_scale, motor.local_hook_scale, hook初期形状, hook spring/bendの役割から切り分ける。",
+    "後方へ向くが束化しない原因を、flagella間距離、流体相互作用、接触・反発、初期配置から切り分ける。",
+    "shape gate PASSが0.5 sで得られるまで、P2-7-006の完了チェックは更新しない。"
+  ]
+}

--- a/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/work_log.md
+++ b/docs/codex-runs/20260603_203726_phase2_p2-7-006_bundling_stability/work_log.md
@@ -1,0 +1,26 @@
+# Phase 2.7 bundling stability diagnostics
+
+## 実装
+
+- `output_sampling.fps_out_3d` を追加し、3D動画を `out_all_steps_3d=false` で間引けるようにした。
+- `flagella.initial_orientation_mode=posterior_aligned` を追加し、hookは側面付着のまま、べん毛初期接線を菌体後方へ向けられるようにした。
+- `step_summary.csv` に束化候補指標と菌体遊泳指標を追加した。
+- `scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py` を追加し、Phase 2.7のtorque sweep summaryを出力できるようにした。
+
+## 診断結果
+
+短時間 `duration_s=0.02`, `n_flagella=3`, `time.dt_star=1.0e-4` では、`side_attach` / `posterior_aligned` と `1.0e-20, 2.0e-20, 3.0e-20 N m` の6条件すべてで `shape_pass_nonbody=True` だった。
+
+0.5秒代表では、`posterior_aligned` の `0.5e-20, 1.0e-20, 2.0e-20 N m` がいずれも最終的に `hook` first-fail となった。`motor.local_spring_scale=1.2` はhook破綻を遅らせたが、`0.5e-20 N m` でも最終stepは `shape_pass_nonbody=False` だった。
+
+後方へ向けること自体はできているが、`bundle_participation_ratio=0.0` のままであり、後方束化は未確認。
+
+## 出力
+
+- `outputs/phase2_7_bundling_sweep/2026-06-03_n3_dt1e4_dur0p02/phase2_7_bundling_sweep_summary.csv`
+- `outputs/phase2_7_bundling_sweep/2026-06-03_n3_posterior_torque0p5e20_spring1p2_dur0p5/phase2_7_bundling_sweep_summary.csv`
+- `outputs/2026-06-03/203936/render/swim3d.mp4`
+
+## 判定
+
+Review result は `FAIL`。実装基盤と診断は進んだが、Phase 2.7完了条件である「0.5秒以上のshape gate PASSかつ後方束化候補」は未達。

--- a/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
+++ b/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
@@ -25,8 +25,8 @@
   "adr_required": false,
   "adr_reason": "今回の変更は既存のPhase 2.7診断に初期角度指定とCSV診断指標を追加したもので、物理モデルの採用判断や重大な仕様変更ではない。束化未達の原因整理はPhase 2.7計画書へ記録した。",
   "commit_type": "diagnostic",
-  "commit_hash": "",
-  "push_status": "not_pushed",
+  "commit_hash": "2d6c300",
+  "push_status": "pushed",
   "next_actions": [
     "distributed_flagellum または診断modeで多本べん毛を比較し、torqueが届いた場合にも束化しないかを確認する。",
     "hook drift を局所spring補強以外の方法で抑える方針を検討する。",

--- a/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
+++ b/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
@@ -25,7 +25,7 @@
   "adr_required": false,
   "adr_reason": "今回の変更は既存のPhase 2.7診断に初期角度指定とCSV診断指標を追加したもので、物理モデルの採用判断や重大な仕様変更ではない。束化未達の原因整理はPhase 2.7計画書へ記録した。",
   "commit_type": "diagnostic",
-  "commit_hash": "2d6c300",
+  "commit_hash": "0e127a70535c7296e21876a9d56ae03ea837a828",
   "push_status": "pushed",
   "next_actions": [
     "distributed_flagellum または診断modeで多本べん毛を比較し、torqueが届いた場合にも束化しないかを確認する。",

--- a/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
+++ b/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/review_result.json
@@ -1,0 +1,35 @@
+{
+  "status": "FAIL",
+  "summary": "Phase 2.7 の後方束化探索で、初期接線角度sweepとflagella-flagella repulsion診断を追加した。形状が保てる条件は見つかったが、後方束化は未達。失敗原因は no_bundle_drive と hook_drift に整理した。",
+  "blocking_issues": [
+    "n_flagella=3, duration_s=0.5, dt_star=1.0e-4 で shape gate PASS かつ posterior_bundle/partial_bundle の条件が見つかっていない。",
+    "形状が保てるトルク帯では bundle_participation_ratio=0.0 かつ flag_flag_close_pair_count=0 で、べん毛同士が束化距離まで近づかない。",
+    "トルクを上げると束化より先に hook length gate が破綻する。"
+  ],
+  "non_blocking_issues": [
+    "代表動画の目視確認は未実施。今回の結論は定量CSVに基づく診断であり、束化成功判定ではない。",
+    "distributed_flagellum または診断modeで多本べん毛を比較し、torque伝達不足と相互作用モデル不足をさらに切り分ける余地がある。"
+  ],
+  "tests_reviewed": [
+    "uv run pytest tests/test_params.py tests/test_model_builder.py tests/test_simulation.py::test_phase27_step_summary_includes_bundle_and_swimming_metrics tests/test_phase2_7_bundling_sweep.py",
+    "uv run ruff check src/sim_swim/model/builder.py src/sim_swim/sim/core.py src/sim_swim/sim/debug_summary.py src/sim_swim/sim/params.py scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py tests/test_params.py tests/test_model_builder.py tests/test_simulation.py tests/test_phase2_7_bundling_sweep.py",
+    "outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_screen_dur0p02/phase2_7_bundling_sweep_summary.csv",
+    "outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_representative_dur0p5/phase2_7_bundling_sweep_summary.csv",
+    "outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_torque_escalation_dur0p5/phase2_7_bundling_sweep_summary.csv",
+    "outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_spring2_dur0p5/phase2_7_bundling_sweep_summary.csv"
+  ],
+  "user_review_required": false,
+  "user_review_command": "",
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "今回の変更は既存のPhase 2.7診断に初期角度指定とCSV診断指標を追加したもので、物理モデルの採用判断や重大な仕様変更ではない。束化未達の原因整理はPhase 2.7計画書へ記録した。",
+  "commit_type": "diagnostic",
+  "commit_hash": "",
+  "push_status": "not_pushed",
+  "next_actions": [
+    "distributed_flagellum または診断modeで多本べん毛を比較し、torqueが届いた場合にも束化しないかを確認する。",
+    "hook drift を局所spring補強以外の方法で抑える方針を検討する。",
+    "流体相互作用または近接相互作用が後方束化を作れる実装になっているか確認する。"
+  ]
+}

--- a/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/work_log.md
+++ b/docs/codex-runs/20260604_115416_phase2_p2-7-006_angle_repulsion/work_log.md
@@ -1,0 +1,55 @@
+# Phase 2.7 P2-7-006 角度sweep・反発診断ログ
+
+## 目的
+
+複数べん毛で、形状崩壊せず後方束化する条件が見つかるかを確認する。特に、初期接線を菌体後方軸から少し開いた条件にし、束化しない原因がべん毛同士の反発・接触なのか、束化駆動不足なのかを切り分ける。
+
+## 実装
+
+- `flagella.initial_tangent_vs_rear_deg` を追加した。
+  - `0 deg`: 菌体後方軸。
+  - `10 deg`: 主候補。後方を向きつつ少し外側へ開く。
+  - `90 deg`: 従来 `side_attach` 相当。
+- `run_phase2_7_bundling_sweep.py` に `--tangent-angles-deg` を追加した。
+- `step_summary.csv` に flagella-flagella segment distance / close-contact count / repulsion force 診断列を追加した。
+- `docs/phase2/phase2_7_bundling_stability_plan.md`, `docs/phase2/phase2_tasks.md`, `docs/PROJECT_PLAN.md` に結果を記録した。
+
+## 実行
+
+短時間screening:
+
+```bash
+uv run python scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py --duration-s 0.02 --dt-star 1.0e-4 --torques 0.5e-20,1.0e-20 --n-flagella 3 --tangent-angles-deg 0,10,30,60,90 --output-dir outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_screen_dur0p02 render.save_frames_3d=false render.save_frames_2d=false output_sampling.out_all_steps_3d=false output_sampling.fps_out_3d=25 motor.local_spring_scale=1.2
+```
+
+0.5秒代表条件:
+
+```bash
+uv run python scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py --duration-s 0.5 --dt-star 1.0e-4 --torques 0.5e-20 --n-flagella 3 --tangent-angles-deg 0,10,30 --output-dir outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_representative_dur0p5 render.save_frames_3d=false render.save_frames_2d=false output_sampling.out_all_steps_3d=false output_sampling.fps_out_3d=25 motor.local_spring_scale=1.2
+```
+
+10度でのトルク上昇:
+
+```bash
+uv run python scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py --duration-s 0.5 --dt-star 1.0e-4 --torques 1.0e-20,2.0e-20 --n-flagella 3 --tangent-angles-deg 10 --output-dir outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_torque_escalation_dur0p5 render.save_frames_3d=false render.save_frames_2d=false output_sampling.out_all_steps_3d=false output_sampling.fps_out_3d=25 motor.local_spring_scale=1.2
+```
+
+10度でのhook補強:
+
+```bash
+uv run python scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py --duration-s 0.5 --dt-star 1.0e-4 --torques 1.0e-20,2.0e-20 --n-flagella 3 --tangent-angles-deg 10 --output-dir outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_spring2_dur0p5 render.save_frames_3d=false render.save_frames_2d=false output_sampling.out_all_steps_3d=false output_sampling.fps_out_3d=25 motor.local_spring_scale=2.0
+```
+
+## 結果
+
+- 短時間screeningでは全10条件が shape gate PASS。ただし全条件 `no_bundle`, `bundle_participation_ratio=0.0`, `flag_flag_close_pair_count=0`。
+- `initial_tangent_vs_rear_deg=10`, `torque_Nm=0.5e-20`, `local_spring_scale=1.2`, `duration_s=0.5` は shape gate PASS。ただし束化なし。
+- `initial_tangent_vs_rear_deg=10`, `torque_Nm=1.0e-20`, `local_spring_scale=2.0`, `duration_s=0.5` も shape gate PASS。ただし束化なし。
+- `1.0e-20` を `local_spring_scale=1.2` で回す条件、および `2.0e-20` 条件では、束化より先に hook length gate が破綻した。
+
+## 判定
+
+今回の探索範囲では、後方束化成功条件は見つからなかった。
+
+原因は、形状が保てるトルク帯では `no_bundle_drive`、トルクを上げた条件では `hook_drift` が先行すること。flagella-flagella repulsion は今回の失敗主因ではない。
+

--- a/docs/phase2/phase2_7_bundling_stability_plan.md
+++ b/docs/phase2/phase2_7_bundling_stability_plan.md
@@ -1,0 +1,158 @@
+# Phase 2.7: 複数べん毛の後方束化・非崩壊条件探索
+
+## 目的
+
+Phase 2.7 では、単一べん毛で確認した `material_twist_local_couple` を複数べん毛へ拡張し、螺旋形状・hook・body が崩壊しないまま後方束化する条件を探す。
+
+最終的には、後方束化したべん毛束によって菌体がどの程度推進し、姿勢がどの程度揺れるかも確認する。単に「束化して見える」だけでなく、遊泳挙動として利用できるかを評価する。
+
+## 基本方針
+
+検証は次の順で行う。
+
+1. 自然初期条件で多べん毛の形状安定トルク帯を求める。
+2. hook角度または初期接線方向を調整し、全べん毛を菌体後方へ向けた `posterior_aligned` 条件を作る。
+3. `posterior_aligned` 条件で安定トルク帯を再探索し、後方束化候補を分類する。
+4. 後方束化候補条件で、菌体の推進量と姿勢変化を定量化する。
+
+この順序にする理由は、最初から後方へ揃えた条件だけを見ると、自然初期条件での多べん毛耐性と、人工的に後方へ向けた初期条件の影響を切り分けにくいためである。
+
+## 実行条件
+
+- `motor.force_distribution=material_twist_local_couple` を主条件とする。
+- `distributed_flagellum` は、torque がべん毛全体へ届いた場合の診断用比較modeとして残す。
+- `time.dt_star=1.0e-4` はCLI overrideで指定し、デフォルト設定は変更しない。
+- 最低検証時間は `duration_s=0.5` とする。
+- 代表条件が見えたら `duration_s=1.0` 以上も検討する。
+- 3D動画は `output_sampling.fps_out_3d` で間引き、長時間レビュー可能なフレーム数にする。
+
+## torque sweep
+
+最初の探索は `n_flagella=3` に固定し、single flagellum の代表条件 `2.0e-20 N m` を中心に粗く見る。
+
+初期候補:
+
+- `0.5e-20 N m`
+- `1.0e-20 N m`
+- `1.5e-20 N m`
+- `2.0e-20 N m`
+- `2.5e-20 N m`
+- `3.0e-20 N m`
+
+多べん毛では flagella 間干渉で不安定化する可能性があるため、上限は結果を見てから広げる。
+
+## posterior aligned 条件
+
+`posterior_aligned` は、自然な初期条件ではなく、短時間で後方束化を観察しやすくするための診断条件として扱う。
+
+目標は、各べん毛の初期接線方向が菌体長軸の後方成分を持つことである。完全に同じ軸へ重ねるのではなく、付着点と螺旋位相の差は残す。これにより、後方束化しやすい条件を作りつつ、べん毛間干渉や部分束化も観察できるようにする。
+
+## 分類
+
+各条件は次のカテゴリに分類する。
+
+- `posterior_bundle`: 多数のべん毛が後方側で近接し、束軸が菌体後方を向く。
+- `partial_bundle`: 2本以上は束化するが、1本以上が独立する。
+- `no_bundle`: 崩壊しないが束化しない。
+- `collapse`: shape gate fail、fly-away、hook破綻、flagellum形状崩壊のいずれか。
+
+1本のみ独立する状態は即FAILとはせず、`partial_bundle` として記録する。
+
+## 指標
+
+形状安定性:
+
+- `shape_pass_nonbody`
+- `first_fail_category_nonbody`
+- `hook_len_rel_err_max`
+- `flag_bond_rel_err_max`
+- `flag_bend_err_max_deg`
+- `flag_torsion_err_max_deg`
+- `net_abs_flag_helix_spin_revolutions`
+
+束化:
+
+- 束中心軸への距離
+- 束参加率
+- 独立べん毛数
+- flagella間距離
+- bundle axis と body axis の角度
+- bundle axis の後方成分
+
+遊泳:
+
+- body重心移動量
+- body平均速度
+- body axis の累積角度変化
+- body angular velocity RMS
+- body姿勢揺らぎRMS
+- bundle axis と body axis の角度
+
+## 完了条件
+
+- `n_flagella=3`, `duration_s>=0.5`, `time.dt_star=1.0e-4` で shape gate PASS の代表条件がある。
+- 自然初期条件と `posterior_aligned` 条件のそれぞれについて、torque と分類結果の表がある。
+- `posterior_bundle` または `partial_bundle` の候補条件が1つ以上ある。
+- 束化候補条件で、菌体推進量と姿勢変化の指標が出力される。
+- 代表動画と確認観点を review_result に記録する。
+
+## 2026-06-03 実装・診断結果
+
+### 追加した実装
+
+- `output_sampling.fps_out_3d` を追加し、`output_sampling.out_all_steps_3d=false` のときに3D動画を指定fpsで間引けるようにした。
+- `flagella.initial_orientation_mode` を追加した。
+  - `side_attach`: 既定値。既存の側面付着条件で、初期接線は菌体後方に対して約90度。
+  - `posterior_aligned`: 診断用。hookは側面付着のまま、べん毛初期接線を菌体後方へ向ける。
+- `step_summary.csv` に束化・遊泳候補指標を追加した。
+- `scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py` を追加し、orientation mode / n_flagella / torque のsweep結果を `phase2_7_bundling_sweep_summary.csv` に集約できるようにした。
+
+### 短時間スクリーニング
+
+条件:
+
+- `n_flagella=3`
+- `time.dt_star=1.0e-4`
+- `duration_s=0.02`
+- `motor.force_distribution=material_twist_local_couple`
+- `torque_Nm = 1.0e-20, 2.0e-20, 3.0e-20`
+- `initial_orientation_mode = side_attach, posterior_aligned`
+
+結果:
+
+- 6条件すべてで `shape_pass_nonbody=True`。
+- `side_attach` は束軸が菌体後方に対して約90度で、後方束化候補ではない。
+- `posterior_aligned` は束軸自体は後方を向くが、`bundle_participation_ratio=0.0` のままで、短時間では束化しない。
+- 出力: `outputs/phase2_7_bundling_sweep/2026-06-03_n3_dt1e4_dur0p02/phase2_7_bundling_sweep_summary.csv`
+
+### 0.5秒代表条件
+
+条件:
+
+- `n_flagella=3`
+- `initial_orientation_mode=posterior_aligned`
+- `time.dt_star=1.0e-4`
+- `duration_s=0.5`
+
+結果:
+
+| torque_Nm | local_spring_scale | shape_pass_nonbody | first_fail_category_nonbody | net_abs_flag_helix_spin_revolutions | bundle_axis_vs_rear_angle_deg | bundle_participation_ratio | body_displacement_um | 判定 |
+| ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `2.0e-20` | `1.0` | `False` | `hook` | `1.4087` | `18.18` | `0.0` | `0.1952` | collapse |
+| `1.0e-20` | `1.0` | `False` | `hook` | `0.6685` | `7.77` | `0.0` | `0.0932` | collapse |
+| `0.5e-20` | `1.0` | `False` | `hook` | `0.2573` | `2.31` | `0.0` | `0.0784` | collapse |
+| `0.5e-20` | `1.2` | `False` | `hook` | `0.2628` | `2.24` | `0.0` | `0.0789` | collapse |
+
+`motor.local_spring_scale=1.2` はhook破綻を遅らせたが、0.5秒最終stepでは `hook_len_rel_err_max=1.0713` となり、現行gateの上限 `1.0` を超えた。
+
+### 現時点の解釈
+
+現行実装では、`posterior_aligned` によって全べん毛の束軸を菌体後方へ向けることはできた。しかし、0.5秒の長時間条件では低トルクでもhook長が徐々に崩れ、後方束化以前にhook gateで落ちる。
+
+また、後方へ向けた条件でも `bundle_participation_ratio=0.0` であり、少なくとも今回の `n_flagella=3`, `0.5e-20..3.0e-20` 範囲では、べん毛同士が束中心軸へ近づく挙動は確認できていない。つまり、短時間で「後方を向いている」状態は作れるが、「後方束化している」状態までは到達していない。
+
+### 残課題
+
+- hook破綻を抑える条件探索が必要である。候補は `motor.local_spring_scale`, `motor.local_hook_scale`, hook spring / bend の扱い、posterior aligned 時のhook初期形状である。
+- 束化しない原因を切り分ける必要がある。候補は、べん毛間の接触・反発・流体相互作用の強さ、初期配置の距離、posterior aligned が平行配置に近く束化駆動を作らないこと。
+- Phase 2.7 は現時点では未完了であり、今回の結果は診断進捗として扱う。

--- a/docs/phase2/phase2_7_bundling_stability_plan.md
+++ b/docs/phase2/phase2_7_bundling_stability_plan.md
@@ -11,8 +11,8 @@ Phase 2.7 では、単一べん毛で確認した `material_twist_local_couple` 
 検証は次の順で行う。
 
 1. 自然初期条件で多べん毛の形状安定トルク帯を求める。
-2. hook角度または初期接線方向を調整し、全べん毛を菌体後方へ向けた `posterior_aligned` 条件を作る。
-3. `posterior_aligned` 条件で安定トルク帯を再探索し、後方束化候補を分類する。
+2. hook角度または初期接線方向を調整し、全べん毛を菌体後方寄りへ向けた条件を作る。
+3. 後方寄り初期接線条件で安定トルク帯を再探索し、後方束化候補を分類する。
 4. 後方束化候補条件で、菌体の推進量と姿勢変化を定量化する。
 
 この順序にする理由は、最初から後方へ揃えた条件だけを見ると、自然初期条件での多べん毛耐性と、人工的に後方へ向けた初期条件の影響を切り分けにくいためである。
@@ -41,11 +41,21 @@ Phase 2.7 では、単一べん毛で確認した `material_twist_local_couple` 
 
 多べん毛では flagella 間干渉で不安定化する可能性があるため、上限は結果を見てから広げる。
 
-## posterior aligned 条件
+## 後方寄り初期接線条件
 
 `posterior_aligned` は、自然な初期条件ではなく、短時間で後方束化を観察しやすくするための診断条件として扱う。
 
 目標は、各べん毛の初期接線方向が菌体長軸の後方成分を持つことである。完全に同じ軸へ重ねるのではなく、付着点と螺旋位相の差は残す。これにより、後方束化しやすい条件を作りつつ、べん毛間干渉や部分束化も観察できるようにする。
+
+2026-06-04時点では、後方軸からの角度を連続値として扱う方針にする。
+
+- `flagella.initial_tangent_vs_rear_deg=0`: 菌体後方軸と平行。旧 `posterior_aligned` 相当。
+- `flagella.initial_tangent_vs_rear_deg=10`: 主候補。ほぼ後方向きだが、完全平行ではなく少し外側へ開く。
+- `flagella.initial_tangent_vs_rear_deg=90`: 従来 `side_attach` 相当。
+
+角度sweepの初期候補は `0, 10, 30, 60, 90 deg` とする。まずは `10 deg` と低トルク `0.5e-20 N m` を優先する。0度条件はhook破綻を誘発しやすい診断条件として扱い、最終的な候補条件とは区別する。
+
+重要な確認点は、初期からべん毛同士が近すぎて repulsion dominated になっていないかである。そのため、初期stepから flagella-flagella minimum distance と close-contact pair count を記録する。
 
 ## 分類
 
@@ -78,6 +88,14 @@ Phase 2.7 では、単一べん毛で確認した `material_twist_local_couple` 
 - flagella間距離
 - bundle axis と body axis の角度
 - bundle axis の後方成分
+
+べん毛間反発:
+
+- flagella-flagella minimum segment distance
+- flagella-flagella close-contact pair count
+- flagella-flagella repulsion mean / max
+- root/hook近傍のrepulsion mean / max
+- 束中心軸距離とrepulsionの関係
 
 遊泳:
 
@@ -156,3 +174,120 @@ Phase 2.7 では、単一べん毛で確認した `material_twist_local_couple` 
 - hook破綻を抑える条件探索が必要である。候補は `motor.local_spring_scale`, `motor.local_hook_scale`, hook spring / bend の扱い、posterior aligned 時のhook初期形状である。
 - 束化しない原因を切り分ける必要がある。候補は、べん毛間の接触・反発・流体相互作用の強さ、初期配置の距離、posterior aligned が平行配置に近く束化駆動を作らないこと。
 - Phase 2.7 は現時点では未完了であり、今回の結果は診断進捗として扱う。
+
+## 2026-06-04 追加方針
+
+次の調査では、`posterior_aligned` の0度固定ではなく、菌体後方軸からの角度を振る。
+
+優先順:
+
+1. `initial_tangent_vs_rear_deg=10`
+2. `initial_tangent_vs_rear_deg=30`
+3. `initial_tangent_vs_rear_deg=0`
+4. `initial_tangent_vs_rear_deg=60`
+5. `initial_tangent_vs_rear_deg=90`
+
+実行は全grid長時間ではなく、短時間screeningと代表長時間検証に分ける。
+
+1. `duration_s=0.02` で `0, 10, 30, 60, 90 deg` と低トルク候補をscreeningする。
+2. `shape_pass_nonbody=True` かつhook指標が良い角度を選ぶ。
+3. 選んだ角度だけ `duration_s=0.5` へ伸ばす。
+4. 0.5 sで shape gate PASSした条件だけ、束化・遊泳指標を解釈する。
+
+失敗時は、失敗原因を次のどれかに分類する。
+
+- `hook_drift`: hook length / local attach-first が時間とともに伸びる。
+- `repulsion_dominated`: flagella-flagella距離が小さく、repulsion force が上がる。
+- `no_bundle_drive`: 後方を向くがflagella間距離が縮まらず、repulsionも小さい。
+- `flag_shape_fail`: flagellum bond / bend / torsion が先に崩れる。
+- `body_motion_unstable`: shapeは通るがbody姿勢変化が大きすぎる。
+
+## 2026-06-04 角度sweep・反発診断結果
+
+### 追加した実装
+
+- `flagella.initial_tangent_vs_rear_deg` を追加した。指定時は `initial_orientation_mode` より優先し、0度を菌体後方軸、90度を従来 `side_attach` 相当として扱う。
+- `scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py` に `--tangent-angles-deg` を追加した。
+- `step_summary.csv` と sweep summary に、べん毛同士のsegment距離、close-contact数、flagella-flagella repulsion force、basal近傍repulsion forceを追加した。
+
+### 短時間screening
+
+条件:
+
+- `n_flagella=3`
+- `time.dt_star=1.0e-4`
+- `duration_s=0.02`
+- `motor.force_distribution=material_twist_local_couple`
+- `motor.local_spring_scale=1.2`
+- `initial_tangent_vs_rear_deg = 0, 10, 30, 60, 90`
+- `torque_Nm = 0.5e-20, 1.0e-20`
+
+結果:
+
+- 10条件すべてで `shape_pass_nonbody=True`。
+- すべて `phase27_class=no_bundle` で、`bundle_participation_ratio=0.0`。
+- すべて `flag_flag_close_pair_count=0`, `flag_flag_repulsion_force_max_N=0.0`。
+- つまり、短時間では「初期から近すぎて反発で壊れる」状態ではなく、「べん毛同士が接触・束化する距離まで近づいていない」状態だった。
+- 出力: `outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_screen_dur0p02/phase2_7_bundling_sweep_summary.csv`
+
+### 0.5秒代表条件
+
+条件:
+
+- `n_flagella=3`
+- `time.dt_star=1.0e-4`
+- `duration_s=0.5`
+- `motor.force_distribution=material_twist_local_couple`
+- `motor.local_spring_scale=1.2`
+- `torque_Nm=0.5e-20`
+
+結果:
+
+| initial_tangent_vs_rear_deg | shape_pass_nonbody | first_fail_category_nonbody | net_abs_flag_helix_spin_revolutions | hook_len_rel_err_max | bundle_axis_vs_rear_angle_deg | bundle_participation_ratio | flag_flag_close_pair_count | 判定 |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `0` | `False` | `hook` | `0.2628` | `1.0713` | `2.24` | `0.0` | `0` | collapse |
+| `10` | `True` | `none` | `0.2927` | `0.9982` | `2.66` | `0.0` | `0` | no_bundle |
+| `30` | `False` | `hook` | `0.3748` | `1.0948` | `39.04` | `0.0` | `0` | collapse |
+
+10度条件では0.5秒のshape gateをぎりぎり通過した。しかし `bundle_participation_ratio=0.0` で、flagella間距離も縮まらず、flagella-flagella repulsionは発生しなかった。
+
+出力:
+
+- `outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle_representative_dur0p5/phase2_7_bundling_sweep_summary.csv`
+
+### 10度条件でのtorque上昇
+
+`initial_tangent_vs_rear_deg=10`, `duration_s=0.5`, `motor.local_spring_scale=1.2` で torque を上げると、束化より先にhookが破綻した。
+
+| torque_Nm | shape_pass_nonbody | first_fail_category_nonbody | first fail t_s | net_abs_flag_helix_spin_revolutions | hook_len_rel_err_max | bundle_participation_ratio | flag_flag_close_pair_count |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `1.0e-20` | `False` | `hook` | `0.2247` | `0.7206` | `1.5328` | `0.0` | `0` |
+| `2.0e-20` | `False` | `hook` | `0.0967` | `1.4328` | `1.8936` | `0.0` | `0` |
+
+`motor.local_spring_scale=2.0` まで補強すると `1.0e-20` はshape gateを通過したが、束化は起きなかった。
+
+| torque_Nm | local_spring_scale | shape_pass_nonbody | first_fail_category_nonbody | net_abs_flag_helix_spin_revolutions | hook_len_rel_err_max | bundle_participation_ratio | flag_flag_close_pair_count | 判定 |
+| ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `1.0e-20` | `2.0` | `True` | `none` | `0.6894` | `0.9908` | `0.0` | `0` | no_bundle |
+| `2.0e-20` | `2.0` | `False` | `hook` | `1.3843` | `1.4057` | `0.0` | `0` | collapse |
+
+出力:
+
+- `outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_torque_escalation_dur0p5/phase2_7_bundling_sweep_summary.csv`
+- `outputs/phase2_7_bundling_sweep/2026-06-04_n3_angle10_spring2_dur0p5/phase2_7_bundling_sweep_summary.csv`
+
+### 現時点の原因整理
+
+今回の範囲では、後方束化成功条件は見つからなかった。主因は次の2つに分けられる。
+
+1. 形状が保てる低トルク条件では、べん毛同士が近づかず、flagella-flagella repulsionも発生しない。これは `no_bundle_drive` であり、初期接線を後方へ向けるだけでは束化を駆動できていない。
+2. トルクを上げると螺旋回転量は増えるが、束化や接触の前にhook length gateが破綻する。これは `hook_drift` である。
+
+したがって、現行の `material_twist_local_couple` + 後方寄り初期接線 + 現行spring-spring repulsion だけでは、`duration_s=0.5` で「崩壊せず後方束化する」条件は未達である。
+
+### 次に詰めるべき点
+
+- 後方束化を作る物理要素として、回転する螺旋同士の流体相互作用が現行実装で十分に表現されているかを確認する。
+- hook drift を抑える方法を、単なる局所spring補強ではなく、hookの平衡長・曲げ拘束・付着直後の初期形状との整合として見直す。
+- `distributed_flagellum` または診断用modeで多本べん毛を回した場合に束化傾向が出るかを比較し、問題がtorque伝達不足か、相互作用モデル不足かを切り分ける。
+- 束化判定は `bundle_participation_ratio` だけでなく、flagella間距離の時間変化とclose-contact発生率を併用する。

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -280,11 +280,13 @@
 
 ### P2-9-009: 3D/2D動画出力のレビュー向けサンプリングを整備する
 
-- status: accepted
-- branch: `feature/phase2-9-output-sampling`
+- status: in_progress
+- branch: `feature/phase2-7-bundling-stability`
+- covered by: `P2-7-006`
 - background:
   - `dt_star=1.0e-4` では内部step数が多く、3D出力を全step保存するとファイル数・動画生成時間が大きくなる。
   - 2D側には `fps_out_2d` があるが、3D側にも同様の `fps_out_3d` が必要である。
+  - Phase 2.7の0.5 s検証を現実的なフレーム数でレビューする前提整備として、P2-7-006と同じPRで扱う。
 - tasks:
   - [ ] `output_sampling.fps_out_3d` を追加する。
   - [ ] 3D render / frame保存 / manifest に `fps_out_3d` を反映する。

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -246,6 +246,11 @@
   - 2026-06-03時点では、`n_flagella=3`, `posterior_aligned`, `duration_s=0.5`, `time.dt_star=1.0e-4` の代表条件で `0.5e-20..2.0e-20 N m` を確認したが、いずれも最終的に `hook` first-fail となった。
   - `motor.local_spring_scale=1.2` はhook破綻を遅らせたが、0.5 s最終stepで `hook_len_rel_err_max=1.0713` となり、shape gate は未達だった。
   - `posterior_aligned` により束軸は後方を向くが、`bundle_participation_ratio=0.0` のままであり、後方束化そのものは未確認である。
+  - 2026-06-04時点では、`flagella.initial_tangent_vs_rear_deg` と flagella-flagella repulsion診断を追加し、`0,10,30,60,90 deg` をscreeningした。
+  - `initial_tangent_vs_rear_deg=10`, `torque_Nm=0.5e-20`, `motor.local_spring_scale=1.2`, `duration_s=0.5` は shape gate を通過したが、`bundle_participation_ratio=0.0`, `flag_flag_close_pair_count=0` で no_bundle だった。
+  - `initial_tangent_vs_rear_deg=10`, `torque_Nm=1.0e-20`, `motor.local_spring_scale=2.0` も shape gate を通過したが、同様に no_bundle だった。
+  - `1.0e-20` を `local_spring_scale=1.2` で回す条件、および `2.0e-20` 条件では、束化より先に hook length gate が破綻した。
+  - 現時点の主因は、形状が保てるトルク帯では `no_bundle_drive`、トルクを上げると `hook_drift` が先行すること。詳細は `docs/phase2/phase2_7_bundling_stability_plan.md` に記録した。
 
 ## Phase 2.8: 遊泳挙動の運動指標検証
 

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -210,7 +210,7 @@
 
 ### P2-7-006: 複数べん毛で崩壊せず後方束化する条件を探索する
 
-- status: proposed
+- status: in_progress
 - source proposal: `docs/planning/phase2_task_proposals.md#proposal-p2-7-006-phase-27`
 - supersedes: `P2-8-007`
 - branch: `feature/phase2-7-bundling-stability`
@@ -222,12 +222,15 @@
   - 短時間で後方束化候補を観察するには、hook角度または初期接線方向を調整し、すべてのべん毛を菌体後方へ向けた代表条件を作るのが有効である。
   - 束化は完全な二値判定が難しい。1本だけ独立し、残りが束化する部分束化もあり得るため、定量指標と目視レビューを併用する。
 - tasks:
-  - [ ] `motor.force_distribution=material_twist_local_couple`, `time.dt_star=1.0e-4` を基本条件とした `n_flagella=3` representative を作る。
+  - [ ] 長時間レビュー用に3D出力を間引ける `output_sampling.fps_out_3d` を使い、`time.dt_star=1.0e-4` と `duration_s>=0.5` の検証を現実的なフレーム数で実行できるようにする。
+  - [ ] 自然初期条件で、`motor.force_distribution=material_twist_local_couple`, `time.dt_star=1.0e-4` を基本条件とした `n_flagella=3` representative を作る。
+  - [ ] 自然初期条件で `motor.torque_Nm` をsweepし、多べん毛での形状安定トルク帯を先に把握する。
+  - [ ] hook角度または初期接線方向を調整した `posterior_aligned` 条件を追加し、短時間で全べん毛が菌体後方へ向かう初期条件を作る。
+  - [ ] `posterior_aligned` 条件で `motor.torque_Nm` をsweepし、崩壊しないが束化しない条件、束化する条件、崩壊する条件を分類する。
   - [ ] `distributed_flagellum` は診断用比較条件として残し、必要に応じて同じ `n_flagella` / torque で比較する。
-  - [ ] hook角度または初期接線方向を調整し、短時間で全べん毛が菌体後方へ向かう初期条件を作る。
-  - [ ] `motor.torque_Nm` をsweepし、崩壊しないが束化しない条件、束化する条件、崩壊する条件を分類する。
   - [ ] `n_flagella=3,6,9` を段階評価し、body/hook/flag の first-fail 分布を整理する。
   - [ ] 束化候補指標を実装・記録する。候補は、束中心軸への距離、束参加率、独立べん毛数、束軸と菌体軸の角度、flagella間距離である。
+  - [ ] 後方束化候補条件で、菌体重心移動量、平均速度、body axis角度変化、姿勢揺らぎRMS、bundle axis と body axis の角度を出力する。
   - [ ] 1本のみ独立する部分束化をFAILではなく別カテゴリとして記録する。
   - [ ] collapse/fly-away が出る条件を再現可能な diagnostic output として保存する。
   - [ ] 代表PASS/FAIL/PARTIAL条件について、定量結果と目視レビュー対象動画を記録する。
@@ -235,7 +238,14 @@
   - [ ] `n_flagella=3` で、0.5 s以上、shape gate PASS、後方束化候補あり、の代表条件が1つ以上ある。
   - [ ] `n_flagella` と torque ごとの collapse / no bundle / partial bundle / posterior bundle の分類表がある。
   - [ ] 後方束化の定量指標が `step_summary.csv` または別CSVへ記録される。
+  - [ ] 後方束化候補条件で、菌体の推進量と姿勢変化を確認できる運動指標が出力される。
   - [ ] 目視レビューが必要な条件では、対象動画・確認観点・自動判定の限界をreview_resultに記録する。
+- docs:
+  - `docs/phase2/phase2_7_bundling_stability_plan.md`
+- latest diagnostic:
+  - 2026-06-03時点では、`n_flagella=3`, `posterior_aligned`, `duration_s=0.5`, `time.dt_star=1.0e-4` の代表条件で `0.5e-20..2.0e-20 N m` を確認したが、いずれも最終的に `hook` first-fail となった。
+  - `motor.local_spring_scale=1.2` はhook破綻を遅らせたが、0.5 s最終stepで `hook_len_rel_err_max=1.0713` となり、shape gate は未達だった。
+  - `posterior_aligned` により束軸は後方を向くが、`bundle_participation_ratio=0.0` のままであり、後方束化そのものは未確認である。
 
 ## Phase 2.8: 遊泳挙動の運動指標検証
 

--- a/scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py
+++ b/scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py
@@ -16,6 +16,7 @@ from sim_swim.sim.params import SimulationConfig, merge_overrides
 
 SUMMARY_FIELDS = [
     "orientation_mode",
+    "initial_tangent_vs_rear_deg",
     "n_flagella",
     "torque_Nm",
     "duration_s",
@@ -25,6 +26,11 @@ SUMMARY_FIELDS = [
     "shape_pass_nonbody",
     "first_fail_category_nonbody",
     "net_abs_flag_helix_spin_revolutions",
+    "hook_len_rel_err_max",
+    "hook_angle_err_max_deg",
+    "flag_bond_rel_err_max",
+    "flag_bend_err_max_deg",
+    "flag_torsion_err_max_deg",
     "bundle_axis_vs_rear_angle_deg",
     "bundle_axis_vs_body_axis_angle_deg",
     "bundle_rearward_projection",
@@ -32,6 +38,13 @@ SUMMARY_FIELDS = [
     "bundle_independent_flagella_count",
     "bundle_tip_axis_dist_mean_um",
     "flag_tip_pair_dist_mean_um",
+    "flag_flag_segment_dist_min_um",
+    "flag_flag_segment_dist_mean_um",
+    "flag_flag_close_pair_count",
+    "flag_flag_repulsion_force_mean_N",
+    "flag_flag_repulsion_force_max_N",
+    "flag_flag_basal_repulsion_force_mean_N",
+    "flag_flag_basal_repulsion_force_max_N",
     "body_displacement_um",
     "body_speed_um_s",
     "body_axis_cumulative_angle_deg",
@@ -45,6 +58,7 @@ STEP_SUMMARY_METRIC_FIELDS = [
     if key
     not in {
         "orientation_mode",
+        "initial_tangent_vs_rear_deg",
         "n_flagella",
         "torque_Nm",
         "duration_s",
@@ -137,6 +151,7 @@ def _build_config(
     raw_cfg: dict[str, Any],
     *,
     orientation_mode: str,
+    initial_tangent_vs_rear_deg: float | None,
     n_flagella: int,
     torque_Nm: float,
     duration_s: float,
@@ -144,10 +159,15 @@ def _build_config(
     overrides: list[str] | None,
 ) -> SimulationConfig:
     override_dict = merge_overrides({}, overrides)
-    override_dict.setdefault("flagella", {})["initial_orientation_mode"] = (
-        orientation_mode
-    )
-    override_dict.setdefault("flagella", {})["n_flagella"] = int(n_flagella)
+    flagella_overrides = override_dict.setdefault("flagella", {})
+    flagella_overrides["initial_orientation_mode"] = orientation_mode
+    if initial_tangent_vs_rear_deg is not None:
+        flagella_overrides["initial_tangent_vs_rear_deg"] = float(
+            initial_tangent_vs_rear_deg
+        )
+    else:
+        flagella_overrides["initial_tangent_vs_rear_deg"] = None
+    flagella_overrides["n_flagella"] = int(n_flagella)
     override_dict.setdefault("motor", {})["torque_Nm"] = float(torque_Nm)
     override_dict.setdefault("time", {})["duration_s"] = float(duration_s)
     override_dict.setdefault("time", {})["dt_star"] = float(dt_star)
@@ -162,6 +182,15 @@ def main() -> None:
         type=_parse_csv_strs,
         default=["side_attach", "posterior_aligned"],
         help="Comma-separated initial orientation modes.",
+    )
+    parser.add_argument(
+        "--tangent-angles-deg",
+        type=_parse_csv_floats,
+        default=None,
+        help=(
+            "Optional comma-separated flagella.initial_tangent_vs_rear_deg values. "
+            "When set, angles override orientation mode and are swept once."
+        ),
     )
     parser.add_argument(
         "--n-flagella",
@@ -198,21 +227,38 @@ def main() -> None:
         writer = csv.DictWriter(handle, fieldnames=SUMMARY_FIELDS)
         writer.writeheader()
 
-        for orientation_mode in args.orientation_modes:
+        orientation_angle_pairs: list[tuple[str, float | None]]
+        if args.tangent_angles_deg is None:
+            orientation_angle_pairs = [
+                (str(mode), None) for mode in args.orientation_modes
+            ]
+        else:
+            orientation_angle_pairs = [
+                ("side_attach", float(angle)) for angle in args.tangent_angles_deg
+            ]
+
+        for orientation_mode, tangent_angle_deg in orientation_angle_pairs:
             for n_flagella in args.n_flagella:
                 for torque in args.torques:
                     cfg = _build_config(
                         raw_cfg,
                         orientation_mode=orientation_mode,
+                        initial_tangent_vs_rear_deg=tangent_angle_deg,
                         n_flagella=int(n_flagella),
                         torque_Nm=float(torque),
                         duration_s=float(args.duration_s),
                         dt_star=float(args.dt_star),
                         overrides=args.overrides,
                     )
+                    angle_label = (
+                        "default"
+                        if tangent_angle_deg is None
+                        else f"{float(tangent_angle_deg):g}deg"
+                    )
                     run_dir = (
                         out_dir
                         / f"orientation_{orientation_mode}"
+                        / f"angle_{angle_label}"
                         / f"n_{int(n_flagella)}"
                         / f"torque_{float(torque):.2e}"
                     )
@@ -227,6 +273,11 @@ def main() -> None:
                     writer.writerow(
                         {
                             "orientation_mode": orientation_mode,
+                            "initial_tangent_vs_rear_deg": (
+                                ""
+                                if tangent_angle_deg is None
+                                else float(tangent_angle_deg)
+                            ),
                             "n_flagella": int(n_flagella),
                             "torque_Nm": float(torque),
                             "duration_s": float(cfg.time.duration_s),

--- a/scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py
+++ b/scripts/01_simulate_swimming/run_phase2_7_bundling_sweep.py
@@ -1,0 +1,249 @@
+"""Phase 2.7 用の多べん毛 torque sweep。"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from sim_swim.sim.core import Simulator
+from sim_swim.sim.params import SimulationConfig, merge_overrides
+
+
+SUMMARY_FIELDS = [
+    "orientation_mode",
+    "n_flagella",
+    "torque_Nm",
+    "duration_s",
+    "dt_star",
+    "output_dir",
+    "phase27_class",
+    "shape_pass_nonbody",
+    "first_fail_category_nonbody",
+    "net_abs_flag_helix_spin_revolutions",
+    "bundle_axis_vs_rear_angle_deg",
+    "bundle_axis_vs_body_axis_angle_deg",
+    "bundle_rearward_projection",
+    "bundle_participation_ratio",
+    "bundle_independent_flagella_count",
+    "bundle_tip_axis_dist_mean_um",
+    "flag_tip_pair_dist_mean_um",
+    "body_displacement_um",
+    "body_speed_um_s",
+    "body_axis_cumulative_angle_deg",
+    "body_axis_wobble_rms_deg",
+    "body_angular_velocity_rms_rad_s",
+]
+
+STEP_SUMMARY_METRIC_FIELDS = [
+    key
+    for key in SUMMARY_FIELDS
+    if key
+    not in {
+        "orientation_mode",
+        "n_flagella",
+        "torque_Nm",
+        "duration_s",
+        "dt_star",
+        "output_dir",
+        "phase27_class",
+    }
+]
+
+
+def _parse_csv_floats(text: str) -> list[float]:
+    values = [float(part.strip()) for part in text.split(",") if part.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("at least one value is required")
+    return values
+
+
+def _parse_csv_ints(text: str) -> list[int]:
+    values = [int(part.strip()) for part in text.split(",") if part.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("at least one value is required")
+    return values
+
+
+def _parse_csv_strs(text: str) -> list[str]:
+    values = [part.strip() for part in text.split(",") if part.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("at least one value is required")
+    return values
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    raw_text = path.read_text(encoding="utf-8") if path.exists() else ""
+    return yaml.safe_load(raw_text) or {}
+
+
+def _step_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _last_step_row(path: Path) -> dict[str, str]:
+    rows = _step_rows(path)
+    if not rows:
+        return {}
+    return rows[-1]
+
+
+def _as_float(row: dict[str, str], key: str, default: float = float("nan")) -> float:
+    try:
+        return float(row.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_bool(row: dict[str, str], key: str) -> bool:
+    return str(row.get(key, "")).strip().lower() in {"true", "1", "yes"}
+
+
+def classify_phase27_condition(row: dict[str, str], n_flagella: int) -> str:
+    """最終stepの診断値から Phase 2.7 用の粗分類を返す。"""
+
+    if not _as_bool(row, "shape_pass_nonbody"):
+        return "collapse"
+
+    rear_angle = _as_float(row, "bundle_axis_vs_rear_angle_deg")
+    rear_projection = _as_float(row, "bundle_rearward_projection")
+    participation = _as_float(row, "bundle_participation_ratio")
+    independent = int(_as_float(row, "bundle_independent_flagella_count", n_flagella))
+
+    posterior_like = rear_angle <= 45.0 and rear_projection >= 0.5
+    if posterior_like and participation >= 0.95 and independent == 0:
+        return "posterior_bundle"
+    if posterior_like and participation >= 0.5 and independent < n_flagella:
+        return "partial_bundle"
+    return "no_bundle"
+
+
+def _net_abs_helix_spin_revolutions(rows: list[dict[str, str]]) -> float:
+    if len(rows) < 2:
+        return float("nan")
+    first = _as_float(rows[0], "flag_helix_spin_phase_deg")
+    last = _as_float(rows[-1], "flag_helix_spin_phase_deg")
+    if not np.isfinite(first) or not np.isfinite(last):
+        return float("nan")
+    return abs(last - first) / 360.0
+
+
+def _build_config(
+    raw_cfg: dict[str, Any],
+    *,
+    orientation_mode: str,
+    n_flagella: int,
+    torque_Nm: float,
+    duration_s: float,
+    dt_star: float,
+    overrides: list[str] | None,
+) -> SimulationConfig:
+    override_dict = merge_overrides({}, overrides)
+    override_dict.setdefault("flagella", {})["initial_orientation_mode"] = (
+        orientation_mode
+    )
+    override_dict.setdefault("flagella", {})["n_flagella"] = int(n_flagella)
+    override_dict.setdefault("motor", {})["torque_Nm"] = float(torque_Nm)
+    override_dict.setdefault("time", {})["duration_s"] = float(duration_s)
+    override_dict.setdefault("time", {})["dt_star"] = float(dt_star)
+    return SimulationConfig.from_dict(raw_cfg).with_overrides(override_dict)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=Path("conf/sim_swim.yaml"))
+    parser.add_argument(
+        "--orientation-modes",
+        type=_parse_csv_strs,
+        default=["side_attach", "posterior_aligned"],
+        help="Comma-separated initial orientation modes.",
+    )
+    parser.add_argument(
+        "--n-flagella",
+        type=_parse_csv_ints,
+        default=[3],
+        help="Comma-separated flagella counts.",
+    )
+    parser.add_argument(
+        "--torques",
+        type=_parse_csv_floats,
+        default=[0.5e-20, 1.0e-20, 1.5e-20, 2.0e-20, 2.5e-20, 3.0e-20],
+        help="Comma-separated motor.torque_Nm values.",
+    )
+    parser.add_argument("--duration-s", type=float, default=0.5)
+    parser.add_argument("--dt-star", type=float, default=1.0e-4)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/phase2_7_bundling_sweep"),
+    )
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help="Optional config overrides such as output_sampling.out_all_steps_3d=false.",
+    )
+    args = parser.parse_args()
+
+    raw_cfg = _load_yaml(args.config)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / "phase2_7_bundling_sweep_summary.csv"
+
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=SUMMARY_FIELDS)
+        writer.writeheader()
+
+        for orientation_mode in args.orientation_modes:
+            for n_flagella in args.n_flagella:
+                for torque in args.torques:
+                    cfg = _build_config(
+                        raw_cfg,
+                        orientation_mode=orientation_mode,
+                        n_flagella=int(n_flagella),
+                        torque_Nm=float(torque),
+                        duration_s=float(args.duration_s),
+                        dt_star=float(args.dt_star),
+                        overrides=args.overrides,
+                    )
+                    run_dir = (
+                        out_dir
+                        / f"orientation_{orientation_mode}"
+                        / f"n_{int(n_flagella)}"
+                        / f"torque_{float(torque):.2e}"
+                    )
+                    run_dir.mkdir(parents=True, exist_ok=True)
+                    sim = Simulator(cfg)
+                    sim.run(cfg.time.duration_s, step_summary_dir=run_dir)
+                    step_rows = _step_rows(run_dir / "step_summary.csv")
+                    last = step_rows[-1] if step_rows else {}
+                    net_abs_spin = _net_abs_helix_spin_revolutions(step_rows)
+                    phase27_class = classify_phase27_condition(last, int(n_flagella))
+
+                    writer.writerow(
+                        {
+                            "orientation_mode": orientation_mode,
+                            "n_flagella": int(n_flagella),
+                            "torque_Nm": float(torque),
+                            "duration_s": float(cfg.time.duration_s),
+                            "dt_star": float(cfg.dt_star),
+                            "output_dir": str(run_dir),
+                            "phase27_class": phase27_class,
+                            "net_abs_flag_helix_spin_revolutions": net_abs_spin,
+                            **{
+                                key: last.get(key, "")
+                                for key in STEP_SUMMARY_METRIC_FIELDS
+                                if key != "net_abs_flag_helix_spin_revolutions"
+                            },
+                        }
+                    )
+
+    print(summary_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sim_swim/model/builder.py
+++ b/src/sim_swim/model/builder.py
@@ -369,7 +369,19 @@ class ModelBuilder:
                 radial_unit = rear_dir
             else:
                 radial_unit = radial / radial_norm
-            axis_u = radial_unit
+            initial_orientation_mode = str(cfg.flagella.initial_orientation_mode)
+            if initial_orientation_mode == "side_attach":
+                axis_u = radial_unit
+                target_angle_deg = 90.0
+            elif initial_orientation_mode == "posterior_aligned":
+                axis_u = rear_dir
+                target_angle_deg = 0.0
+            else:
+                raise ValueError(
+                    "Unsupported flagella.initial_orientation_mode:"
+                    f" {initial_orientation_mode}. Use 'side_attach' or"
+                    " 'posterior_aligned'."
+                )
             hook_offset_um = hook_length_um * radial_unit
 
             ref = np.array([1.0, 0.0, 0.0], dtype=float)
@@ -404,7 +416,6 @@ class ModelBuilder:
             angle_deg = math.degrees(
                 math.acos(float(np.clip(np.dot(tangent0, rear_dir), -1.0, 1.0)))
             )
-            target_angle_deg = 90.0
             if abs(angle_deg - target_angle_deg) > 10.0 + 1e-8:
                 raise ValueError(
                     "Flagellum base tangent is not aligned to expected direction:"

--- a/src/sim_swim/model/builder.py
+++ b/src/sim_swim/model/builder.py
@@ -370,7 +370,28 @@ class ModelBuilder:
             else:
                 radial_unit = radial / radial_norm
             initial_orientation_mode = str(cfg.flagella.initial_orientation_mode)
-            if initial_orientation_mode == "side_attach":
+            if cfg.flagella.initial_tangent_vs_rear_deg is not None:
+                target_angle_deg = float(cfg.flagella.initial_tangent_vs_rear_deg)
+                if not (0.0 <= target_angle_deg <= 180.0):
+                    raise ValueError(
+                        "flagella.initial_tangent_vs_rear_deg must be in [0, 180]:"
+                        f" {target_angle_deg}"
+                    )
+                target_rad = math.radians(target_angle_deg)
+                side_component = (
+                    radial_unit - float(np.dot(radial_unit, rear_dir)) * rear_dir
+                )
+                side_norm = float(np.linalg.norm(side_component))
+                if side_norm <= 1e-12:
+                    side_component = radial_unit
+                else:
+                    side_component /= side_norm
+                axis_u = (
+                    math.cos(target_rad) * rear_dir
+                    + math.sin(target_rad) * side_component
+                )
+                axis_u /= max(float(np.linalg.norm(axis_u)), 1e-12)
+            elif initial_orientation_mode == "side_attach":
                 axis_u = radial_unit
                 target_angle_deg = 90.0
             elif initial_orientation_mode == "posterior_aligned":

--- a/src/sim_swim/render/render3d.py
+++ b/src/sim_swim/render/render3d.py
@@ -132,7 +132,7 @@ def save_swim_movie(
     render_states = _select_frames(
         states_list,
         out_all_steps_3d=cfg.output_sampling.out_all_steps_3d,
-        fps_hint=cfg.output_sampling.fps_out_2d,
+        fps_hint=cfg.output_sampling.fps_out_3d,
     )
 
     frames_dir = out_dir / "frames_3d"
@@ -146,7 +146,10 @@ def save_swim_movie(
     writer: cv2.VideoWriter | None = None
     last_frame: np.ndarray | None = None
 
-    fps_3d = min(60.0, max(1.0, 1.0 / max(cfg.output_dt_s, 1e-9)))
+    if cfg.output_sampling.out_all_steps_3d:
+        fps_3d = min(60.0, max(1.0, 1.0 / max(cfg.output_dt_s, 1e-9)))
+    else:
+        fps_3d = max(1.0, float(cfg.output_sampling.fps_out_3d))
 
     for idx, st in enumerate(render_states):
         fig = plt.figure(figsize=(5, 5))

--- a/src/sim_swim/sim/core.py
+++ b/src/sim_swim/sim/core.py
@@ -36,6 +36,17 @@ INITIAL_GEOMETRY_CONTRACT = {
 }
 
 
+def _target_tangent_vs_rear_deg(initial_orientation_mode: str) -> float:
+    if initial_orientation_mode == "side_attach":
+        return 90.0
+    if initial_orientation_mode == "posterior_aligned":
+        return 0.0
+    raise ValueError(
+        "Unsupported flagella.initial_orientation_mode:"
+        f" {initial_orientation_mode}. Use 'side_attach' or 'posterior_aligned'."
+    )
+
+
 def _quat_normalize(q: np.ndarray) -> np.ndarray:
     norm = np.linalg.norm(q)
     if norm == 0:
@@ -249,6 +260,9 @@ class Simulator:
         summary: dict[str, Any] = {
             "flagella": {
                 "init_mode": str(self.config.flagella.init_mode),
+                "initial_orientation_mode": str(
+                    self.config.flagella.initial_orientation_mode
+                ),
                 "stub_mode": str(self.config.flagella.stub_mode),
                 "n_flagella": int(self.config.flagella.n_flagella),
                 "n_beads_per_flagellum": int(
@@ -287,6 +301,12 @@ class Simulator:
             },
             "per_flagellum": [],
         }
+        tangent_target_deg = _target_tangent_vs_rear_deg(
+            str(self.config.flagella.initial_orientation_mode)
+        )
+        summary["flagella"]["geometry_contract"]["tolerances"][
+            "tangent_vs_rear_target_deg"
+        ] = tangent_target_deg
 
         for f_id, idxs in enumerate(self.model.flagella_indices):
             idx = idxs.astype(int, copy=False)
@@ -389,7 +409,7 @@ class Simulator:
             if float(np.max(torsion_err)) > tol["torsion_err_max_deg"]:
                 failures.append("torsion_angle")
             if (
-                abs(tangent_vs_rear_deg - tol["tangent_vs_rear_target_deg"])
+                abs(tangent_vs_rear_deg - tangent_target_deg)
                 > tol["tangent_vs_rear_abs_tol_deg"]
             ):
                 failures.append("base_tangent")

--- a/src/sim_swim/sim/core.py
+++ b/src/sim_swim/sim/core.py
@@ -36,7 +36,12 @@ INITIAL_GEOMETRY_CONTRACT = {
 }
 
 
-def _target_tangent_vs_rear_deg(initial_orientation_mode: str) -> float:
+def _target_tangent_vs_rear_deg(
+    initial_orientation_mode: str,
+    initial_tangent_vs_rear_deg: float | None,
+) -> float:
+    if initial_tangent_vs_rear_deg is not None:
+        return float(initial_tangent_vs_rear_deg)
     if initial_orientation_mode == "side_attach":
         return 90.0
     if initial_orientation_mode == "posterior_aligned":
@@ -263,6 +268,11 @@ class Simulator:
                 "initial_orientation_mode": str(
                     self.config.flagella.initial_orientation_mode
                 ),
+                "initial_tangent_vs_rear_deg": (
+                    float(self.config.flagella.initial_tangent_vs_rear_deg)
+                    if self.config.flagella.initial_tangent_vs_rear_deg is not None
+                    else None
+                ),
                 "stub_mode": str(self.config.flagella.stub_mode),
                 "n_flagella": int(self.config.flagella.n_flagella),
                 "n_beads_per_flagellum": int(
@@ -302,7 +312,8 @@ class Simulator:
             "per_flagellum": [],
         }
         tangent_target_deg = _target_tangent_vs_rear_deg(
-            str(self.config.flagella.initial_orientation_mode)
+            str(self.config.flagella.initial_orientation_mode),
+            self.config.flagella.initial_tangent_vs_rear_deg,
         )
         summary["flagella"]["geometry_contract"]["tolerances"][
             "tangent_vs_rear_target_deg"

--- a/src/sim_swim/sim/debug_summary.py
+++ b/src/sim_swim/sim/debug_summary.py
@@ -62,6 +62,22 @@ STEP_SUMMARY_COLUMNS = [
     "flag_bond_len_max_over_b",
     "flag_bond_rel_err_mean",
     "flag_bond_rel_err_max",
+    "body_displacement_um",
+    "body_speed_um_s",
+    "body_axis_step_angle_deg",
+    "body_axis_cumulative_angle_deg",
+    "body_axis_wobble_rms_deg",
+    "body_angular_velocity_rms_rad_s",
+    "bundle_axis_vs_body_axis_angle_deg",
+    "bundle_axis_vs_rear_angle_deg",
+    "bundle_rearward_projection",
+    "bundle_tip_axis_dist_mean_um",
+    "bundle_tip_axis_dist_max_um",
+    "bundle_participation_ratio",
+    "bundle_independent_flagella_count",
+    "flag_tip_pair_dist_mean_um",
+    "flag_tip_pair_dist_min_um",
+    "flag_tip_pair_dist_max_um",
     "F_total_mean_body",
     "F_total_mean_flag",
     "F_total_mean_all",
@@ -431,6 +447,126 @@ def _pair_rel_error_stats(
     return float(np.mean(rel)), float(np.max(rel))
 
 
+def _unit_vector(vec: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(vec))
+    if norm <= 1e-18:
+        return np.zeros(3, dtype=float)
+    return vec / norm
+
+
+def _angle_between_deg(a: np.ndarray, b: np.ndarray) -> float:
+    a_u = _unit_vector(a)
+    b_u = _unit_vector(b)
+    if float(np.linalg.norm(a_u)) <= 1e-18 or float(np.linalg.norm(b_u)) <= 1e-18:
+        return float("nan")
+    return float(np.rad2deg(np.arccos(float(np.clip(np.dot(a_u, b_u), -1.0, 1.0)))))
+
+
+def _body_center_axis_rear(
+    positions_m: np.ndarray, model: SimModel
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    body_idx = model.body_indices.astype(int, copy=False)
+    center = np.mean(positions_m[body_idx], axis=0)
+    if len(model.body_layer_indices) >= 2:
+        first = model.body_layer_indices[0].astype(int, copy=False)
+        last = model.body_layer_indices[-1].astype(int, copy=False)
+        c_first = np.mean(positions_m[first], axis=0)
+        c_last = np.mean(positions_m[last], axis=0)
+        axis = _unit_vector(c_last - c_first)
+    else:
+        axis = np.array([1.0, 0.0, 0.0], dtype=float)
+    if float(np.linalg.norm(axis)) <= 1e-18:
+        axis = np.array([1.0, 0.0, 0.0], dtype=float)
+    rear = -axis
+    return center, axis, rear
+
+
+def _flag_tip_pair_stats_um(tips_m: np.ndarray) -> tuple[float, float, float]:
+    if tips_m.shape[0] < 2:
+        return float("nan"), float("nan"), float("nan")
+    dists: list[float] = []
+    for i in range(tips_m.shape[0]):
+        for j in range(i + 1, tips_m.shape[0]):
+            dists.append(float(np.linalg.norm(tips_m[i] - tips_m[j]) * M_TO_UM))
+    arr = np.asarray(dists, dtype=float)
+    return float(np.mean(arr)), float(np.min(arr)), float(np.max(arr))
+
+
+def _bundle_metrics(
+    positions_m: np.ndarray,
+    model: SimModel,
+    cfg: SimulationConfig,
+    body_axis: np.ndarray,
+    rear_dir: np.ndarray,
+) -> dict[str, float | int]:
+    n_flagella = len(model.flagella_indices)
+    if n_flagella <= 0:
+        return {
+            "bundle_axis_vs_body_axis_angle_deg": float("nan"),
+            "bundle_axis_vs_rear_angle_deg": float("nan"),
+            "bundle_rearward_projection": float("nan"),
+            "bundle_tip_axis_dist_mean_um": float("nan"),
+            "bundle_tip_axis_dist_max_um": float("nan"),
+            "bundle_participation_ratio": float("nan"),
+            "bundle_independent_flagella_count": 0,
+            "flag_tip_pair_dist_mean_um": float("nan"),
+            "flag_tip_pair_dist_min_um": float("nan"),
+            "flag_tip_pair_dist_max_um": float("nan"),
+        }
+
+    roots = np.asarray(
+        [positions_m[int(idx[0])] for idx in model.flagella_indices],
+        dtype=float,
+    )
+    tips = np.asarray(
+        [positions_m[int(idx[-1])] for idx in model.flagella_indices],
+        dtype=float,
+    )
+    root_center = np.mean(roots, axis=0)
+    tip_center = np.mean(tips, axis=0)
+    bundle_axis = _unit_vector(tip_center - root_center)
+    if float(np.linalg.norm(bundle_axis)) <= 1e-18:
+        bundle_axis_body_angle = float("nan")
+        bundle_axis_rear_angle = float("nan")
+        rearward_projection = float("nan")
+        tip_axis_dist_um = np.full((n_flagella,), float("nan"), dtype=float)
+    else:
+        angle_forward = _angle_between_deg(bundle_axis, body_axis)
+        angle_rear = _angle_between_deg(bundle_axis, -body_axis)
+        bundle_axis_body_angle = float(np.nanmin([angle_forward, angle_rear]))
+        bundle_axis_rear_angle = _angle_between_deg(bundle_axis, rear_dir)
+        rearward_projection = float(np.dot(bundle_axis, rear_dir))
+        p1 = root_center + bundle_axis
+        tip_axis_dist_um = _point_to_line_distance(tips, root_center, p1) * M_TO_UM
+
+    threshold_um = max(0.75 * float(cfg.scale.b_um), 1e-12)
+    if np.isfinite(tip_axis_dist_um).all():
+        participants = tip_axis_dist_um <= threshold_um
+        participation_ratio = float(np.mean(participants))
+        independent_count = int(np.sum(~participants))
+        tip_axis_dist_mean_um = float(np.mean(tip_axis_dist_um))
+        tip_axis_dist_max_um = float(np.max(tip_axis_dist_um))
+    else:
+        participation_ratio = float("nan")
+        independent_count = n_flagella
+        tip_axis_dist_mean_um = float("nan")
+        tip_axis_dist_max_um = float("nan")
+
+    pair_mean, pair_min, pair_max = _flag_tip_pair_stats_um(tips)
+    return {
+        "bundle_axis_vs_body_axis_angle_deg": bundle_axis_body_angle,
+        "bundle_axis_vs_rear_angle_deg": bundle_axis_rear_angle,
+        "bundle_rearward_projection": rearward_projection,
+        "bundle_tip_axis_dist_mean_um": tip_axis_dist_mean_um,
+        "bundle_tip_axis_dist_max_um": tip_axis_dist_max_um,
+        "bundle_participation_ratio": participation_ratio,
+        "bundle_independent_flagella_count": independent_count,
+        "flag_tip_pair_dist_mean_um": pair_mean,
+        "flag_tip_pair_dist_min_um": pair_min,
+        "flag_tip_pair_dist_max_um": pair_max,
+    }
+
+
 def _triangle_area(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
     return 0.5 * float(np.linalg.norm(np.cross(b - a, c - a)))
 
@@ -773,6 +909,20 @@ class StepSummaryRecorder:
         self.prev_flag_helix_spin_offset_deg: float | None = None
         self.prev_flag_helix_spin_phase_deg: float | None = None
         self.prev_flag_helix_spin_t_s: float | None = None
+        initial_center, initial_axis, _ = _body_center_axis_rear(
+            self.model.positions_m,
+            self.model,
+        )
+        self.initial_body_center_m = initial_center
+        self.initial_body_axis = initial_axis
+        self.prev_body_center_m: np.ndarray | None = None
+        self.prev_body_axis: np.ndarray | None = None
+        self.prev_body_t_s: float | None = None
+        self.body_axis_cumulative_angle_deg = 0.0
+        self.body_axis_wobble_square_sum = 0.0
+        self.body_axis_wobble_count = 0
+        self.body_omega_square_sum = 0.0
+        self.body_omega_count = 0
 
         pair_rows = _pair_row_lookup(self.spring_pairs)
 
@@ -1216,6 +1366,58 @@ class StepSummaryRecorder:
             flag_bend_err_max_deg=flag_bend_err_max_deg,
             flag_torsion_err_max_deg=flag_torsion_err_max_deg,
         )
+        body_center_m, body_axis, rear_dir = _body_center_axis_rear(
+            pos_after,
+            self.model,
+        )
+        t_s = float(t_star * self.cfg.tau_s)
+        body_displacement_um = float(
+            np.linalg.norm(body_center_m - self.initial_body_center_m) * M_TO_UM
+        )
+        body_speed_um_s = float("nan")
+        body_axis_step_angle_deg = 0.0
+        if self.prev_body_center_m is not None and self.prev_body_t_s is not None:
+            body_dt_s = max(t_s - self.prev_body_t_s, 1e-30)
+            body_speed_um_s = float(
+                np.linalg.norm(body_center_m - self.prev_body_center_m)
+                * M_TO_UM
+                / body_dt_s
+            )
+            body_axis_step_angle_deg = _angle_between_deg(
+                self.prev_body_axis,
+                body_axis,
+            )
+            if np.isfinite(body_axis_step_angle_deg):
+                self.body_axis_cumulative_angle_deg += float(body_axis_step_angle_deg)
+                omega_rad_s = np.deg2rad(float(body_axis_step_angle_deg)) / body_dt_s
+                self.body_omega_square_sum += float(omega_rad_s * omega_rad_s)
+                self.body_omega_count += 1
+        body_wobble_deg = _angle_between_deg(self.initial_body_axis, body_axis)
+        if np.isfinite(body_wobble_deg):
+            self.body_axis_wobble_square_sum += float(body_wobble_deg**2)
+            self.body_axis_wobble_count += 1
+        body_axis_wobble_rms_deg = (
+            float(
+                np.sqrt(
+                    self.body_axis_wobble_square_sum
+                    / max(self.body_axis_wobble_count, 1)
+                )
+            )
+            if self.body_axis_wobble_count > 0
+            else float("nan")
+        )
+        body_angular_velocity_rms_rad_s = (
+            float(np.sqrt(self.body_omega_square_sum / max(self.body_omega_count, 1)))
+            if self.body_omega_count > 0
+            else float("nan")
+        )
+        bundle_metrics = _bundle_metrics(
+            pos_after,
+            self.model,
+            self.cfg,
+            body_axis,
+            rear_dir,
+        )
 
         row: dict[str, float | int | bool] = {
             "step": int(step),
@@ -1264,6 +1466,13 @@ class StepSummaryRecorder:
             "flag_bond_len_max_over_b": flag_bond_len_max_over_b,
             "flag_bond_rel_err_mean": flag_bond_rel_err_mean,
             "flag_bond_rel_err_max": flag_bond_rel_err_max,
+            "body_displacement_um": body_displacement_um,
+            "body_speed_um_s": body_speed_um_s,
+            "body_axis_step_angle_deg": body_axis_step_angle_deg,
+            "body_axis_cumulative_angle_deg": self.body_axis_cumulative_angle_deg,
+            "body_axis_wobble_rms_deg": body_axis_wobble_rms_deg,
+            "body_angular_velocity_rms_rad_s": body_angular_velocity_rms_rad_s,
+            **bundle_metrics,
             "F_total_mean_body": _mean_norm(diag.total_forces, self.body_mask),
             "F_total_mean_flag": _mean_norm(diag.total_forces, self.flag_mask),
             "F_total_mean_all": float(
@@ -1380,6 +1589,9 @@ class StepSummaryRecorder:
         self._writer.writerow(row)
         self._csv_fp.flush()
         self.prev_flag_states = self.model.flag_states.copy()
+        self.prev_body_center_m = body_center_m.copy()
+        self.prev_body_axis = body_axis.copy()
+        self.prev_body_t_s = t_s
 
     def write_csv(self) -> Path:
         if self._csv_fp is not None:

--- a/src/sim_swim/sim/debug_summary.py
+++ b/src/sim_swim/sim/debug_summary.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass, field
+import math
 from pathlib import Path
 from typing import TextIO
 
 import numpy as np
 
 from sim_swim.dynamics.engine import StepDiagnostics
+from sim_swim.dynamics.forces import _closest_points_on_segments
 from sim_swim.model.types import PolymorphState, SimModel
 from sim_swim.sim.params import SimulationConfig
 
@@ -78,6 +80,13 @@ STEP_SUMMARY_COLUMNS = [
     "flag_tip_pair_dist_mean_um",
     "flag_tip_pair_dist_min_um",
     "flag_tip_pair_dist_max_um",
+    "flag_flag_segment_dist_min_um",
+    "flag_flag_segment_dist_mean_um",
+    "flag_flag_close_pair_count",
+    "flag_flag_repulsion_force_mean_N",
+    "flag_flag_repulsion_force_max_N",
+    "flag_flag_basal_repulsion_force_mean_N",
+    "flag_flag_basal_repulsion_force_max_N",
     "F_total_mean_body",
     "F_total_mean_flag",
     "F_total_mean_all",
@@ -567,6 +576,90 @@ def _bundle_metrics(
     }
 
 
+def _flag_flag_repulsion_metrics(
+    positions_m: np.ndarray,
+    spring_pairs: np.ndarray,
+    segment_pair_indices: np.ndarray,
+    basal_flag_bead_indices: np.ndarray,
+    cfg: SimulationConfig,
+) -> dict[str, float | int]:
+    if segment_pair_indices.size == 0:
+        return {
+            "flag_flag_segment_dist_min_um": float("nan"),
+            "flag_flag_segment_dist_mean_um": float("nan"),
+            "flag_flag_close_pair_count": 0,
+            "flag_flag_repulsion_force_mean_N": 0.0,
+            "flag_flag_repulsion_force_max_N": 0.0,
+            "flag_flag_basal_repulsion_force_mean_N": 0.0,
+            "flag_flag_basal_repulsion_force_max_N": 0.0,
+        }
+
+    cutoff_m = (
+        float(cfg.potentials.spring_spring_repulsion.cutoff_over_b)
+        * max(float(cfg.scale.b_um), 1e-12)
+        * 1.0e-6
+    )
+    a_length_m = (
+        float(cfg.potentials.spring_spring_repulsion.a_ss_over_b)
+        * max(float(cfg.scale.b_um), 1e-12)
+        * 1.0e-6
+    )
+    a_ss = float(cfg.potentials.spring_spring_repulsion.A_ss_over_T) * float(
+        cfg.torque_for_forces_Nm
+    )
+    cutoff_eff = max(cutoff_m, 0.0)
+    a_eff = max(a_length_m, 1e-12)
+    forces = np.zeros_like(positions_m)
+    distances_um: list[float] = []
+    active_magnitudes: list[float] = []
+
+    for seg_a, seg_b in segment_pair_indices.astype(int, copy=False):
+        i, j = spring_pairs[int(seg_a)]
+        k, ell = spring_pairs[int(seg_b)]
+        p1 = positions_m[int(i)]
+        q1 = positions_m[int(j)]
+        p2 = positions_m[int(k)]
+        q2 = positions_m[int(ell)]
+        pa, pb, s, t, dist = _closest_points_on_segments(p1, q1, p2, q2)
+        distances_um.append(float(dist * M_TO_UM))
+        if dist >= cutoff_eff:
+            continue
+
+        dir_vec = (pa - pb) / max(float(np.linalg.norm(pa - pb)), 1e-18)
+        mag = (a_ss / a_eff) * math.exp(-dist / a_eff)
+        active_magnitudes.append(float(abs(mag)))
+        f = mag * dir_vec
+        forces[int(i)] += (1.0 - s) * f
+        forces[int(j)] += s * f
+        forces[int(k)] -= (1.0 - t) * f
+        forces[int(ell)] -= t * f
+
+    distances = np.asarray(distances_um, dtype=float)
+    active = np.asarray(active_magnitudes, dtype=float)
+    basal = basal_flag_bead_indices.astype(int, copy=False)
+    if basal.size > 0:
+        basal_norms = np.linalg.norm(forces[basal], axis=1)
+        basal_mean = float(np.mean(basal_norms))
+        basal_max = float(np.max(basal_norms))
+    else:
+        basal_mean = float("nan")
+        basal_max = float("nan")
+
+    return {
+        "flag_flag_segment_dist_min_um": float(np.min(distances)),
+        "flag_flag_segment_dist_mean_um": float(np.mean(distances)),
+        "flag_flag_close_pair_count": int(active.size),
+        "flag_flag_repulsion_force_mean_N": (
+            float(np.mean(active)) if active.size > 0 else 0.0
+        ),
+        "flag_flag_repulsion_force_max_N": (
+            float(np.max(active)) if active.size > 0 else 0.0
+        ),
+        "flag_flag_basal_repulsion_force_mean_N": basal_mean,
+        "flag_flag_basal_repulsion_force_max_N": basal_max,
+    }
+
+
 def _triangle_area(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
     return 0.5 * float(np.linalg.norm(np.cross(b - a, c - a)))
 
@@ -991,6 +1084,8 @@ class StepSummaryRecorder:
             self.body_body_rows = np.zeros((0,), dtype=int)
             self.flag_intra_rows = np.zeros((0,), dtype=int)
             self.body_flag_rows = np.zeros((0,), dtype=int)
+            self.flag_flag_segment_pair_indices = np.zeros((0, 2), dtype=int)
+            self.basal_flag_bead_indices = np.zeros((0,), dtype=int)
             return
 
         i = self.spring_pairs[:, 0]
@@ -1003,6 +1098,30 @@ class StepSummaryRecorder:
         self.body_body_rows = np.where(bi & bj)[0]
         self.body_flag_rows = np.where(np.logical_xor(bi, bj))[0]
         self.flag_intra_rows = np.where((~bi) & (~bj) & (fi == fj) & (fi >= 0))[0]
+
+        spring_flag_ids = np.full((self.spring_pairs.shape[0],), -1, dtype=int)
+        spring_flag_ids[self.flag_intra_rows] = fi[self.flag_intra_rows]
+        flag_flag_segment_pairs: list[tuple[int, int]] = []
+        for seg_a_raw, seg_b_raw in self.model.segment_pair_indices.astype(
+            int, copy=False
+        ):
+            seg_a = int(seg_a_raw)
+            seg_b = int(seg_b_raw)
+            if seg_a >= spring_flag_ids.size or seg_b >= spring_flag_ids.size:
+                continue
+            flag_a = int(spring_flag_ids[seg_a])
+            flag_b = int(spring_flag_ids[seg_b])
+            if flag_a >= 0 and flag_b >= 0 and flag_a != flag_b:
+                flag_flag_segment_pairs.append((seg_a, seg_b))
+        self.flag_flag_segment_pair_indices = np.asarray(
+            flag_flag_segment_pairs, dtype=int
+        ).reshape((-1, 2))
+
+        basal_beads: list[int] = []
+        for flag_indices in self.model.flagella_indices:
+            chain = flag_indices.astype(int, copy=False)
+            basal_beads.extend(chain[: min(2, chain.size)].tolist())
+        self.basal_flag_bead_indices = np.asarray(basal_beads, dtype=int)
 
     def _phase_reference_frame(
         self, positions_m: np.ndarray
@@ -1418,6 +1537,13 @@ class StepSummaryRecorder:
             body_axis,
             rear_dir,
         )
+        flag_flag_repulsion_metrics = _flag_flag_repulsion_metrics(
+            pos_after,
+            self.spring_pairs,
+            self.flag_flag_segment_pair_indices,
+            self.basal_flag_bead_indices,
+            self.cfg,
+        )
 
         row: dict[str, float | int | bool] = {
             "step": int(step),
@@ -1473,6 +1599,7 @@ class StepSummaryRecorder:
             "body_axis_wobble_rms_deg": body_axis_wobble_rms_deg,
             "body_angular_velocity_rms_rad_s": body_angular_velocity_rms_rad_s,
             **bundle_metrics,
+            **flag_flag_repulsion_metrics,
             "F_total_mean_body": _mean_norm(diag.total_forces, self.body_mask),
             "F_total_mean_flag": _mean_norm(diag.total_forces, self.flag_mask),
             "F_total_mean_all": float(

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -163,6 +163,7 @@ class FlagellumParams:
     n_flagella: int = 3
     placement_mode: str = "uniform"
     init_mode: str = "legacy_radius_pitch"
+    initial_orientation_mode: str = "side_attach"
     stub_mode: str = (
         "full_flagella"  # minimal_basal_stub | extended_basal_stub_5 |
         # full_flagella
@@ -313,6 +314,7 @@ class OutputSamplingParams:
     """出力サンプリング設定。"""
 
     out_all_steps_3d: bool = True
+    fps_out_3d: float = 25.0
     fps_out_2d: float = 25.0
 
 
@@ -657,6 +659,9 @@ class SimulationConfig:
             n_flagella=int(_get(flag_raw, "n_flagella", 3)),
             placement_mode=str(_get(flag_raw, "placement_mode", "uniform")),
             init_mode=str(_get(flag_raw, "init_mode", "legacy_radius_pitch")),
+            initial_orientation_mode=str(
+                _get(flag_raw, "initial_orientation_mode", "side_attach")
+            ),
             stub_mode=str(_get(flag_raw, "stub_mode", "full_flagella")),
             discretization=FlagellaDiscretizationParams(ds_over_b=float(ds_over_b)),
             n_beads_per_flagellum=max(2, int(n_beads_per_flagellum)),
@@ -820,8 +825,12 @@ class SimulationConfig:
 
         out_sample_raw = raw.get("output_sampling", {}) or {}
         old_fps = (raw.get("time", {}) or {}).get("fps_out")
+        fps_out_3d_raw = out_sample_raw.get(
+            "fps_out_3d", out_sample_raw.get("fps_3d_out", old_fps or 25.0)
+        )
         output_sampling = OutputSamplingParams(
             out_all_steps_3d=bool(_get(out_sample_raw, "out_all_steps_3d", True)),
+            fps_out_3d=float(fps_out_3d_raw),
             fps_out_2d=float(_get(out_sample_raw, "fps_out_2d", old_fps or 25.0)),
         )
 

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -164,6 +164,7 @@ class FlagellumParams:
     placement_mode: str = "uniform"
     init_mode: str = "legacy_radius_pitch"
     initial_orientation_mode: str = "side_attach"
+    initial_tangent_vs_rear_deg: float | None = None
     stub_mode: str = (
         "full_flagella"  # minimal_basal_stub | extended_basal_stub_5 |
         # full_flagella
@@ -661,6 +662,11 @@ class SimulationConfig:
             init_mode=str(_get(flag_raw, "init_mode", "legacy_radius_pitch")),
             initial_orientation_mode=str(
                 _get(flag_raw, "initial_orientation_mode", "side_attach")
+            ),
+            initial_tangent_vs_rear_deg=(
+                float(flag_raw["initial_tangent_vs_rear_deg"])
+                if flag_raw.get("initial_tangent_vs_rear_deg") not in (None, "")
+                else None
             ),
             stub_mode=str(_get(flag_raw, "stub_mode", "full_flagella")),
             discretization=FlagellaDiscretizationParams(ds_over_b=float(ds_over_b)),

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -18,6 +18,7 @@ def _make_cfg(
     ds_over_b: float = 0.58,
     flag_length_over_b: float = 2.32,
     init_mode: str = "legacy_radius_pitch",
+    initial_orientation_mode: str = "side_attach",
     stub_mode: str = "full_flagella",
     n_beads_per_flagellum: int | None = None,
     seed: int = 0,
@@ -26,6 +27,7 @@ def _make_cfg(
         "n_flagella": n_flagella,
         "placement_mode": "uniform",
         "init_mode": init_mode,
+        "initial_orientation_mode": initial_orientation_mode,
         "stub_mode": stub_mode,
         "discretization": {"ds_over_b": ds_over_b},
         "bond_L_over_b": ds_over_b,
@@ -132,6 +134,21 @@ def _dihedral_angle_rad(
 
 def _wrap_deg(deg: float) -> float:
     return float((deg + 180.0) % 360.0 - 180.0)
+
+
+def _base_tangent_vs_rear_deg(model: SimModel, flag_id: int) -> float:
+    first = np.mean(model.positions_m[model.body_layer_indices[0]], axis=0)
+    last = np.mean(model.positions_m[model.body_layer_indices[-1]], axis=0)
+    body_axis = last - first
+    body_axis = body_axis / max(float(np.linalg.norm(body_axis)), 1e-18)
+    rear_dir = -body_axis
+
+    idx = model.flagella_indices[flag_id].astype(int, copy=False)
+    tangent = model.positions_m[idx[1]] - model.positions_m[idx[0]]
+    tangent = tangent / max(float(np.linalg.norm(tangent)), 1e-18)
+    return float(
+        np.rad2deg(np.arccos(float(np.clip(np.dot(tangent, rear_dir), -1.0, 1.0))))
+    )
 
 
 def _estimate_helix_radius_pitch_over_b(
@@ -519,6 +536,27 @@ def test_flagella_base_tangent_is_perpendicular_to_rear(n_flagella: int) -> None
             np.arccos(float(np.clip(np.dot(tangent0, rear_dir), -1.0, 1.0)))
         )
         assert abs(angle_deg - 90.0) <= 10.0
+
+
+def test_posterior_aligned_base_tangent_points_rearward() -> None:
+    cfg = _make_cfg(
+        n_flagella=3,
+        init_mode="paper_table1",
+        initial_orientation_mode="posterior_aligned",
+        n_beads_per_flagellum=11,
+    )
+
+    model = ModelBuilder(cfg).build()
+
+    angles = [_base_tangent_vs_rear_deg(model, f_id) for f_id in range(3)]
+    assert angles == pytest.approx([0.0, 0.0, 0.0], abs=1.0e-6)
+
+
+def test_invalid_initial_orientation_mode_is_rejected() -> None:
+    cfg = _make_cfg(initial_orientation_mode="invalid")
+
+    with pytest.raises(ValueError, match="initial_orientation_mode"):
+        ModelBuilder(cfg).build()
 
 
 def test_body_has_no_torsion_quads() -> None:

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -19,6 +19,7 @@ def _make_cfg(
     flag_length_over_b: float = 2.32,
     init_mode: str = "legacy_radius_pitch",
     initial_orientation_mode: str = "side_attach",
+    initial_tangent_vs_rear_deg: float | None = None,
     stub_mode: str = "full_flagella",
     n_beads_per_flagellum: int | None = None,
     seed: int = 0,
@@ -28,6 +29,7 @@ def _make_cfg(
         "placement_mode": "uniform",
         "init_mode": init_mode,
         "initial_orientation_mode": initial_orientation_mode,
+        "initial_tangent_vs_rear_deg": initial_tangent_vs_rear_deg,
         "stub_mode": stub_mode,
         "discretization": {"ds_over_b": ds_over_b},
         "bond_L_over_b": ds_over_b,
@@ -550,6 +552,28 @@ def test_posterior_aligned_base_tangent_points_rearward() -> None:
 
     angles = [_base_tangent_vs_rear_deg(model, f_id) for f_id in range(3)]
     assert angles == pytest.approx([0.0, 0.0, 0.0], abs=1.0e-6)
+
+
+def test_initial_tangent_vs_rear_deg_overrides_orientation_mode() -> None:
+    cfg = _make_cfg(
+        n_flagella=3,
+        init_mode="paper_table1",
+        initial_orientation_mode="side_attach",
+        initial_tangent_vs_rear_deg=10.0,
+        n_beads_per_flagellum=11,
+    )
+
+    model = ModelBuilder(cfg).build()
+
+    angles = [_base_tangent_vs_rear_deg(model, f_id) for f_id in range(3)]
+    assert angles == pytest.approx([10.0, 10.0, 10.0], abs=1.0e-6)
+
+
+def test_invalid_initial_tangent_vs_rear_deg_is_rejected() -> None:
+    cfg = _make_cfg(initial_tangent_vs_rear_deg=-1.0)
+
+    with pytest.raises(ValueError, match="initial_tangent_vs_rear_deg"):
+        ModelBuilder(cfg).build()
 
 
 def test_invalid_initial_orientation_mode_is_rejected() -> None:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -219,6 +219,35 @@ def test_motor_local_scales_can_be_configured() -> None:
     assert sim_cfg.motor.local_torsion_scale == pytest.approx(0.5)
 
 
+def test_output_sampling_fps_out_3d_can_be_configured() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    cfg["output_sampling"] = {
+        "out_all_steps_3d": False,
+        "fps_out_3d": 12.5,
+        "fps_out_2d": 25.0,
+    }
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.output_sampling.out_all_steps_3d is False
+    assert sim_cfg.output_sampling.fps_out_3d == pytest.approx(12.5)
+    assert sim_cfg.output_sampling.fps_out_2d == pytest.approx(25.0)
+
+
+def test_output_sampling_accepts_fps_3d_out_alias() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    cfg["output_sampling"] = {
+        "out_all_steps_3d": False,
+        "fps_3d_out": 10.0,
+    }
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.output_sampling.fps_out_3d == pytest.approx(10.0)
+
+
 def test_projection_config_is_ignored_after_removal() -> None:
     cfg = _base_cfg()
     cfg["projection"] = {
@@ -296,6 +325,30 @@ def test_flagella_init_mode_can_be_set_to_paper_table1() -> None:
 
     assert sim_cfg.flagella.init_mode == "paper_table1"
     assert sim_cfg.flagella.n_beads_per_flagellum == 15
+
+
+def test_flagella_initial_orientation_mode_defaults_to_side_attach() -> None:
+    cfg = _base_cfg()
+    cfg["flagella"] = {"bond_L_over_b": 0.58, "length_over_b": 5.8}
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.flagella.initial_orientation_mode == "side_attach"
+
+
+def test_flagella_initial_orientation_mode_can_be_set_to_posterior_aligned() -> None:
+    cfg = _base_cfg()
+    cfg["flagella"] = {
+        "initial_orientation_mode": "posterior_aligned",
+        "bond_L_over_b": 0.58,
+        "length_over_b": 5.8,
+    }
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.flagella.initial_orientation_mode == "posterior_aligned"
 
 
 def test_flagella_stub_mode_can_be_set_to_minimal_basal_stub() -> None:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -351,6 +351,20 @@ def test_flagella_initial_orientation_mode_can_be_set_to_posterior_aligned() -> 
     assert sim_cfg.flagella.initial_orientation_mode == "posterior_aligned"
 
 
+def test_flagella_initial_tangent_vs_rear_deg_can_be_configured() -> None:
+    cfg = _base_cfg()
+    cfg["flagella"] = {
+        "initial_tangent_vs_rear_deg": 10.0,
+        "bond_L_over_b": 0.58,
+        "length_over_b": 5.8,
+    }
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.flagella.initial_tangent_vs_rear_deg == pytest.approx(10.0)
+
+
 def test_flagella_stub_mode_can_be_set_to_minimal_basal_stub() -> None:
     cfg = _base_cfg()
     cfg["flagella"] = {

--- a/tests/test_phase2_7_bundling_sweep.py
+++ b/tests/test_phase2_7_bundling_sweep.py
@@ -66,3 +66,25 @@ def test_phase27_net_abs_helix_spin_revolutions_uses_phase_delta() -> None:
     ]
 
     assert phase27._net_abs_helix_spin_revolutions(rows) == 1.0
+
+
+def test_phase27_build_config_sets_initial_tangent_angle() -> None:
+    raw_cfg = phase27._load_yaml(
+        Path(__file__).resolve().parents[1] / "conf/sim_swim.yaml"
+    )
+
+    cfg = phase27._build_config(
+        raw_cfg,
+        orientation_mode="side_attach",
+        initial_tangent_vs_rear_deg=10.0,
+        n_flagella=3,
+        torque_Nm=0.5e-20,
+        duration_s=0.02,
+        dt_star=1.0e-4,
+        overrides=[],
+    )
+
+    assert cfg.flagella.initial_orientation_mode == "side_attach"
+    assert cfg.flagella.initial_tangent_vs_rear_deg == 10.0
+    assert cfg.flagella.n_flagella == 3
+    assert cfg.motor.torque_Nm == 0.5e-20

--- a/tests/test_phase2_7_bundling_sweep.py
+++ b/tests/test_phase2_7_bundling_sweep.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "01_simulate_swimming"
+    / "run_phase2_7_bundling_sweep.py"
+)
+SPEC = importlib.util.spec_from_file_location("phase27_bundling_sweep", SCRIPT_PATH)
+assert SPEC is not None
+phase27 = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(phase27)
+
+
+def test_phase27_classifies_shape_fail_as_collapse() -> None:
+    row = {"shape_pass_nonbody": "False"}
+
+    assert phase27.classify_phase27_condition(row, n_flagella=3) == "collapse"
+
+
+def test_phase27_classifies_posterior_bundle() -> None:
+    row = {
+        "shape_pass_nonbody": "True",
+        "bundle_axis_vs_rear_angle_deg": "12.0",
+        "bundle_rearward_projection": "0.9",
+        "bundle_participation_ratio": "1.0",
+        "bundle_independent_flagella_count": "0",
+    }
+
+    assert phase27.classify_phase27_condition(row, n_flagella=3) == "posterior_bundle"
+
+
+def test_phase27_classifies_partial_bundle() -> None:
+    row = {
+        "shape_pass_nonbody": "True",
+        "bundle_axis_vs_rear_angle_deg": "20.0",
+        "bundle_rearward_projection": "0.8",
+        "bundle_participation_ratio": "0.67",
+        "bundle_independent_flagella_count": "1",
+    }
+
+    assert phase27.classify_phase27_condition(row, n_flagella=3) == "partial_bundle"
+
+
+def test_phase27_classifies_nonposterior_condition_as_no_bundle() -> None:
+    row = {
+        "shape_pass_nonbody": "True",
+        "bundle_axis_vs_rear_angle_deg": "90.0",
+        "bundle_rearward_projection": "0.0",
+        "bundle_participation_ratio": "1.0",
+        "bundle_independent_flagella_count": "0",
+    }
+
+    assert phase27.classify_phase27_condition(row, n_flagella=3) == "no_bundle"
+
+
+def test_phase27_net_abs_helix_spin_revolutions_uses_phase_delta() -> None:
+    rows = [
+        {"flag_helix_spin_phase_deg": "10.0"},
+        {"flag_helix_spin_phase_deg": "370.0"},
+    ]
+
+    assert phase27._net_abs_helix_spin_revolutions(rows) == 1.0

--- a/tests/test_render_state_and_projection.py
+++ b/tests/test_render_state_and_projection.py
@@ -7,6 +7,7 @@ from sim_swim.render.render3d import (
     _hook_edges,
     _resolve_view_range_um,
     _run_tumble_label,
+    _select_frames,
     save_swim_movie,
 )
 from sim_swim.sim.flagella_geometry import FlagellaRig
@@ -132,6 +133,24 @@ def test_view_range_defaults_to_3_when_no_flagella_are_present() -> None:
     )
 
     assert _resolve_view_range_um(cfg, rig) == 3.0
+
+
+def test_select_frames_uses_3d_sampling_rate_when_not_all_steps() -> None:
+    states = [
+        SimulationState(
+            t=float(i) * 0.01,
+            position_um=(0.0, 0.0, 0.0),
+            quaternion=(0.0, 0.0, 0.0, 1.0),
+            velocity_um_s=(0.0, 0.0, 0.0),
+            omega_rad_s=(0.0, 0.0, 0.0),
+            bead_positions_um=np.zeros((1, 3), dtype=float),
+        )
+        for i in range(11)
+    ]
+
+    selected = _select_frames(states, out_all_steps_3d=False, fps_hint=20.0)
+
+    assert [round(st.t, 2) for st in selected] == [0.0, 0.05, 0.1]
 
 
 def test_save_swim_movie_emits_render_outputs(tmp_path, monkeypatch) -> None:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -433,6 +433,81 @@ def test_phase2_initial_geometry_summary_contract_matches_step0(
     assert float(step0["flag_torsion_err_max_deg"]) <= 1.0e-2
 
 
+def test_posterior_aligned_initial_geometry_summary_uses_rearward_tangent_contract(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_cfg(
+        motor_torque_Nm=0.0,
+        hook_enabled=True,
+        n_flagella=3,
+        stub_mode="full_flagella",
+        duration_s=0.001,
+    ).with_overrides({"flagella": {"initial_orientation_mode": "posterior_aligned"}})
+    sim = Simulator(cfg)
+    sim.run(cfg.time.duration_s, step_summary_dir=tmp_path / "posterior_initial")
+
+    data = json.loads(
+        (tmp_path / "posterior_initial" / "initial_geometry_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert data["flagella"]["initial_orientation_mode"] == "posterior_aligned"
+    assert data["flagella"]["geometry_contract"]["tolerances"][
+        "tangent_vs_rear_target_deg"
+    ] == pytest.approx(0.0)
+    assert [f["initial_geometry_pass"] for f in data["per_flagellum"]] == [
+        True,
+        True,
+        True,
+    ]
+    assert [
+        f["initial_tangent_vs_rear_direction_angle_deg"] for f in data["per_flagellum"]
+    ] == pytest.approx([0.0, 0.0, 0.0], abs=1.0e-6)
+
+
+def test_phase27_step_summary_includes_bundle_and_swimming_metrics(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_cfg(
+        motor_torque_Nm=0.0,
+        hook_enabled=True,
+        n_flagella=3,
+        stub_mode="full_flagella",
+        duration_s=0.001,
+    ).with_overrides({"flagella": {"initial_orientation_mode": "posterior_aligned"}})
+    sim = Simulator(cfg)
+    rows = _run_and_load_step_summary(
+        sim,
+        cfg.time.duration_s,
+        tmp_path / "phase27_metrics",
+    )
+    first = rows[0]
+
+    for key in [
+        "body_displacement_um",
+        "body_speed_um_s",
+        "body_axis_cumulative_angle_deg",
+        "body_axis_wobble_rms_deg",
+        "body_angular_velocity_rms_rad_s",
+        "bundle_axis_vs_body_axis_angle_deg",
+        "bundle_axis_vs_rear_angle_deg",
+        "bundle_rearward_projection",
+        "bundle_tip_axis_dist_mean_um",
+        "bundle_participation_ratio",
+        "bundle_independent_flagella_count",
+        "flag_tip_pair_dist_mean_um",
+    ]:
+        assert key in first
+
+    assert float(first["bundle_axis_vs_rear_angle_deg"]) == pytest.approx(
+        0.0,
+        abs=1.0e-5,
+    )
+    assert float(first["bundle_rearward_projection"]) == pytest.approx(1.0)
+    assert float(first["bundle_participation_ratio"]) >= 0.0
+
+
 def test_phase1_body_static_stability(tmp_path: Path) -> None:
     cfg = _make_cfg(
         motor_torque_Nm=0.0,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -497,6 +497,13 @@ def test_phase27_step_summary_includes_bundle_and_swimming_metrics(
         "bundle_participation_ratio",
         "bundle_independent_flagella_count",
         "flag_tip_pair_dist_mean_um",
+        "flag_flag_segment_dist_min_um",
+        "flag_flag_segment_dist_mean_um",
+        "flag_flag_close_pair_count",
+        "flag_flag_repulsion_force_mean_N",
+        "flag_flag_repulsion_force_max_N",
+        "flag_flag_basal_repulsion_force_mean_N",
+        "flag_flag_basal_repulsion_force_max_N",
     ]:
         assert key in first
 
@@ -506,6 +513,8 @@ def test_phase27_step_summary_includes_bundle_and_swimming_metrics(
     )
     assert float(first["bundle_rearward_projection"]) == pytest.approx(1.0)
     assert float(first["bundle_participation_ratio"]) >= 0.0
+    assert float(first["flag_flag_segment_dist_min_um"]) > 0.0
+    assert int(first["flag_flag_close_pair_count"]) >= 0
 
 
 def test_phase1_body_static_stability(tmp_path: Path) -> None:


### PR DESCRIPTION
## 目的・概要
Phase 2.7 の複数べん毛条件で、後方束化と形状安定性を診断するための実装・定量指標・実行結果を追加する。

## 背景
単一べん毛では `material_twist_local_couple` により螺旋形状維持とnet回転を確認済み。次に複数べん毛で、崩壊せず後方束化する条件を探索する必要がある。

## 詳細
- `output_sampling.fps_out_3d` を追加し、長時間3D出力を間引けるようにした。
- `flagella.initial_orientation_mode` / `flagella.initial_tangent_vs_rear_deg` を追加し、後方寄り初期接線条件を指定可能にした。
- Phase 2.7 sweep script を追加した。
- `step_summary.csv` に束化・遊泳・flagella-flagella repulsion 診断指標を追加した。
- `n_flagella=3`, `duration_s=0.5`, `dt_star=1.0e-4` の代表条件を探索した。

## 現時点の判定
このPRは診断進捗であり、Phase 2.7 完了PRではない。

後方束化成功条件は未発見。形状が保てる条件では `no_bundle_drive`、トルクを上げると `hook_drift` が支配的という原因整理まで実施した。

#56 は merge 済みで、本PRは `main` base。