### PR TITLE
fix(codex): PR review output schemaを修正

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -106,7 +106,7 @@ jobs:
                   "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["path", "line", "severity", "message"],
+                    "required": ["path", "line", "severity", "message", "suggested_code"],
                     "properties": {
                       "path": {
                         "type": "string"
@@ -151,6 +151,8 @@ jobs:
             Pull request body:
             ----
             ${{ steps.pr.outputs.body }}
+
+            For every inline_comments item, include suggested_code. Use an empty string when there is no concrete GitHub suggestion block to post.
 
             Return JSON only, matching the provided output schema. Do not wrap the JSON in Markdown fences.
 

--- a/docs/adr/0005_codex_pr_review_action.md
+++ b/docs/adr/0005_codex_pr_review_action.md
@@ -23,6 +23,7 @@ Codex PRレビューは以下の構成で導入する。
 - GitHubへの投稿はCodexに任せず、workflow内の固定 `actions/github-script` で検証してから `pulls.createReview` を呼ぶ。
 - `path` と `line` がPR diff上の変更行に対応できる指摘だけinline review commentとして投稿する。
 - `suggested_code` がある場合だけGitHub Markdownの `suggestion` blockへ変換する。
+- OpenAI structured outputのschema制約に合わせ、`inline_comments` の各要素では `suggested_code` を必須キーとする。具体的な提案コードがない場合は空文字 `""` を使う。
 - inline化できない指摘はReview本文のfallback notesへ回す。
 - レビュー本文は日本語、見出しと `PASS` / `FAIL` は固定形式にする。
 

--- a/docs/codex-runs/20260616_232536_codex_review_schema_fix/review_result.json
+++ b/docs/codex-runs/20260616_232536_codex_review_schema_fix/review_result.json
@@ -15,9 +15,9 @@
   "adr_required": false,
   "adr_reason": "既存ADR 0005の決定内容を補足する小修正であり、新規ADRは不要。",
   "commit_type": "complete",
-  "commit_hash": "",
-  "push_status": "not_pushed",
-  "pull_request_url": "",
+  "commit_hash": "4f83ed970afd53dbe4e34b5a8f397bad5af30308",
+  "push_status": "pushed",
+  "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/67",
   "next_actions": [
     "修正PRをmainへmerge後、対象PRで @codex review を再コメントする。"
   ]

--- a/docs/codex-runs/20260616_232536_codex_review_schema_fix/review_result.json
+++ b/docs/codex-runs/20260616_232536_codex_review_schema_fix/review_result.json
@@ -1,0 +1,24 @@
+{
+  "status": "PASS",
+  "summary": "Codex PR review workflowのstructured output schema不備を修正し、suggested_codeを必須キーとして空文字運用を明記した。",
+  "blocking_issues": [],
+  "non_blocking_issues": [],
+  "tests_reviewed": [
+    "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/codex-review.yml\"); puts \"YAML OK\"'",
+    "ruby -e '... output-schema JSON required/properties consistency ...'",
+    "git diff --check"
+  ],
+  "user_review_required": false,
+  "user_review_command": "",
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "既存ADR 0005の決定内容を補足する小修正であり、新規ADRは不要。",
+  "commit_type": "complete",
+  "commit_hash": "",
+  "push_status": "not_pushed",
+  "pull_request_url": "",
+  "next_actions": [
+    "修正PRをmainへmerge後、対象PRで @codex review を再コメントする。"
+  ]
+}

--- a/docs/codex-runs/20260616_232536_codex_review_schema_fix/work_log.md
+++ b/docs/codex-runs/20260616_232536_codex_review_schema_fix/work_log.md
@@ -1,0 +1,22 @@
+# Codex review schema fix
+
+## 目的
+
+PRコメント `@codex review` で起動する `codex-review` workflow が、OpenAI structured output schemaの検証で失敗する問題を修正する。
+
+## 原因
+
+`inline_comments.items.properties` には `suggested_code` が定義されていたが、`additionalProperties: false` のobject schemaで `required` に含まれていなかった。
+Codex/OpenAI API側では、structured output用schemaとして各objectの `required` が `properties` の全キーを含む必要があり、`Missing 'suggested_code'` で失敗していた。
+
+## 変更
+
+- `.github/workflows/codex-review.yml` の `inline_comments.items.required` に `suggested_code` を追加した。
+- `suggested_code` がない場合は空文字を返すよう、Codex review promptに明記した。
+- ADR 0005にschema上の必須キーと空文字運用を追記した。
+
+## 確認
+
+- YAML構文確認: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codex-review.yml"); puts "YAML OK"'`
+- output-schema JSON確認: `SCHEMA OK`
+- git diff確認: `git diff --check`


### PR DESCRIPTION
## 目的・概要
`@codex review` で起動する Codex PR review Action が、structured output schema検証で失敗する問題を修正します。

## 背景
PR #60で `@codex review` を実行したところ、`inline_comments.items.properties` に `suggested_code` がある一方で `required` に含まれておらず、OpenAI API側で `invalid_json_schema` となっていました。

## 詳細
- `.github/workflows/codex-review.yml` の `inline_comments.items.required` に `suggested_code` を追加
- suggestion不要時は `suggested_code: ""` を返すようpromptに明記
- ADR 0005にschema制約と空文字運用を追記
- Codex run log / review_result を追加

## Checks
- YAML構文確認: pass
- output-schema JSON確認: pass
- `git diff --check`: pass
- commit hook: `uv run ruff format --check .`: pass
- commit hook: `uv run ruff check .`: pass
- commit hook: `uv run pytest -q`: 159 passed

## 次の操作
このPRをmainへmerge後、PR #60で再度 `@codex review` をコメントしてください。