### PR TITLE
[codex] Add issue workflow skill

### DIFF
--- a/docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json
+++ b/docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json
@@ -23,9 +23,9 @@
   "adr_required": false,
   "adr_reason": "Codex workflow 用 skill と運用 reference の追加であり、物理モデル、出力形式、依存関係、テスト戦略の大きな変更ではないため ADR は不要。",
   "commit_type": "complete",
-  "commit_hash": "d995859",
-  "push_status": "not_pushed",
-  "pull_request_url": "",
+  "commit_hash": "2ea781a",
+  "push_status": "pushed",
+  "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/62",
   "next_actions": [
     "今後の issue template に task type、scope、required context、execution budget、completion target を追加するか検討する。",
     "必要に応じて docs/codex-notes/phase2_current_index.md または docs/codex-runs/RUN_INDEX.md を別 issue で作成し、過去ログ探索コストをさらに下げる。",

--- a/docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json
+++ b/docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json
@@ -1,0 +1,34 @@
+{
+  "status": "PASS",
+  "summary": "Issue #50 に対応し、issue 単位作業で Codex の context / tool / simulation resource を削減するための repository-local skill を tools/codex/skills/flagella-issue-workflow/ に追加した。SKILL.md は短い入口に限定し、context routing、completion policy、resource reduction 案を references へ分離した。",
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "この skill は repository 内のレビュー対象として追加したものであり、現環境の自動 discovery 用 ~/.codex/skills には install していない。",
+    "repo の .codex/ はこの実行環境では read-only 扱いだったため、Codex workflow 用の tools/codex/skills 配下に配置した。",
+    "実際のリソース削減効果は、今後の issue 本文に task type、scope、execution budget を書く運用と併用して評価する必要がある。"
+  ],
+  "tests_reviewed": [
+    "python3 /Users/kentatakemori/.codex/skills/.system/skill-creator/scripts/quick_validate.py tools/codex/skills/flagella-issue-workflow",
+    "python3 -m json.tool docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json",
+    "rg -n \"TODO|\\\\[TODO|Use -issue\" tools/codex/skills/flagella-issue-workflow",
+    "git diff --cached --check",
+    "commit hook: uv run ruff format --check .",
+    "commit hook: uv run ruff check .",
+    "commit hook: uv run pytest -q (159 passed)"
+  ],
+  "user_review_required": false,
+  "user_review_command": "",
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "Codex workflow 用 skill と運用 reference の追加であり、物理モデル、出力形式、依存関係、テスト戦略の大きな変更ではないため ADR は不要。",
+  "commit_type": "complete",
+  "commit_hash": "d995859",
+  "push_status": "not_pushed",
+  "pull_request_url": "",
+  "next_actions": [
+    "今後の issue template に task type、scope、required context、execution budget、completion target を追加するか検討する。",
+    "必要に応じて docs/codex-notes/phase2_current_index.md または docs/codex-runs/RUN_INDEX.md を別 issue で作成し、過去ログ探索コストをさらに下げる。",
+    "この repository-local skill を実運用で使い、不要な context 読み込みや重い simulation 実行が減るか確認する。"
+  ]
+}

--- a/docs/codex-runs/20260615_235848_codex_issue50_skill/work_log.md
+++ b/docs/codex-runs/20260615_235848_codex_issue50_skill/work_log.md
@@ -1,0 +1,34 @@
+# Codex Run Log
+
+## Task
+
+Issue #50「SKILL.mdの追加」に対応し、issue 単位作業で Codex の context / tool / simulation resource を削減するための repository-local skill を追加する。
+
+## Scope
+
+- Add a repository-reviewed skill under `tools/codex/skills/flagella-issue-workflow/`.
+- Keep `SKILL.md` concise and move detailed routing / completion / resource policy into references.
+- Record whether SKILL.md can reduce resources and list additional reduction ideas for future issues.
+
+Out of scope:
+
+- Install the skill into `~/.codex/skills`.
+- Change Phase 2 physical simulation code.
+- Run Phase 2 simulations.
+
+## Implementation
+
+- Created `tools/codex/skills/flagella-issue-workflow/SKILL.md`.
+- Added `references/context-routing.md` to route required project documents by task type.
+- Added `references/completion-policy.md` to summarize review_result, commit, push, and PR completion handling.
+- Added `references/resource-reduction.md` to document expected resource savings and future issue template ideas.
+- Fixed generated `agents/openai.yaml` default prompt so it references `$flagella-issue-workflow`.
+
+## Verification
+
+- `python3 /Users/kentatakemori/.codex/skills/.system/skill-creator/scripts/quick_validate.py tools/codex/skills/flagella-issue-workflow`
+- `rg -n "TODO|\\[TODO|Use -issue" tools/codex/skills/flagella-issue-workflow`
+
+## Result
+
+The skill validates successfully. This is a workflow/docs-only change, so Phase 2 simulations and full pytest were not run.

--- a/tools/codex/skills/flagella-issue-workflow/SKILL.md
+++ b/tools/codex/skills/flagella-issue-workflow/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: flagella-issue-workflow
+description: Use for issue-driven Codex work in this repository when handling GitHub issues, task planning, implementation, simulation/test execution, result analysis, review_result logging, commits, pushes, PR creation, or when reducing context/resource usage by routing only the necessary project documents.
+---
+
+# Flagella Issue Workflow
+
+## Overview
+
+この skill は、`prj-flagella-estimation` の issue 単位作業を、必要な文書だけを読んで進めるための workflow である。
+目的は、`AGENTS.md` の完了条件を守りながら、方針検討・実装・実行・分析・報告の各段階で context と実行コストを使いすぎないことである。
+
+## Start
+
+1. 最初に `git status --short --branch` と現在 branch を確認する。
+2. issue / PR / user request の対象を特定する。
+3. `main` / `master` 上で直接作業しない。新規 issue 対応は最新 `main` から feature branch を作る。
+4. まず作業タイプを分類する。
+
+作業タイプ:
+
+- `planning`: 方針検討、タスク分解、issue draft、実装前整理。
+- `implementation`: コード、設定、テスト、ドキュメントの変更。
+- `diagnostic`: Phase 2 simulation sweep、失敗条件保存、原因切り分け。
+- `review-only`: 差分レビュー、CI確認、既存結果の整理。
+- `workflow`: Codex 運用、skill、review_result、PR作成方針の変更。
+
+## Context Routing
+
+常に全部読まず、作業タイプで読む文書を絞る。
+
+- どの文書を読むか迷う場合は `references/context-routing.md` を読む。
+- review_result、commit、push、PR 完了条件が必要な場合は `references/completion-policy.md` を読む。
+- リソース削減方針、軽量/重量タスクの分け方、今後の issue 化候補が必要な場合は `references/resource-reduction.md` を読む。
+
+基本ルール:
+
+- `AGENTS.md` は repo policy の正本として扱う。
+- `docs/PROJECT_PLAN.md` は phase 全体の現在地を確認するときだけ読む。
+- `docs/phase2/phase2_tasks.md` は採択済み Phase 2 task の status / acceptance criteria を確認するときだけ読む。
+- 個別 task の詳細は、該当する `docs/phase*/phase*_*.md` だけ読む。
+- 過去 run log は、該当 issue / branch / phase に直接関係するものだけ読む。
+
+## Workflow
+
+1. **方針検討**
+   - issue 本文、関連 task、直近の該当 docs だけで scope を決める。
+   - 実装に入る前に、完了条件、実行すべき test/simulation、目視レビュー要否を分ける。
+   - 方針検討だけの依頼では、重い simulation や full pytest は走らせない。
+
+2. **実装**
+   - 変更は scope 内に限定する。
+   - `scripts/` は orchestration、再利用ロジックは `src/`、Codex workflow 補助は `tools/codex/` に置く。
+   - Phase 2 の物理モデル変更では、参照論文モデル、現行実装、数値安定化、project-specific extension を区別して記録する。
+
+3. **実行**
+   - 最小の targeted test から実行する。
+   - Phase 2 の simulation は、まず短時間または代表条件で確認し、必要があるときだけ sweep / 長時間実行へ進む。
+   - `time.dt_star` は default config を変えず、必要な run で CLI override する。
+
+4. **結果分析**
+   - PASS / FAIL だけでなく、残った blocking issue と次に切り分けるべき原因を記録する。
+   - Phase 2 の collapse、fly-away、hook drift、no_bundle などは、失敗でも再現条件が有用なら diagnostic progress として扱う。
+
+5. **報告・完了**
+   - `docs/codex-runs/<run-id>/review_result.json` を作成する。
+   - PASS 完了なら commit / push / PR まで行う。
+   - FAIL 診断でも有用な場合は、diagnostic / wip / docs commit として保存できる。ただし完了とは言わない。
+
+## Resource Discipline
+
+- `SKILL.md` に長い project history を入れない。長い情報は reference へ分離する。
+- 1回の issue で「方針検討」と「実装・実行」を混ぜすぎない。必要なら PR を分ける。
+- full test / long simulation / video render は、acceptance criteria に必要な場合だけ実行する。
+- 既存 docs の探索は `rg` で候補を絞ってから読む。
+- 最終報告では、読んだもの、変えたもの、走らせたもの、走らせなかったものを短く明示する。

--- a/tools/codex/skills/flagella-issue-workflow/agents/openai.yaml
+++ b/tools/codex/skills/flagella-issue-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Flagella Issue Workflow"
+  short_description: "Issue-driven Codex workflow for this repo"
+  default_prompt: "Use $flagella-issue-workflow to handle a project issue with scoped planning, implementation, verification, and reporting."

--- a/tools/codex/skills/flagella-issue-workflow/references/completion-policy.md
+++ b/tools/codex/skills/flagella-issue-workflow/references/completion-policy.md
@@ -1,0 +1,82 @@
+# Completion Policy
+
+この reference は、issue 対応の完了処理を軽く確実に行うための要約である。正本は `AGENTS.md`。
+
+## Run ID
+
+形式:
+
+`YYYYMMDD_HHMMSS_<phase>_<task-id>`
+
+例:
+
+`20260615_233000_codex_issue50_skill`
+
+保存先:
+
+`docs/codex-runs/<run-id>/`
+
+## Required Files
+
+原則:
+
+- `docs/codex-runs/<run-id>/review_result.json`
+- 必要なら `docs/codex-runs/<run-id>/work_log.md`
+
+`review_result.json` は完了状態の正本である。
+
+## PASS Conditions
+
+PASS と言うには、次を満たす。
+
+- requested implementation / documentation change が完了している。
+- relevant tests/checks が PASS、または未実行理由が明確。
+- review step が完了している。
+- `review_result.json` の `status` が `"PASS"`。
+- work log / review result が保存されている。
+- final state が commit 済み。
+- remote access があれば push 済み。
+- pushed feature branch なら PR 作成済み。
+
+## FAIL / Diagnostic Conditions
+
+Phase 2 では、FAIL でも有用な診断進捗を commit / push してよい。
+
+例:
+
+- collapse mode を再現した。
+- fly-away 条件を保存した。
+- hook drift や no_bundle_drive を切り分けた。
+- failing test で次の target behavior を定義した。
+- 物理モデル差分や数値上の不一致を記録した。
+
+FAIL commit は完了扱いにしない。commit type は `diagnostic`, `wip`, `docs`, `test` 相当の内容にする。
+
+## Review Result Fields
+
+最低限、以下を埋める。
+
+- `status`
+- `summary`
+- `blocking_issues`
+- `non_blocking_issues`
+- `tests_reviewed`
+- `user_review_required`
+- `user_review_command`
+- `user_review_outputs`
+- `user_review_points`
+- `adr_required`
+- `adr_reason`
+- `commit_type`
+- `commit_hash`
+- `push_status`
+- `pull_request_url`
+- `next_actions`
+
+## Commit / Push / PR
+
+- commit message は `type(scope): summary`。
+- `main` / `master` へ直接 commit しない。
+- feature branch を push したら PR を作る。
+- GitHub issue は明示依頼がない限り作らない。
+- PR は作ってよいが、merge はしない。

--- a/tools/codex/skills/flagella-issue-workflow/references/context-routing.md
+++ b/tools/codex/skills/flagella-issue-workflow/references/context-routing.md
@@ -1,0 +1,108 @@
+# Context Routing
+
+この reference は、issue 単位作業で読む文書を絞るための routing 表である。
+
+## Always Check First
+
+- `git status --short --branch`
+- user request の最新内容
+- 対象 issue / PR の本文とコメント
+
+## Repository Policy
+
+読む条件:
+
+- branch / commit / push / PR / review_result の扱いを判断する。
+- 完了条件や禁止事項を確認する。
+- Phase 2 の目視レビュー要否を判断する。
+
+読む文書:
+
+- `AGENTS.md`
+
+注意:
+
+- `AGENTS.md` は正本なので、skill や docs と矛盾した場合は `AGENTS.md` を優先する。
+
+## Project State
+
+読む条件:
+
+- phase の現在地を確認する。
+- task が Phase 2.6 / 2.7 / 2.8 など、どの流れに属するか判断する。
+
+読む文書:
+
+- `docs/PROJECT_PLAN.md`
+- `docs/TASK_MAP.md`
+
+読み方:
+
+- 該当 phase の status と直近の progress だけ読む。
+- 全履歴を毎回読み直さない。
+
+## Accepted Tasks
+
+読む条件:
+
+- 既存採択済み task の status、acceptance criteria、branch、source issue を確認する。
+- task checkbox を更新してよいか判断する。
+
+読む文書:
+
+- `docs/phase2/phase2_tasks.md`
+
+読み方:
+
+- `rg -n "source issue|P2-|status|acceptance criteria|current diagnostic notes" docs/phase2/phase2_tasks.md`
+- 該当 task 周辺だけ読む。
+
+## Phase 2 Detail Docs
+
+読む条件:
+
+- 物理モデル、simulation 条件、既存診断結果、代表出力を確認する。
+
+主な文書:
+
+- `docs/phase2/phase2_6_helix_retention_gate.md`
+- `docs/phase2/phase2_6_torque_transmission_model_evaluation.md`
+- `docs/phase2/phase2_7_bundling_stability_plan.md`
+
+読み方:
+
+- issue が Phase 2.7 なら Phase 2.7 doc を優先し、Phase 2.6 docs は代表条件や前提が必要な範囲だけ読む。
+- 過去の失敗条件を探すときは `outputs/` ではなく、まず docs と `docs/codex-runs/*/review_result.json` を読む。
+
+## Legacy Prompts
+
+読む条件:
+
+- `AGENTS.md` / `docs/PROJECT_PLAN.md` へ移行中の内容が必要。
+- 古い acceptance criteria や original prompt の根拠が必要。
+
+読む文書:
+
+- `prompts/00_project_context.md`
+- `prompts/01_repo_rules.md`
+- relevant `prompts/phase*/`
+
+注意:
+
+- 現在の正本は `AGENTS.md` と `docs/PROJECT_PLAN.md`。legacy prompt は補助として扱う。
+
+## Codex Run Logs
+
+読む条件:
+
+- 直近 run の PASS / FAIL、commit hash、残 issue、出力先を確認する。
+- 既存 PR / branch の作業を引き継ぐ。
+
+探し方:
+
+- `rg -n "source issue|pull_request_url|commit_hash|blocking_issues|next_actions|Issue #<num>|phase2_<task>" docs/codex-runs`
+
+読み方:
+
+- まず `review_result.json` を読む。
+- 詳細な reasoning が必要な場合だけ同じ run の `work_log.md` を読む。

--- a/tools/codex/skills/flagella-issue-workflow/references/resource-reduction.md
+++ b/tools/codex/skills/flagella-issue-workflow/references/resource-reduction.md
@@ -1,0 +1,99 @@
+# Resource Reduction
+
+この reference は、Codex の context 使用量、tool 実行量、simulation/test 実行コストを下げるための方針である。
+
+## Does This Skill Reduce Resources?
+
+削減できる可能性は高い。
+
+理由:
+
+- 毎回読む文書を `task type` と `phase` で routing できる。
+- `SKILL.md` 本体を短くし、必要時だけ reference を読む progressive disclosure にできる。
+- 方針検討だけの依頼で、重い simulation や full pytest を走らせる判断を避けやすい。
+- `review_result.json` と `work_log.md` の読み方を固定し、過去ログ探索を `review_result` 優先にできる。
+
+限界:
+
+- Skill は自動で source of truth を更新しない。`AGENTS.md`、`docs/PROJECT_PLAN.md`、`docs/phase2/*` が肥大化し続けると効果は下がる。
+- 実際に効果を出すには、issue 本文に task type、対象 phase、期待する完了範囲を書く必要がある。
+
+## Lightweight vs Heavyweight Work
+
+軽量扱い:
+
+- issue 整理、方針検討、task decomposition。
+- docs/planning への proposal。
+- review_result / work_log の整理。
+- 小さな docs 変更。
+- targeted unit test だけで十分な変更。
+
+重量扱い:
+
+- Phase 2 simulation sweep。
+- `duration_s>=0.5` かつ `time.dt_star=1.0e-4` の長時間実行。
+- 3D/2D動画 render。
+- full pytest。
+- 物理モデルや出力 format の変更。
+
+運用:
+
+- 軽量 task では、まず `git diff --check`、JSON/YAML validation、該当 docs の整合だけでよいか判断する。
+- 重量 task では、短時間 representative、targeted tests、sweep、full tests の順で段階実行する。
+
+## Issue Template Suggestions
+
+今後の issue には、以下を入れると resource 使用量を下げやすい。
+
+```markdown
+## Task type
+- [ ] planning
+- [ ] implementation
+- [ ] diagnostic
+- [ ] review-only
+- [ ] workflow
+
+## Scope
+- Target phase:
+- Target files/modules:
+- Out of scope:
+
+## Required context
+- Must read:
+- Read only if needed:
+
+## Execution budget
+- Tests:
+- Simulation:
+- Video render:
+- Full pytest required: yes/no
+
+## Completion target
+- PASS completion required: yes/no
+- Diagnostic FAIL can be committed: yes/no
+- User visual review required: yes/no/unknown
+```
+
+## Other Reduction Ideas
+
+1. `docs/codex-notes/phase2_current_index.md` を作る。
+   - Phase 2 の current representative、最新 issue、最新 PR、読むべき doc を1ページにまとめる。
+   - 長い `docs/PROJECT_PLAN.md` と `docs/phase2/phase2_tasks.md` を毎回読む頻度を下げる。
+
+2. `docs/codex-runs/RUN_INDEX.md` を作る。
+   - run-id、issue、branch、status、commit、PR、next action だけを表にする。
+   - 過去 run の `review_result.json` 全探索を減らす。
+
+3. issue を `planning PR` と `implementation PR` に分ける。
+   - 方針が不確かな task では、まず docs/planning と review_result だけで PASS する軽量 PR を作る。
+   - 実装 PR は acceptance criteria と execution budget が固まってから始める。
+
+4. simulation sweep の manifest summary を標準化する。
+   - sweep summary の主要列と代表条件を固定し、毎回 CSV 全体を読まなくてよいようにする。
+
+5. 「full pytest が必要な条件」を明文化する。
+   - docs-only / workflow-only では full pytest を必須にしない。
+   - physics / output format / shared library 変更では full pytest または未実行理由を必須にする。
+
+6. user visual review issue を分離する。
+   - 動画生成と目視判定が必要な場合、生成 PR と review result 更新 PR を分けると無駄な再実行を減らせる。


### PR DESCRIPTION
## Summary

Closes #50.

- Add a repository-local Codex skill at `tools/codex/skills/flagella-issue-workflow/`.
- Keep `SKILL.md` short and route detailed context to references.
- Document context routing, completion policy, and resource-reduction ideas for future issue-driven work.

## Resource reduction notes

The skill should reduce Codex resource use by avoiding full project-document reads on every issue, separating planning-only work from heavy implementation/simulation work, and making `review_result.json` the first stop for past run context.

Additional future candidates are documented in `references/resource-reduction.md`, including an issue template with `task type`, `scope`, `required context`, and `execution budget`, plus possible `docs/codex-runs/RUN_INDEX.md` and `docs/codex-notes/phase2_current_index.md` indexes.

## Validation

- `python3 /Users/kentatakemori/.codex/skills/.system/skill-creator/scripts/quick_validate.py tools/codex/skills/flagella-issue-workflow`
- `python3 -m json.tool docs/codex-runs/20260615_235848_codex_issue50_skill/review_result.json`
- `rg -n "TODO|\\[TODO|Use -issue" tools/codex/skills/flagella-issue-workflow` (no matches)
- commit hook: `uv run ruff format --check .`
- commit hook: `uv run ruff check .`
- commit hook: `uv run pytest -q` (159 passed)

## Review

- User visual review required: no
- ADR: not created; this is Codex workflow documentation, not a physical model or output format decision.
