### PR TITLE
Allow Codex gate to pass resolved review threads

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -278,9 +278,6 @@ jobs:
                   ) {
                     state = "success";
                     description = "Codex PR review completed with PASS.";
-                  } else if (allCurrentCodexThreadsAddressed) {
-                    state = "success";
-                    description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
                     description = `Codex PR review produced feedback; resolve ${unresolvedCurrentCodexThreads.length} current thread(s).`;
                   }
@@ -289,9 +286,6 @@ jobs:
                   if (hasCleanReviewSignal(latestConnectorComment.body)) {
                     state = "success";
                     description = "Codex review completed with PASS.";
-                  } else if (allCurrentCodexThreadsAddressed) {
-                    state = "success";
-                    description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
                     description = `Codex review produced feedback; resolve ${unresolvedCurrentCodexThreads.length} current thread(s).`;
                   }

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -90,11 +90,67 @@ jobs:
             const bodyMentionsHead = (body, headSha) =>
               typeof body === "string" &&
               (body.includes(headSha) || body.includes(headSha.slice(0, 10)));
+            const extractReviewSha = (body) => {
+              if (typeof body !== "string") {
+                return "";
+              }
+              const match = body.match(/@codex\s+review\s+([0-9a-f]{10,40})/i);
+              return match ? match[1].toLowerCase() : "";
+            };
             const hasPassVerdict = (body) =>
               /final verdict[\s\S]{0,200}\bpass\b/i.test(body);
             const hasCleanReviewSignal = (body) =>
               hasPassVerdict(body) ||
               /didn['’]t find any major issues/i.test(body);
+            const hasConnectorFeedback = (reviewOrComment) =>
+              typeof reviewOrComment?.body === "string" &&
+              !hasCleanReviewSignal(reviewOrComment.body);
+
+            async function listCodexReviewThreads(prNumber) {
+              const query = `
+                query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
+                        nodes {
+                          id
+                          isResolved
+                          isOutdated
+                          comments(first: 100) {
+                            nodes {
+                              author {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`;
+              const threads = [];
+              let cursor = null;
+              for (;;) {
+                const result = await github.graphql(query, {
+                  owner,
+                  repo,
+                  number: prNumber,
+                  cursor,
+                });
+                const reviewThreads =
+                  result.repository.pullRequest.reviewThreads;
+                threads.push(...reviewThreads.nodes);
+                if (!reviewThreads.pageInfo.hasNextPage) {
+                  break;
+                }
+                cursor = reviewThreads.pageInfo.endCursor;
+              }
+              return threads;
+            }
 
             async function evaluatePullRequest(prNumber) {
               const { data: pull } = await github.rest.pulls.get({
@@ -126,6 +182,31 @@ jobs:
                 bodyMentionsHead(review.body, headSha);
               const commentTargetsHead = (comment) =>
                 bodyMentionsHead(comment.body, headSha);
+              const prCommits = await github.paginate(
+                github.rest.pulls.listCommits,
+                {
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  per_page: 100,
+                }
+              );
+              const prCommitShas = prCommits.map((commit) =>
+                commit.sha.toLowerCase()
+              );
+              const shaBelongsToPr = (sha) =>
+                sha &&
+                prCommitShas.some((commitSha) => commitSha.startsWith(sha));
+              const currentCodexThreads = (
+                await listCodexReviewThreads(prNumber)
+              ).filter((thread) =>
+                thread.comments.nodes.some((comment) =>
+                  isConnector(comment.author?.login)
+                )
+              );
+              const unresolvedCurrentCodexThreads = currentCodexThreads.filter(
+                (thread) => !thread.isResolved && !thread.isOutdated
+              );
               const connectorThumbsUp = async (comment, headSha) => {
                 if (!bodyMentionsHead(comment.body, headSha)) {
                   return false;
@@ -149,12 +230,16 @@ jobs:
                 );
               };
 
+              const reviewRequests = comments
+                .filter((comment) => isReviewRequest(comment))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
               const latestRequest = comments
                 .filter((comment) =>
                   isReviewRequest(comment) &&
                   bodyMentionsHead(comment.body, headSha)
                 )
                 .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+              const latestAnyRequest = reviewRequests[0];
 
               let state = "failure";
               let description = `Run @codex review ${headSha.slice(0, 10)} after the latest commit.`;
@@ -189,19 +274,54 @@ jobs:
                   ) {
                     state = "success";
                     description = "Codex PR review completed with PASS.";
+                  } else if (unresolvedCurrentCodexThreads.length === 0) {
+                    state = "success";
+                    description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
-                    description = "Codex PR review produced feedback; address it and rerun @codex review.";
+                    description = `Codex PR review produced feedback; resolve ${unresolvedCurrentCodexThreads.length} current thread(s).`;
                   }
                 } else if (connectorComments.length > 0) {
                   const latestConnectorComment = connectorComments[0];
                   if (hasCleanReviewSignal(latestConnectorComment.body)) {
                     state = "success";
                     description = "Codex review completed with PASS.";
+                  } else if (unresolvedCurrentCodexThreads.length === 0) {
+                    state = "success";
+                    description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
-                    description = "Codex review produced feedback; address it and rerun @codex review.";
+                    description = `Codex review produced feedback; resolve ${unresolvedCurrentCodexThreads.length} current thread(s).`;
                   }
                 } else {
                   description = `Waiting for Codex connector response for ${headSha.slice(0, 10)}.`;
+                }
+              } else if (latestAnyRequest) {
+                const latestRequestAt = new Date(
+                  latestAnyRequest.updated_at || latestAnyRequest.created_at
+                );
+                const requestedSha = extractReviewSha(latestAnyRequest.body);
+                const connectorResponses = [
+                  ...comments.filter((comment) =>
+                    isConnector(comment.user?.login) &&
+                    new Date(comment.created_at) >= latestRequestAt
+                  ),
+                  ...reviews.filter((review) =>
+                    isConnector(review.user?.login) &&
+                    new Date(review.submitted_at) >= latestRequestAt
+                  ),
+                ];
+                const feedbackSeen = connectorResponses.some(hasConnectorFeedback);
+                if (!shaBelongsToPr(requestedSha)) {
+                  description = `Run @codex review ${headSha.slice(0, 10)} with a PR commit SHA.`;
+                } else if (connectorResponses.length === 0) {
+                  description = `Waiting for Codex connector response for ${requestedSha}.`;
+                } else if (
+                  feedbackSeen &&
+                  unresolvedCurrentCodexThreads.length === 0
+                ) {
+                  state = "success";
+                  description = "Codex review feedback addressed; all current threads resolved or outdated.";
+                } else if (feedbackSeen) {
+                  description = `Codex review produced feedback; resolve ${unresolvedCurrentCodexThreads.length} current thread(s).`;
                 }
               }
 

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -103,6 +103,7 @@ jobs:
               hasPassVerdict(body) ||
               /didn['’]t find any major issues/i.test(body);
             const hasConnectorFeedback = (reviewOrComment) =>
+              reviewOrComment?.state !== "APPROVED" &&
               typeof reviewOrComment?.body === "string" &&
               !hasCleanReviewSignal(reviewOrComment.body);
 
@@ -207,6 +208,9 @@ jobs:
               const unresolvedCurrentCodexThreads = currentCodexThreads.filter(
                 (thread) => !thread.isResolved && !thread.isOutdated
               );
+              const allCurrentCodexThreadsAddressed =
+                currentCodexThreads.length > 0 &&
+                unresolvedCurrentCodexThreads.length === 0;
               const connectorThumbsUp = async (comment, headSha) => {
                 if (!bodyMentionsHead(comment.body, headSha)) {
                   return false;
@@ -274,7 +278,7 @@ jobs:
                   ) {
                     state = "success";
                     description = "Codex PR review completed with PASS.";
-                  } else if (unresolvedCurrentCodexThreads.length === 0) {
+                  } else if (allCurrentCodexThreadsAddressed) {
                     state = "success";
                     description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
@@ -285,7 +289,7 @@ jobs:
                   if (hasCleanReviewSignal(latestConnectorComment.body)) {
                     state = "success";
                     description = "Codex review completed with PASS.";
-                  } else if (unresolvedCurrentCodexThreads.length === 0) {
+                  } else if (allCurrentCodexThreadsAddressed) {
                     state = "success";
                     description = "Codex review feedback addressed; all current threads resolved or outdated.";
                   } else {
@@ -316,7 +320,7 @@ jobs:
                   description = `Waiting for Codex connector response for ${requestedSha}.`;
                 } else if (
                   feedbackSeen &&
-                  unresolvedCurrentCodexThreads.length === 0
+                  allCurrentCodexThreadsAddressed
                 ) {
                   state = "success";
                   description = "Codex review feedback addressed; all current threads resolved or outdated.";

--- a/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
+++ b/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
@@ -1,0 +1,39 @@
+{
+  "status": "PASS",
+  "summary": "codex-review-gate を、Codex review feedback 後の修正では最新 head 再reviewだけを必須にせず、connector-authored review threads がすべて resolved または outdated なら pass できるように更新した。運用文書には、修正不要で resolve する場合の理由コメント必須化と、PR 後の動的状態を tracked review_result.json に同期するだけの commit を作らない方針を追記した。",
+  "blocking_issues": [],
+  "non_blocking_issues": [],
+  "tests_reviewed": [
+    {
+      "command": "git diff --check",
+      "status": "PASS",
+      "notes": "差分に whitespace error がないことを確認。"
+    },
+    {
+      "command": "uv run python -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/codex-review-gate.yml').read_text())\"",
+      "status": "PASS",
+      "notes": "codex-review-gate workflow YAML を構文確認。"
+    },
+    {
+      "command": "python3 -m json.tool docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json",
+      "status": "PASS",
+      "notes": "完了記録 JSON を構文確認。"
+    },
+    {
+      "command": "uv run pytest -q -m light",
+      "status": "PASS",
+      "notes": "153 passed, 227 deselected。"
+    }
+  ],
+  "user_review_required": false,
+  "user_review_command": "",
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "既に導入済みの codex-review-gate の判定条件を、ユーザー承認済みの review-once 運用へ小さく調整する変更であり、詳細な方針整理は #140 側の ADR 更新で扱う。",
+  "commit_type": "complete",
+  "commit_hash": "not_applicable",
+  "push_status": "not_applicable",
+  "pull_request_url": "",
+  "next_actions": []
+}

--- a/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
+++ b/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
@@ -28,6 +28,11 @@
       "command": "Codex review thread PRRT_kwDOQ9ZAzs6TK1pe",
       "status": "PASS",
       "notes": "APPROVED review を feedback として扱わず、resolved/outdated パスには connector-authored review thread の実在を要求するよう修正。"
+    },
+    {
+      "command": "Codex review thread PRRT_kwDOQ9ZAzs6TK-rT",
+      "status": "PASS",
+      "notes": "現在 head への非clean review応答では過去の resolved thread による addressed パスを使わず、修正commit後の fallback 評価だけで resolved/outdated パスを使うよう修正。"
     }
   ],
   "user_review_required": false,

--- a/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
+++ b/docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "summary": "codex-review-gate を、Codex review feedback 後の修正では最新 head 再reviewだけを必須にせず、connector-authored review threads がすべて resolved または outdated なら pass できるように更新した。運用文書には、修正不要で resolve する場合の理由コメント必須化と、PR 後の動的状態を tracked review_result.json に同期するだけの commit を作らない方針を追記した。",
+  "summary": "codex-review-gate を、Codex review feedback 後の修正では最新 head 再reviewだけを必須にせず、connector-authored review threads が実在し，すべて resolved または outdated なら pass できるように更新した。APPROVED review を feedback と誤判定しないようにし、運用文書には、修正不要で resolve する場合の理由コメント必須化と、PR 後の動的状態を tracked review_result.json に同期するだけの commit を作らない方針を追記した。",
   "blocking_issues": [],
   "non_blocking_issues": [],
   "tests_reviewed": [
@@ -23,6 +23,11 @@
       "command": "uv run pytest -q -m light",
       "status": "PASS",
       "notes": "153 passed, 227 deselected。"
+    },
+    {
+      "command": "Codex review thread PRRT_kwDOQ9ZAzs6TK1pe",
+      "status": "PASS",
+      "notes": "APPROVED review を feedback として扱わず、resolved/outdated パスには connector-authored review thread の実在を要求するよう修正。"
     }
   ],
   "user_review_required": false,

--- a/docs/codex/codex_workflow.md
+++ b/docs/codex/codex_workflow.md
@@ -150,6 +150,8 @@ For merge-gated PRs, request review after the latest push with the current head 
 
 `@codex review <head-short-sha>`
 
+Codex Cloud review は原則1回の final-candidate review とする。指摘が出た場合は actionable thread を一括修正し，対象チェックを再実行してから thread を resolve する。修正不要と判断して resolve する場合は，該当 thread に理由コメントを残す。
+
 This connector review is a PR review assistant, not the source of truth for task completion. Its `PASS` / `FAIL` verdict does not replace the required local `docs/codex-runs/<run-id>/review_result.json`.
 
 Codex Cloud review comments should:
@@ -163,7 +165,7 @@ Codex Cloud review comments should:
 
 Do not add repository-managed `openai/codex-action` workflows for PR review unless a new ADR explicitly reintroduces that approach.
 
-The repository-managed `codex-review-gate` workflow is allowed because it does not run Codex. It only verifies that a Cloud connector review was requested for the current head SHA and that an exact allowlisted connector login, `chatgpt-codex-connector` or `chatgpt-codex-connector[bot]`, responded through a PR review, PR comment, or thumbs-up reaction targeting that head SHA. PR comments, PR reviews, and scheduled open-PR scans are paginated. The gate runs on PR updates, issue comments, PR review submissions, manual dispatch, and schedule. Because a no-finding connector review may appear only as a thumbs-up reaction, the gate also re-evaluates open PRs on a short schedule and can be re-run manually with `workflow_dispatch`. After the workflow is merged to `main`, repository rulesets should require both `test` and `codex-review-gate` before merging to `main`.
+The repository-managed `codex-review-gate` workflow is allowed because it does not run Codex. It verifies that a Cloud connector review was requested by `@codex review <sha>` for a PR commit and that an exact allowlisted connector login, `chatgpt-codex-connector` or `chatgpt-codex-connector[bot]`, responded through a PR review, PR comment, or thumbs-up reaction. A clean connector response on the current head passes the gate. If the connector produced feedback, the gate passes once all current connector-authored review threads are resolved or outdated; it does not require another review solely because the fix changed the head SHA. CI status，thread resolve 状態，PR URL，final head SHA など PR 作成後に変わる状態を tracked `review_result.json` に同期するためだけの commit は作らない。PR comments, PR reviews, review threads, and scheduled open-PR scans are paginated. The gate runs on PR updates, issue comments, PR review submissions, manual dispatch, and schedule. Because a no-finding connector review may appear only as a thumbs-up reaction, the gate also re-evaluates open PRs on a short schedule and can be re-run manually with `workflow_dispatch`. After the workflow is merged to `main`, repository rulesets should require both `test` and `codex-review-gate` before merging to `main`.
 
 ## Reporting and decision gates
 


### PR DESCRIPTION
## Summary
- Allow codex-review-gate to pass after Codex feedback when all current connector-authored review threads are resolved or outdated.
- Keep the existing clean current-head review path.
- Document the one-review workflow, reason comments for no-change resolves, and no metadata-only commits for dynamic PR state.

## Checks
- git diff --check
- python3 -m json.tool docs/codex-runs/20260723_161500_codex_review_thread_gate/review_result.json
- uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/codex-review-gate.yml').read_text())"
- uv run pytest -q -m light

## Notes
This is a small transition PR intended to unblock #140 under the new review-thread based gate policy. Full pytest is not required for this workflow/docs-only change under the current test policy.