### PR TITLE
feat(phase3): add GT passthrough clip pipeline

### DIFF
--- a/conf/phase3/gt_passthrough_v1.yaml
+++ b/conf/phase3/gt_passthrough_v1.yaml
@@ -1,0 +1,16 @@
+dataset_id: phase3_gt_passthrough_v1
+input_dataset: outputs/phase2_analysis/flagella_count_behavior/datasets/v1
+output_dir:
+clip:
+  duration_s: 0.5
+  window_policy: non_overlap
+  overlap_stride_fraction: 0.5
+  frame_rate_hz: 25.0
+  crop_size_px: 96
+  pixel_size_um: 0.1
+filters:
+  allowed_n_flagella: [1, 2, 3]
+  require_use_for_ml_candidate: true
+  max_per_class: 3
+freeze:
+  baseline_torque_Nm: 2.0e-20

--- a/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
+++ b/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
@@ -1,0 +1,47 @@
+{
+  "status": "PASS",
+  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "The real Phase 2 dataset v1 pilot was not run by Codex because the user requested v1 pilot execution to remain manual.",
+    "The current renderer is a lightweight state_archive rasterizer for GT passthrough; pseudo-microscopy domain tuning and render variation remain under #17/#128.",
+    "Real-video detection/tracking and scale-normalization choices remain blocked on #8/#9."
+  ],
+  "tests_reviewed": [
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest -q tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py",
+      "result": "PASS (12 passed)"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS (394 passed)"
+    }
+  ],
+  "user_review_required": false,
+  "user_review_command": null,
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "This PR implements the already documented #127/#143 Phase 3 GT passthrough boundary without changing the physical model, adding dependencies, or changing the accepted schema. Real-video and dataset-adoption decisions remain separate issues.",
+  "commit_type": "complete",
+  "commit_hash": null,
+  "push_status": "not_pushed",
+  "pull_request_url": null,
+  "next_actions": [
+    "User-run the Phase 2 dataset v1 pilot command and inspect the generated manifest, metadata JSONL, split summary, QC summary, and clips.",
+    "Use the pilot output to evaluate #129 clip counts and grouped split sufficiency for 0.5 s non-overlap, then compare 0.25 s / 1.0 s variants.",
+    "Keep real-video detection/tracking out of this PR and continue it after #8/#9 input and scale-normalization decisions."
+  ]
+}

--- a/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
+++ b/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records stratified grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. The user-run v1 pilot generated 9 samples and 18 clips with each n_flagella class represented in train/val/test. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
+  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records stratified grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. The user-run v1 pilot generated 9 samples and 18 clips with each n_flagella class represented in train/val/test. Codex review feedback was addressed by making frame-end metadata inclusive and preserving config path, CLI overrides, max_per_class, and environment details in the manifest. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
   "blocking_issues": [],
   "non_blocking_issues": [
     "The current renderer is a lightweight state_archive rasterizer for GT passthrough; pseudo-microscopy domain tuning and render variation remain under #17/#128.",
@@ -34,6 +34,10 @@
     {
       "command": "pilot split audit",
       "result": "PASS (no group_key leakage; n_flagella=1,2,3 each have 2 train, 2 val, and 2 test clips)"
+    },
+    {
+      "command": "pilot metadata/provenance audit after Codex review fixes",
+      "result": "PASS (clip.source_frame_end=12, clip.t_end_s=0.48 for 13 frames at 25 Hz; manifest records config_path, CLI overrides, environment, and max_per_class)"
     }
   ],
   "user_review_required": false,

--- a/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
+++ b/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
@@ -1,9 +1,8 @@
 {
   "status": "PASS",
-  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
+  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records stratified grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. The user-run v1 pilot generated 9 samples and 18 clips with each n_flagella class represented in train/val/test. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
   "blocking_issues": [],
   "non_blocking_issues": [
-    "The real Phase 2 dataset v1 pilot was not run by Codex because the user requested v1 pilot execution to remain manual.",
     "The current renderer is a lightweight state_archive rasterizer for GT passthrough; pseudo-microscopy domain tuning and render variation remain under #17/#128.",
     "Real-video detection/tracking and scale-normalization choices remain blocked on #8/#9."
   ],
@@ -22,11 +21,19 @@
     },
     {
       "command": "uv run pytest -q tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py",
-      "result": "PASS (12 passed)"
+      "result": "PASS (13 passed)"
     },
     {
       "command": "uv run pytest -q",
-      "result": "PASS (394 passed)"
+      "result": "PASS (395 passed)"
+    },
+    {
+      "command": "uv run python scripts/03_phase3/build_clip_dataset.py config=conf/phase3/gt_passthrough_v1.yaml input_dataset=outputs/phase2_analysis/flagella_count_behavior/datasets/v1 output_dir=outputs/2026-07-24/001500/phase3_gt_passthrough_v1 clip.duration_s=0.5 clip.window_policy=non_overlap",
+      "result": "PASS (sample_count=9, clip_count=18)"
+    },
+    {
+      "command": "pilot split audit",
+      "result": "PASS (no group_key leakage; n_flagella=1,2,3 each have 2 train, 2 val, and 2 test clips)"
     }
   ],
   "user_review_required": false,
@@ -40,7 +47,6 @@
   "push_status": "not_pushed",
   "pull_request_url": null,
   "next_actions": [
-    "User-run the Phase 2 dataset v1 pilot command and inspect the generated manifest, metadata JSONL, split summary, QC summary, and clips.",
     "Use the pilot output to evaluate #129 clip counts and grouped split sufficiency for 0.5 s non-overlap, then compare 0.25 s / 1.0 s variants.",
     "Keep real-video detection/tracking out of this PR and continue it after #8/#9 input and scale-normalization decisions."
   ]

--- a/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
+++ b/docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records stratified grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. The user-run v1 pilot generated 9 samples and 18 clips with each n_flagella class represented in train/val/test. Codex review feedback was addressed by making frame-end metadata inclusive and preserving config path, CLI overrides, max_per_class, and environment details in the manifest. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
+  "summary": "Implemented the first Phase 3 Issue #6 pseudo-GT passthrough pipeline. The new code reads Phase 2 dataset summaries and state_archive.npz files, filters the MVP baseline to n_flagella=1,2,3 with use_for_ml_candidate=True and baseline torque, renders lightweight uint8 .npy clips, writes #127-compatible metadata JSONL, records stratified grouped split summaries without group_key leakage, and emits QC summaries, manifest.json, and run.log. The user-run v1 pilots generated 27 clips at 0.25 s, 18 clips at 0.5 s, and 9 clips at 1.0 s, with each n_flagella class represented in train/val/test and no group_key leakage. Codex review feedback was addressed by making frame-end metadata inclusive and preserving config path, CLI overrides, max_per_class, and environment details in the manifest. Real-video detection/tracking remains intentionally out of scope for #8/#9.",
   "blocking_issues": [],
   "non_blocking_issues": [
     "The current renderer is a lightweight state_archive rasterizer for GT passthrough; pseudo-microscopy domain tuning and render variation remain under #17/#128.",
@@ -38,6 +38,18 @@
     {
       "command": "pilot metadata/provenance audit after Codex review fixes",
       "result": "PASS (clip.source_frame_end=12, clip.t_end_s=0.48 for 13 frames at 25 Hz; manifest records config_path, CLI overrides, environment, and max_per_class)"
+    },
+    {
+      "command": "uv run python scripts/03_phase3/build_clip_dataset.py config=conf/phase3/gt_passthrough_v1.yaml input_dataset=outputs/phase2_analysis/flagella_count_behavior/datasets/v1 output_dir=outputs/2026-07-24/phase3_compare_0p25/phase3_gt_passthrough_v1 clip.duration_s=0.25 clip.window_policy=non_overlap",
+      "result": "PASS (sample_count=9, clip_count=27, clip shape=(7, 96, 96), no group_key leakage)"
+    },
+    {
+      "command": "uv run python scripts/03_phase3/build_clip_dataset.py config=conf/phase3/gt_passthrough_v1.yaml input_dataset=outputs/phase2_analysis/flagella_count_behavior/datasets/v1 output_dir=outputs/2026-07-24/phase3_compare_1p0/phase3_gt_passthrough_v1 clip.duration_s=1.0 clip.window_policy=non_overlap",
+      "result": "PASS (sample_count=9, clip_count=9, clip shape=(25, 96, 96), no group_key leakage)"
+    },
+    {
+      "command": "comparison pilot split audit",
+      "result": "PASS (0.25 s has 3 train / 3 val / 3 test clips per n_flagella class; 1.0 s has 1 train / 1 val / 1 test clip per n_flagella class)"
     }
   ],
   "user_review_required": false,
@@ -51,7 +63,7 @@
   "push_status": "not_pushed",
   "pull_request_url": null,
   "next_actions": [
-    "Use the pilot output to evaluate #129 clip counts and grouped split sufficiency for 0.5 s non-overlap, then compare 0.25 s / 1.0 s variants.",
+    "Use the 0.25 s / 0.5 s / 1.0 s pilot outputs to evaluate #129 clip-count sufficiency and downstream Phase 4 readiness.",
     "Keep real-video detection/tracking out of this PR and continue it after #8/#9 input and scale-normalization decisions."
   ]
 }

--- a/docs/phase3/phase3_4_common_clip_pipeline_plan.md
+++ b/docs/phase3/phase3_4_common_clip_pipeline_plan.md
@@ -19,6 +19,22 @@ Phase 2 dataset v1
   -> grouped split summary / QC summary
 ```
 
+## Implemented First PR Scope
+
+最初の #6 実装PRでは，実動画経路を確定せず，Phase 2 pseudo GT passthrough のみを実装する。
+
+実装単位:
+
+- package: `src/flagella_estimation/phase3/`
+- CLI: `scripts/03_phase3/build_clip_dataset.py`
+- config: `conf/phase3/gt_passthrough_v1.yaml`
+- clip artifact: `clips/<clip_id>.npy`，`uint8` grayscale，shape `(T, H, W)`
+- default: `clip.duration_s=0.5`，`clip.window_policy=non_overlap`，`frame_rate_hz=25.0`
+- MVP filter: `n_flagella=1,2,3`，`use_for_ml_candidate=True`，baseline torque only
+- output metadata: `schemas/phase3_clip_metadata.schema.json` compatible JSONL
+
+この実装は `state_archive.npz` を軽量 rasterize するため，Phase 2 の重い simulation / render を再実行しない。Phase 2 dataset v1 全体への pilot 実行は手元の実データ出力を読むため，Codex は自動実行せずユーザー実行に渡す。
+
 ## Work Breakdown
 
 | step | scope | output | test boundary |
@@ -65,17 +81,15 @@ outputs/YYYY-MM-DD/HHMMSS/phase3_common_clip/
 
 ## Library Interfaces
 
-Initial module candidates under `src/flagella_estimation/phase3/`:
+Initial modules under `src/flagella_estimation/phase3/`:
 
-- `inventory.py`: read source descriptors and provenance.
-- `tracks.py`: normalize GT / detection track records into a common track object.
 - `windows.py`: generate frame windows from fps, source frame count, duration, and policy.
-- `crops.py`: compute crop windows and padding.
+- `render.py`: rasterize Phase 2 `SimulationState` frames into grayscale `.npy` clips.
 - `metadata.py`: build #127 metadata objects.
 - `splits.py`: grouped split helper by `track.group_key`.
-- `cli.py`: orchestration boundary for scripts.
+- `pipeline.py`: read Phase 2 dataset summary, apply MVP freeze filters, write clips / metadata / summaries / manifest.
 
-Implementation should keep real-video detection behind an adapter interface so that pseudo GT passthrough can land first.
+Future real-video detection should be added behind an adapter interface so that pseudo GT passthrough and detection / tracking both feed the same metadata builder.
 
 ## Real Video Boundary
 

--- a/docs/phase3/phase3_4_common_clip_pipeline_plan.md
+++ b/docs/phase3/phase3_4_common_clip_pipeline_plan.md
@@ -32,8 +32,9 @@ Phase 2 dataset v1
 - default: `clip.duration_s=0.5`，`clip.window_policy=non_overlap`，`frame_rate_hz=25.0`
 - MVP filter: `n_flagella=1,2,3`，`use_for_ml_candidate=True`，baseline torque only
 - output metadata: `schemas/phase3_clip_metadata.schema.json` compatible JSONL
+- split policy: `group_key` leakage を禁止し，MVP label (`n_flagella=1,2,3`) ごとに grouped split を割り当てる
 
-この実装は `state_archive.npz` を軽量 rasterize するため，Phase 2 の重い simulation / render を再実行しない。Phase 2 dataset v1 全体への pilot 実行は手元の実データ出力を読むため，Codex は自動実行せずユーザー実行に渡す。
+この実装は `state_archive.npz` を軽量 rasterize するため，Phase 2 の重い simulation / render を再実行しない。Phase 2 dataset v1 全体への pilot 実行は手元の実データ出力を読むため，ユーザー実行に渡す。
 
 ## Work Breakdown
 

--- a/docs/phase3/phase3_4_common_clip_pipeline_plan.md
+++ b/docs/phase3/phase3_4_common_clip_pipeline_plan.md
@@ -80,6 +80,8 @@ outputs/YYYY-MM-DD/HHMMSS/phase3_common_clip/
 
 `clip_metadata.jsonl` contains one #127-compatible metadata object per clip. `manifest.json` records config path, overrides, input paths, output paths, git commit, environment, and schema version when available.
 
+Frame end metadata follows the inclusive source-frame convention: for a 13-frame clip covering source frames `0..12`, `clip.source_frame_end=12` and `clip.t_end_s` is the timestamp of frame `12`.
+
 ## Library Interfaces
 
 Initial modules under `src/flagella_estimation/phase3/`:

--- a/docs/phase3/phase3_current.md
+++ b/docs/phase3/phase3_current.md
@@ -15,7 +15,7 @@ Phase 3 は common clip schema の固定を #127 / PR #142 で完了し，clip d
 - #127: closed / merged。実動画 detection 経路と擬似動画 GT passthrough 経路を，共通clip / metadata schemaへ収束させた。schema 正本は `docs/phase3/phase3_1_clip_metadata_schema.md`，機械可読schemaは `schemas/phase3_clip_metadata.schema.json`。
 - #129: 1 clip の時間長と必要な独立run数を決める。
 - #128: 学習datasetへ混ぜてよい条件変更を整理する。
-- #6: 共通clip生成pipelineの実装親Issue。
+- #6: 共通clip生成pipelineの実装親Issue。最初の実装PRでは Phase 2 擬似動画 GT passthrough の `.npy` clip / metadata / grouped split / QC 出力から着手する。
 
 MVP 固定方針（2026-07-23 のユーザー判断に基づく）:
 
@@ -56,9 +56,10 @@ dataset splitでは，同一 `run_id` / `source_video_id` / `track_id` 由来の
 
 ## Next Actions
 
-1. #129 の設計に従い，`0.5 s` non-overlap default と，`0.25 s` / `1.0 s` 比較条件の軽量 fixture を実装する。
-2. #128 の設計に従い，torque variation を MVP freeze check で除外し，小範囲 render augmentation と dataset version 規則を Phase 4 dataset freeze checklist へ接続する。
-3. #6 で擬似動画 GT passthrough から最小pipeline実装に入る。実動画 detection / tracking は #8 / #9 の入力条件整理後に本格化する。
+1. #6 の最小 GT passthrough pipeline を draft PR で検証し，`conf/phase3/gt_passthrough_v1.yaml` を使った v1 pilot をユーザー実行に渡す。
+2. #129 の設計に従い，pilot 出力から `0.5 s` non-overlap default と `0.25 s` / `1.0 s` 比較条件の clip 数・group 数を評価する。
+3. #128 の設計に従い，torque variation を MVP freeze check で除外し，小範囲 render augmentation と dataset version 規則を Phase 4 dataset freeze checklist へ接続する。
+4. 実動画 detection / tracking は #8 / #9 の入力条件整理後に本格化する。
 
 ## Key references
 

--- a/docs/phase3/phase3_issue_map.md
+++ b/docs/phase3/phase3_issue_map.md
@@ -32,7 +32,7 @@ Phase 3 / 4 MVP
 | 1 | #127 | closed; PR #142 merged | 実動画・擬似動画の共通 clip / metadata schema を固定する | `docs/phase3/phase3_1_clip_metadata_schema.md`, `schemas/phase3_clip_metadata.schema.json`, 最小 fixture |
 | 2 | #129 | in design | clip時間長と必要独立run数を評価する | `docs/phase3/phase3_2_clip_duration_run_count.md`，grouped split 評価計画，learning curve 実行案 |
 | 3 | #128 | in design | 学習datasetへ混ぜてよい条件変更を分類する | `docs/phase3/phase3_3_dataset_mixing_versioning.md`，augmentation / domain variation / dataset version規則 |
-| 4 | #6 | implementation prep | Phase 3 pipeline を実装する | `docs/phase3/phase3_4_common_clip_pipeline_plan.md`，GT passthrough / crop / metadata 出力 |
+| 4 | #6 | first implementation | Phase 3 pipeline を実装する | Phase 2 pseudo GT passthrough CLI，`.npy` clip，#127 metadata JSONL，grouped split / QC summaries |
 
 ## Supporting Issues
 
@@ -47,4 +47,4 @@ Phase 3 / 4 MVP
 
 ## Implementation Boundary
 
-#127 は schema と contract test までで完了した。重い動画生成，長時間 simulation，clip時間長の採用判断，training dataset への条件混在判断は #129 / #128 / #6 へ残す。
+#127 は schema と contract test までで完了した。#6 の最初の実装は Phase 2 pseudo GT passthrough に限定し，実動画 detection / tracking は #8 / #9 後に分離する。重い動画生成，長時間 simulation，clip時間長の最終評価，training dataset への条件混在判断は #129 / #128 / Phase 4 へ残す。

--- a/docs/phase3/phase3_tasks.md
+++ b/docs/phase3/phase3_tasks.md
@@ -67,3 +67,32 @@
   - `docs/phase3/phase3_2_clip_duration_run_count.md`
   - `docs/phase3/phase3_3_dataset_mixing_versioning.md`
   - `docs/phase3/phase3_4_common_clip_pipeline_plan.md`
+
+## Phase 3.3: common clip pipeline MVP
+
+### P3-3-001: Issue #6 Phase 2 pseudo GT passthrough の最小実装
+
+- status: complete
+- source issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/6`
+- branch: `feature/phase3-6-gt-passthrough`
+- goal: Phase 2 dataset v1 の擬似動画 GT を再検出せず，共通 clip / metadata schema へ変換する最小 pipeline を実装する。
+- result:
+  - `src/flagella_estimation/phase3/` に window generation，state archive rasterize，metadata builder，grouped split，pipeline orchestration を追加した。
+  - `scripts/03_phase3/build_clip_dataset.py` で `config=...` と `KEY=VALUE` override を受ける CLI を追加した。
+  - `conf/phase3/gt_passthrough_v1.yaml` に v1 pilot 用 default を追加した。
+  - MVP freeze として `n_flagella=1,2,3`，`use_for_ml_candidate=True`，baseline torque only を固定した。
+  - 出力は `run.log`，`manifest.json`，`clip_metadata.jsonl`，`split_summary.csv`，`qc_summary.csv`，`clips/<clip_id>.npy` とした。
+  - 実動画 detection / tracking は #8 / #9 後の別実装へ残した。
+- acceptance criteria:
+  - [x] `src/flagella_estimation/`のPhase 3 package構成がある。
+  - [x] 擬似動画のGround Truth passthroughを実装する。
+  - [x] 個体clipとmetadataを出力する。
+  - [x] 同一run / track由来データをgroup化できる。
+  - [x] library-level testを追加する。
+  - [ ] 実動画のdetection / trackingを実装する。
+  - [ ] 実動画・擬似動画を同じCLI / library境界から処理できる。
+- verification:
+  - `uv run pytest -q tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py`
+- docs:
+  - `docs/phase3/phase3_current.md`
+  - `docs/phase3/phase3_4_common_clip_pipeline_plan.md`

--- a/scripts/03_phase3/__init__.py
+++ b/scripts/03_phase3/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3 script namespace."""

--- a/scripts/03_phase3/build_clip_dataset.py
+++ b/scripts/03_phase3/build_clip_dataset.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Build Phase 3 common clips from Phase 2 pseudo-GT state archives."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from flagella_estimation.phase3.pipeline import build_clip_dataset, load_config
+
+
+def _split_config_key(argv: list[str]) -> tuple[Path | None, list[str]]:
+    rest: list[str] = []
+    config: Path | None = None
+    for item in argv:
+        if item.startswith("config="):
+            config = Path(item.split("=", 1)[1])
+        else:
+            rest.append(item)
+    return config, rest
+
+
+def main(argv: list[str] | None = None) -> None:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    config_from_key, parser_argv = _split_config_key(raw_argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("overrides", nargs="*", help="Optional KEY=VALUE overrides")
+    args = parser.parse_args(parser_argv)
+    if config_from_key is not None and args.config is not None:
+        parser.error("Use either config=PATH or --config PATH (not both)")
+    cfg = load_config(config_from_key or args.config, args.overrides)
+    output_dir = build_clip_dataset(cfg)
+    print(output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flagella_estimation/__init__.py
+++ b/src/flagella_estimation/__init__.py
@@ -1,0 +1,1 @@
+"""Flagella-count estimation package."""

--- a/src/flagella_estimation/phase3/__init__.py
+++ b/src/flagella_estimation/phase3/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3 common clip generation helpers."""

--- a/src/flagella_estimation/phase3/metadata.py
+++ b/src/flagella_estimation/phase3/metadata.py
@@ -40,7 +40,9 @@ def build_gt_passthrough_metadata(
 
     frame_count = window.frame_count
     t_start_s = window.start / frame_rate_hz
-    t_end_s = window.end / frame_rate_hz
+    inclusive_clip_end = window.end - 1
+    inclusive_track_end = source_frame_count - 1
+    t_end_s = inclusive_clip_end / frame_rate_hz
     frames = []
     for local_index, geometry in enumerate(frame_geometries):
         source_frame_index = window.start + local_index
@@ -94,9 +96,9 @@ def build_gt_passthrough_metadata(
             "group_key": group_key,
             "source_track_id": track_id,
             "source_frame_start": 0,
-            "source_frame_end": source_frame_count,
+            "source_frame_end": inclusive_track_end,
             "t_start_s": 0.0,
-            "t_end_s": source_duration_s,
+            "t_end_s": inclusive_track_end / frame_rate_hz,
         },
         "clip": {
             "clip_id": clip_id,
@@ -107,7 +109,7 @@ def build_gt_passthrough_metadata(
             "frame_rate_hz": frame_rate_hz,
             "duration_s": frame_count / frame_rate_hz,
             "source_frame_start": window.start,
-            "source_frame_end": window.end,
+            "source_frame_end": inclusive_clip_end,
             "t_start_s": t_start_s,
             "t_end_s": t_end_s,
         },

--- a/src/flagella_estimation/phase3/metadata.py
+++ b/src/flagella_estimation/phase3/metadata.py
@@ -1,0 +1,133 @@
+"""Metadata builders for Phase 3 common clip records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from flagella_estimation.phase3.render import FrameGeometry
+from flagella_estimation.phase3.windows import FrameWindow
+
+
+SCHEMA_VERSION = "phase3_clip_metadata/v0"
+PIPELINE_NAME = "phase3_gt_passthrough"
+PIPELINE_VERSION = "0.1.0"
+
+
+def build_gt_passthrough_metadata(
+    *,
+    dataset_id: str,
+    source_video_id: str,
+    source_path: Path,
+    frame_rate_hz: float,
+    source_frame_count: int,
+    source_duration_s: float,
+    run_id: str,
+    raw_run_dir: Path,
+    n_flagella: int,
+    track_id: str,
+    group_key: str,
+    clip_id: str,
+    clip_index: int,
+    window: FrameWindow,
+    window_policy: str,
+    output_path: Path,
+    crop_size_px: int,
+    pixel_size_um: float,
+    frame_geometries: list[FrameGeometry],
+) -> dict[str, Any]:
+    """Build a #127-compatible metadata object for one pseudo-GT clip."""
+
+    frame_count = window.frame_count
+    t_start_s = window.start / frame_rate_hz
+    t_end_s = window.end / frame_rate_hz
+    frames = []
+    for local_index, geometry in enumerate(frame_geometries):
+        source_frame_index = window.start + local_index
+        frames.append(
+            {
+                "frame_id": f"{source_video_id}:f{source_frame_index:06d}",
+                "clip_frame_index": local_index,
+                "source_frame_index": source_frame_index,
+                "t_s": source_frame_index / frame_rate_hz,
+                "bbox_xywh_px": list(geometry.bbox_xywh_px),
+                "crop_xywh_px": list(geometry.crop_xywh_px),
+                "center_xy_px": list(geometry.center_xy_px),
+                "body_axis_angle_rad": geometry.body_axis_angle_rad,
+                "body_length_px": geometry.body_length_px,
+                "body_width_px": geometry.body_width_px,
+                "detection_confidence": 1.0,
+                "qc_status": "pass",
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dataset_id": dataset_id,
+        "source_video": {
+            "source_video_id": source_video_id,
+            "source_kind": "phase2_pseudo",
+            "source_path": str(source_path),
+            "frame_rate_hz": frame_rate_hz,
+            "width_px": crop_size_px,
+            "height_px": crop_size_px,
+            "duration_s": source_duration_s,
+            "frame_count": source_frame_count,
+            "codec_fourcc": None,
+            "file_size_bytes": source_path.stat().st_size
+            if source_path.exists()
+            else None,
+        },
+        "processing_mode": "gt_passthrough",
+        "provenance": {
+            "pipeline_name": PIPELINE_NAME,
+            "pipeline_version": PIPELINE_VERSION,
+            "model_id": "phase2_flagella_count_behavior_v1",
+            "dataset_version": "v1",
+            "run_id": run_id,
+            "render_id": "state_archive_numpy_v1",
+            "condition_id": run_id,
+            "raw_run_dir": str(raw_run_dir),
+        },
+        "track": {
+            "track_id": track_id,
+            "group_key": group_key,
+            "source_track_id": track_id,
+            "source_frame_start": 0,
+            "source_frame_end": source_frame_count,
+            "t_start_s": 0.0,
+            "t_end_s": source_duration_s,
+        },
+        "clip": {
+            "clip_id": clip_id,
+            "clip_index": clip_index,
+            "window_policy": window_policy,
+            "output_path": str(output_path),
+            "frame_count": frame_count,
+            "frame_rate_hz": frame_rate_hz,
+            "duration_s": frame_count / frame_rate_hz,
+            "source_frame_start": window.start,
+            "source_frame_end": window.end,
+            "t_start_s": t_start_s,
+            "t_end_s": t_end_s,
+        },
+        "normalization": {
+            "crop_size_px": [crop_size_px, crop_size_px],
+            "centering_mode": "body_center",
+            "scale_mode": "fixed_um_per_px",
+            "rotation_mode": "none",
+            "pixel_size_um": pixel_size_um,
+        },
+        "frames": frames,
+        "labels": {
+            "n_flagella": n_flagella,
+            "label_source": "phase2_gt",
+        },
+        "qc": {
+            "status": "pass",
+            "exclusion_reason": None,
+            "detection_confidence_min": 1.0,
+            "tracking_gap_count": 0,
+            "notes": "pseudo GT passthrough from Phase 2 state archive",
+        },
+    }

--- a/src/flagella_estimation/phase3/pipeline.py
+++ b/src/flagella_estimation/phase3/pipeline.py
@@ -1,0 +1,346 @@
+"""Phase 3 pseudo-GT passthrough pipeline."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import yaml
+
+from flagella_estimation.phase3.metadata import (
+    SCHEMA_VERSION,
+    build_gt_passthrough_metadata,
+)
+from flagella_estimation.phase3.render import render_clip_array, select_frames
+from flagella_estimation.phase3.splits import (
+    assign_grouped_splits,
+    assert_no_group_leakage,
+)
+from flagella_estimation.phase3.windows import generate_windows
+from sim_swim.analysis.flagella_count_behavior import load_state_archive
+
+
+@dataclass(frozen=True)
+class Phase3Config:
+    dataset_id: str
+    input_dataset: Path
+    output_dir: Path
+    duration_s: float = 0.5
+    window_policy: str = "non_overlap"
+    overlap_stride_fraction: float = 0.5
+    frame_rate_hz: float = 25.0
+    crop_size_px: int = 96
+    pixel_size_um: float = 0.1
+    allowed_n_flagella: tuple[int, ...] = (1, 2, 3)
+    max_per_class: int | None = None
+    baseline_torque_Nm: float = 2.0e-20
+    require_use_for_ml_candidate: bool = True
+
+
+def _now_jst() -> datetime:
+    return datetime.now(ZoneInfo("Asia/Tokyo"))
+
+
+def default_output_dir() -> Path:
+    now = _now_jst()
+    return (
+        Path("outputs")
+        / now.strftime("%Y-%m-%d")
+        / now.strftime("%H%M%S")
+        / "phase3_gt_passthrough_v1"
+    )
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _to_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def _to_float(value: Any) -> float:
+    return float(str(value).strip())
+
+
+def _git_info() -> dict[str, Any]:
+    def run(cmd: list[str]) -> str:
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True).strip()
+
+    try:
+        return {
+            "commit": run(["git", "rev-parse", "HEAD"]),
+            "commit_short": run(["git", "rev-parse", "--short", "HEAD"]),
+            "branch": run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+            "is_clean": run(["git", "status", "--porcelain"]) == "",
+        }
+    except Exception:
+        return {
+            "commit": "unknown",
+            "commit_short": "unknown",
+            "branch": "unknown",
+            "is_clean": False,
+        }
+
+
+def load_config(path: Path | None, overrides: list[str] | None = None) -> Phase3Config:
+    raw: dict[str, Any] = {}
+    if path is not None:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    data = _apply_overrides(raw, overrides or [])
+    clip = dict(data.get("clip", {}) or {})
+    filters = dict(data.get("filters", {}) or {})
+    freeze = dict(data.get("freeze", {}) or {})
+    return Phase3Config(
+        dataset_id=str(data.get("dataset_id", "phase3_gt_passthrough_v1")),
+        input_dataset=Path(str(data.get("input_dataset", ""))),
+        output_dir=Path(str(data.get("output_dir") or default_output_dir())),
+        duration_s=float(clip.get("duration_s", 0.5)),
+        window_policy=str(clip.get("window_policy", "non_overlap")),
+        overlap_stride_fraction=float(clip.get("overlap_stride_fraction", 0.5)),
+        frame_rate_hz=float(clip.get("frame_rate_hz", 25.0)),
+        crop_size_px=int(clip.get("crop_size_px", 96)),
+        pixel_size_um=float(clip.get("pixel_size_um", 0.1)),
+        allowed_n_flagella=tuple(
+            int(v) for v in filters.get("allowed_n_flagella", [1, 2, 3])
+        ),
+        max_per_class=(
+            None
+            if filters.get("max_per_class") in (None, "")
+            else int(filters.get("max_per_class"))
+        ),
+        baseline_torque_Nm=float(freeze.get("baseline_torque_Nm", 2.0e-20)),
+        require_use_for_ml_candidate=bool(
+            filters.get("require_use_for_ml_candidate", True)
+        ),
+    )
+
+
+def _apply_overrides(raw: dict[str, Any], overrides: list[str]) -> dict[str, Any]:
+    data = dict(raw)
+    for item in overrides:
+        if "=" not in item:
+            raise ValueError(f"Invalid override; expected KEY=VALUE: {item}")
+        key, value = item.split("=", 1)
+        node = data
+        parts = key.split(".")
+        for part in parts[:-1]:
+            child = node.setdefault(part, {})
+            if not isinstance(child, dict):
+                raise ValueError(f"Override path conflict: {key}")
+            node = child
+        node[parts[-1]] = yaml.safe_load(value)
+    return data
+
+
+def validate_training_candidate(
+    row: dict[str, str], cfg: Phase3Config
+) -> tuple[bool, str | None]:
+    n_flagella = int(_to_float(row.get("n_flagella", "0")))
+    if n_flagella not in cfg.allowed_n_flagella:
+        return False, "n_flagella_not_in_mvp_scope"
+    if cfg.require_use_for_ml_candidate and not _to_bool(
+        row.get("use_for_ml_candidate")
+    ):
+        return False, "not_use_for_ml_candidate"
+    torque = _to_float(row.get("torque_Nm", "nan"))
+    if not np.isclose(torque, cfg.baseline_torque_Nm, rtol=1.0e-9, atol=0.0):
+        return False, "torque_variation_diagnostic_only"
+    return True, None
+
+
+def select_samples(
+    rows: list[dict[str, str]], cfg: Phase3Config
+) -> list[dict[str, str]]:
+    selected: list[dict[str, str]] = []
+    per_class: dict[int, int] = {}
+    for row in rows:
+        ok, _reason = validate_training_candidate(row, cfg)
+        if not ok:
+            continue
+        n_flagella = int(_to_float(row["n_flagella"]))
+        current_count = per_class.get(n_flagella, 0)
+        if cfg.max_per_class is not None and current_count >= cfg.max_per_class:
+            continue
+        selected.append(row)
+        per_class[n_flagella] = current_count + 1
+    return selected
+
+
+def build_clip_dataset(cfg: Phase3Config) -> Path:
+    summary_path = cfg.input_dataset / "summary.csv"
+    if not summary_path.is_file():
+        raise FileNotFoundError(f"summary.csv not found: {summary_path}")
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+    clips_dir = cfg.output_dir / "clips"
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    all_rows = _read_csv(summary_path)
+    selected_rows = select_samples(all_rows, cfg)
+    metadata_records: list[dict[str, Any]] = []
+    qc_rows: list[dict[str, Any]] = []
+    split_rows: list[dict[str, Any]] = []
+
+    group_keys = [f"phase2:v1:{row['sample_id']}" for row in selected_rows]
+    split_by_group = assign_grouped_splits(group_keys)
+
+    for row in selected_rows:
+        sample_id = str(row["sample_id"])
+        n_flagella = int(_to_float(row["n_flagella"]))
+        raw_run_dir = Path(str(row["raw_dir"]))
+        archive_path = raw_run_dir / "state_archive.npz"
+        if not archive_path.is_file():
+            qc_rows.append(
+                {
+                    "sample_id": sample_id,
+                    "n_flagella": n_flagella,
+                    "status": "fail",
+                    "exclusion_reason": "missing_state_archive",
+                    "clip_count": 0,
+                }
+            )
+            continue
+
+        states = select_frames(load_state_archive(archive_path), cfg.frame_rate_hz)
+        windows = generate_windows(
+            source_frame_count=len(states),
+            frame_rate_hz=cfg.frame_rate_hz,
+            duration_s=cfg.duration_s,
+            policy=cfg.window_policy,
+            overlap_stride_fraction=cfg.overlap_stride_fraction,
+        )
+        group_key = f"phase2:v1:{sample_id}"
+        source_duration_s = len(states) / cfg.frame_rate_hz
+        for clip_index, window in enumerate(windows):
+            clip_id = f"{sample_id}_c{clip_index:04d}"
+            output_path = clips_dir / f"{clip_id}.npy"
+            clip_array, geometries = render_clip_array(
+                states[window.start : window.end],
+                image_size_px=cfg.crop_size_px,
+                pixel_size_um=cfg.pixel_size_um,
+            )
+            np.save(output_path, clip_array)
+            metadata = build_gt_passthrough_metadata(
+                dataset_id=cfg.dataset_id,
+                source_video_id=sample_id,
+                source_path=archive_path,
+                frame_rate_hz=cfg.frame_rate_hz,
+                source_frame_count=len(states),
+                source_duration_s=source_duration_s,
+                run_id=sample_id,
+                raw_run_dir=raw_run_dir,
+                n_flagella=n_flagella,
+                track_id=f"{sample_id}:gt_track_0000",
+                group_key=group_key,
+                clip_id=clip_id,
+                clip_index=clip_index,
+                window=window,
+                window_policy=cfg.window_policy,
+                output_path=output_path,
+                crop_size_px=cfg.crop_size_px,
+                pixel_size_um=cfg.pixel_size_um,
+                frame_geometries=geometries,
+            )
+            metadata_records.append(metadata)
+            split_rows.append(
+                {
+                    "clip_id": clip_id,
+                    "sample_id": sample_id,
+                    "group_key": group_key,
+                    "split": split_by_group[group_key],
+                    "n_flagella": n_flagella,
+                }
+            )
+        qc_rows.append(
+            {
+                "sample_id": sample_id,
+                "n_flagella": n_flagella,
+                "status": "pass" if windows else "fail",
+                "exclusion_reason": None if windows else "no_complete_window",
+                "clip_count": len(windows),
+            }
+        )
+
+    assert_no_group_leakage(
+        {"group_key": str(row["group_key"]), "split": str(row["split"])}
+        for row in split_rows
+    )
+    metadata_path = cfg.output_dir / "clip_metadata.jsonl"
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        for record in metadata_records:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    _write_csv(
+        cfg.output_dir / "split_summary.csv",
+        split_rows,
+        ["clip_id", "sample_id", "group_key", "split", "n_flagella"],
+    )
+    _write_csv(
+        cfg.output_dir / "qc_summary.csv",
+        qc_rows,
+        ["sample_id", "n_flagella", "status", "exclusion_reason", "clip_count"],
+    )
+    manifest = {
+        "pipeline_name": "phase3_gt_passthrough",
+        "schema_version": SCHEMA_VERSION,
+        "created_at": _now_jst().isoformat(),
+        "dataset_id": cfg.dataset_id,
+        "input_dataset": str(cfg.input_dataset),
+        "output_dir": str(cfg.output_dir),
+        "clip": {
+            "duration_s": cfg.duration_s,
+            "window_policy": cfg.window_policy,
+            "overlap_stride_fraction": cfg.overlap_stride_fraction,
+            "frame_rate_hz": cfg.frame_rate_hz,
+            "crop_size_px": cfg.crop_size_px,
+            "pixel_size_um": cfg.pixel_size_um,
+        },
+        "filters": {
+            "allowed_n_flagella": list(cfg.allowed_n_flagella),
+            "require_use_for_ml_candidate": cfg.require_use_for_ml_candidate,
+            "baseline_torque_Nm": cfg.baseline_torque_Nm,
+        },
+        "outputs": {
+            "clip_metadata_jsonl": str(metadata_path),
+            "clips_dir": str(clips_dir),
+            "split_summary_csv": str(cfg.output_dir / "split_summary.csv"),
+            "qc_summary_csv": str(cfg.output_dir / "qc_summary.csv"),
+        },
+        "sample_count": len(selected_rows),
+        "clip_count": len(metadata_records),
+        "git": _git_info(),
+    }
+    (cfg.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (cfg.output_dir / "run.log").write_text(
+        "\n".join(
+            [
+                f"created_at={manifest['created_at']}",
+                f"input_dataset={cfg.input_dataset}",
+                f"output_dir={cfg.output_dir}",
+                f"sample_count={len(selected_rows)}",
+                f"clip_count={len(metadata_records)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return cfg.output_dir

--- a/src/flagella_estimation/phase3/pipeline.py
+++ b/src/flagella_estimation/phase3/pipeline.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 from pathlib import Path
+import platform
 import subprocess
+import sys
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -32,6 +34,8 @@ class Phase3Config:
     dataset_id: str
     input_dataset: Path
     output_dir: Path
+    config_path: Path | None = None
+    cli_overrides: tuple[str, ...] = ()
     duration_s: float = 0.5
     window_policy: str = "non_overlap"
     overlap_stride_fraction: float = 0.5
@@ -100,6 +104,14 @@ def _git_info() -> dict[str, Any]:
         }
 
 
+def _environment_info() -> dict[str, Any]:
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "numpy": np.__version__,
+    }
+
+
 def load_config(path: Path | None, overrides: list[str] | None = None) -> Phase3Config:
     raw: dict[str, Any] = {}
     if path is not None:
@@ -112,6 +124,8 @@ def load_config(path: Path | None, overrides: list[str] | None = None) -> Phase3
         dataset_id=str(data.get("dataset_id", "phase3_gt_passthrough_v1")),
         input_dataset=Path(str(data.get("input_dataset", ""))),
         output_dir=Path(str(data.get("output_dir") or default_output_dir())),
+        config_path=path,
+        cli_overrides=tuple(overrides or ()),
         duration_s=float(clip.get("duration_s", 0.5)),
         window_policy=str(clip.get("window_policy", "non_overlap")),
         overlap_stride_fraction=float(clip.get("overlap_stride_fraction", 0.5)),
@@ -321,6 +335,13 @@ def build_clip_dataset(cfg: Phase3Config) -> Path:
             "allowed_n_flagella": list(cfg.allowed_n_flagella),
             "require_use_for_ml_candidate": cfg.require_use_for_ml_candidate,
             "baseline_torque_Nm": cfg.baseline_torque_Nm,
+            "max_per_class": cfg.max_per_class,
+        },
+        "invocation": {
+            "config_path": str(cfg.config_path)
+            if cfg.config_path is not None
+            else None,
+            "cli_overrides": list(cfg.cli_overrides),
         },
         "outputs": {
             "clip_metadata_jsonl": str(metadata_path),
@@ -331,6 +352,7 @@ def build_clip_dataset(cfg: Phase3Config) -> Path:
         "sample_count": len(selected_rows),
         "clip_count": len(metadata_records),
         "git": _git_info(),
+        "environment": _environment_info(),
     }
     (cfg.output_dir / "manifest.json").write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2),

--- a/src/flagella_estimation/phase3/pipeline.py
+++ b/src/flagella_estimation/phase3/pipeline.py
@@ -198,8 +198,14 @@ def build_clip_dataset(cfg: Phase3Config) -> Path:
     qc_rows: list[dict[str, Any]] = []
     split_rows: list[dict[str, Any]] = []
 
-    group_keys = [f"phase2:v1:{row['sample_id']}" for row in selected_rows]
-    split_by_group = assign_grouped_splits(group_keys)
+    group_labels = {
+        f"phase2:v1:{row['sample_id']}": int(_to_float(row["n_flagella"]))
+        for row in selected_rows
+    }
+    split_by_group = assign_grouped_splits(
+        group_labels.keys(),
+        group_labels=group_labels,
+    )
 
     for row in selected_rows:
         sample_id = str(row["sample_id"])

--- a/src/flagella_estimation/phase3/render.py
+++ b/src/flagella_estimation/phase3/render.py
@@ -1,0 +1,122 @@
+"""Lightweight Phase 2 state archive to Phase 3 clip rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from sim_swim.sim.core import SimulationState
+
+
+@dataclass(frozen=True)
+class FrameGeometry:
+    bbox_xywh_px: tuple[float, float, float, float]
+    crop_xywh_px: tuple[float, float, float, float]
+    center_xy_px: tuple[float, float]
+    body_axis_angle_rad: float | None
+    body_length_px: float | None
+    body_width_px: float | None
+
+
+def select_frames(
+    states: list[SimulationState], frame_rate_hz: float
+) -> list[SimulationState]:
+    """Select approximately evenly-spaced output frames from raw simulation states."""
+
+    if not states:
+        return []
+    if frame_rate_hz <= 0.0:
+        raise ValueError("frame_rate_hz must be > 0")
+    interval_s = 1.0 / frame_rate_hz
+    selected: list[SimulationState] = []
+    next_t = float(states[0].t)
+    for state in states:
+        if float(state.t) + 1.0e-12 >= next_t:
+            selected.append(state)
+            next_t += interval_s
+    if selected and selected[-1] is not states[-1]:
+        selected.append(states[-1])
+    return selected
+
+
+def render_state_frame(
+    state: SimulationState,
+    *,
+    image_size_px: int,
+    pixel_size_um: float,
+) -> tuple[np.ndarray, FrameGeometry]:
+    """Render archived bead positions as a centered grayscale numpy frame."""
+
+    if image_size_px <= 0:
+        raise ValueError("image_size_px must be > 0")
+    if pixel_size_um <= 0.0:
+        raise ValueError("pixel_size_um must be > 0")
+
+    frame = np.full((image_size_px, image_size_px), 255, dtype=np.uint8)
+    beads = np.asarray(state.bead_positions_um, dtype=float)
+    if beads.size == 0:
+        center = (image_size_px / 2.0, image_size_px / 2.0)
+        geom = FrameGeometry(
+            bbox_xywh_px=(center[0], center[1], 0.0, 0.0),
+            crop_xywh_px=(0.0, 0.0, float(image_size_px), float(image_size_px)),
+            center_xy_px=center,
+            body_axis_angle_rad=None,
+            body_length_px=None,
+            body_width_px=None,
+        )
+        return frame, geom
+
+    xy_um = beads[:, :2]
+    center_um = np.asarray(state.position_um[:2], dtype=float)
+    xy_px = (xy_um - center_um) / pixel_size_um + image_size_px / 2.0
+    rounded = np.rint(xy_px).astype(int)
+    valid = (
+        (rounded[:, 0] >= 0)
+        & (rounded[:, 0] < image_size_px)
+        & (rounded[:, 1] >= 0)
+        & (rounded[:, 1] < image_size_px)
+    )
+    for x_px, y_px in rounded[valid]:
+        x0 = max(int(x_px) - 1, 0)
+        x1 = min(int(x_px) + 2, image_size_px)
+        y0 = max(int(y_px) - 1, 0)
+        y1 = min(int(y_px) + 2, image_size_px)
+        frame[y0:y1, x0:x1] = 60
+
+    min_xy = np.min(xy_px, axis=0)
+    max_xy = np.max(xy_px, axis=0)
+    bbox_w, bbox_h = np.maximum(max_xy - min_xy, 1.0)
+    center_xy = np.mean(xy_px, axis=0)
+    geom = FrameGeometry(
+        bbox_xywh_px=(float(min_xy[0]), float(min_xy[1]), float(bbox_w), float(bbox_h)),
+        crop_xywh_px=(0.0, 0.0, float(image_size_px), float(image_size_px)),
+        center_xy_px=(float(center_xy[0]), float(center_xy[1])),
+        body_axis_angle_rad=None,
+        body_length_px=float(max(bbox_w, bbox_h)),
+        body_width_px=float(min(bbox_w, bbox_h)),
+    )
+    return frame, geom
+
+
+def render_clip_array(
+    states: list[SimulationState],
+    *,
+    image_size_px: int,
+    pixel_size_um: float,
+) -> tuple[np.ndarray, list[FrameGeometry]]:
+    """Render a list of states into a uint8 `(T, H, W)` clip array."""
+
+    frames: list[np.ndarray] = []
+    geometries: list[FrameGeometry] = []
+    for state in states:
+        frame, geometry = render_state_frame(
+            state,
+            image_size_px=image_size_px,
+            pixel_size_um=pixel_size_um,
+        )
+        frames.append(frame)
+        geometries.append(geometry)
+    if not frames:
+        raise ValueError("Cannot render an empty clip")
+    return np.stack(frames, axis=0), geometries

--- a/src/flagella_estimation/phase3/splits.py
+++ b/src/flagella_estimation/phase3/splits.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 
@@ -15,6 +16,7 @@ class SplitAssignment:
 def assign_grouped_splits(
     group_keys: Iterable[str],
     *,
+    group_labels: Mapping[str, int] | None = None,
     train_fraction: float = 0.67,
     val_fraction: float = 0.22,
 ) -> dict[str, str]:
@@ -28,9 +30,47 @@ def assign_grouped_splits(
     if train_fraction + val_fraction > 1.0:
         raise ValueError("train_fraction + val_fraction must be <= 1")
 
+    if group_labels is not None:
+        missing = [group_key for group_key in groups if group_key not in group_labels]
+        if missing:
+            raise ValueError(f"group_labels missing group keys: {missing}")
+        by_label: dict[int, list[str]] = defaultdict(list)
+        for group_key in groups:
+            by_label[int(group_labels[group_key])].append(group_key)
+        assignments: dict[str, str] = {}
+        for label_groups in by_label.values():
+            assignments.update(
+                _assign_ordered_groups(
+                    sorted(label_groups),
+                    train_fraction=train_fraction,
+                    val_fraction=val_fraction,
+                )
+            )
+        return assignments
+
+    return _assign_ordered_groups(
+        groups,
+        train_fraction=train_fraction,
+        val_fraction=val_fraction,
+    )
+
+
+def _assign_ordered_groups(
+    groups: list[str],
+    *,
+    train_fraction: float,
+    val_fraction: float,
+) -> dict[str, str]:
+    """Assign already ordered groups to splits."""
+
     n_groups = len(groups)
-    train_count = min(n_groups, int(round(n_groups * train_fraction)))
-    val_count = min(n_groups - train_count, int(round(n_groups * val_fraction)))
+    train_count = min(n_groups, max(1, int(round(n_groups * train_fraction))))
+    remaining_after_train = n_groups - train_count
+    val_count = min(remaining_after_train, int(round(n_groups * val_fraction)))
+    if n_groups >= 3 and val_count == 0:
+        val_count = 1
+    if n_groups >= 3 and train_count + val_count == n_groups and train_count > 1:
+        train_count -= 1
     assignments: dict[str, str] = {}
     for index, group_key in enumerate(groups):
         if index < train_count:

--- a/src/flagella_estimation/phase3/splits.py
+++ b/src/flagella_estimation/phase3/splits.py
@@ -1,0 +1,57 @@
+"""Grouped split helpers for Phase 3 datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SplitAssignment:
+    group_key: str
+    split: str
+
+
+def assign_grouped_splits(
+    group_keys: Iterable[str],
+    *,
+    train_fraction: float = 0.67,
+    val_fraction: float = 0.22,
+) -> dict[str, str]:
+    """Assign each group key to exactly one split."""
+
+    groups = sorted(set(group_keys))
+    if not groups:
+        return {}
+    if train_fraction < 0.0 or val_fraction < 0.0:
+        raise ValueError("split fractions must be non-negative")
+    if train_fraction + val_fraction > 1.0:
+        raise ValueError("train_fraction + val_fraction must be <= 1")
+
+    n_groups = len(groups)
+    train_count = min(n_groups, int(round(n_groups * train_fraction)))
+    val_count = min(n_groups - train_count, int(round(n_groups * val_fraction)))
+    assignments: dict[str, str] = {}
+    for index, group_key in enumerate(groups):
+        if index < train_count:
+            split = "train"
+        elif index < train_count + val_count:
+            split = "val"
+        else:
+            split = "test"
+        assignments[group_key] = split
+    return assignments
+
+
+def assert_no_group_leakage(rows: Iterable[dict[str, str]]) -> None:
+    """Raise if the same group key appears in multiple splits."""
+
+    seen: dict[str, str] = {}
+    for row in rows:
+        group_key = str(row["group_key"])
+        split = str(row["split"])
+        previous = seen.setdefault(group_key, split)
+        if previous != split:
+            raise ValueError(
+                f"group_key leakage: {group_key} appears in {previous} and {split}"
+            )

--- a/src/flagella_estimation/phase3/windows.py
+++ b/src/flagella_estimation/phase3/windows.py
@@ -1,0 +1,64 @@
+"""Window generation for Phase 3 clip datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class FrameWindow:
+    """Inclusive/exclusive source frame window."""
+
+    start: int
+    end: int
+
+    @property
+    def frame_count(self) -> int:
+        return self.end - self.start
+
+
+def clip_frame_count(duration_s: float, frame_rate_hz: float) -> int:
+    """Return the required frame count for a duration at a frame rate."""
+
+    if duration_s <= 0.0:
+        raise ValueError("duration_s must be > 0")
+    if frame_rate_hz <= 0.0:
+        raise ValueError("frame_rate_hz must be > 0")
+    return max(1, int(math.ceil(duration_s * frame_rate_hz)))
+
+
+def generate_windows(
+    *,
+    source_frame_count: int,
+    frame_rate_hz: float,
+    duration_s: float,
+    policy: str = "non_overlap",
+    overlap_stride_fraction: float = 0.5,
+) -> list[FrameWindow]:
+    """Generate fixed-length frame windows.
+
+    Partial windows are intentionally dropped so that every clip has a stable
+    tensor shape.
+    """
+
+    if source_frame_count <= 0:
+        return []
+    frames_per_clip = clip_frame_count(duration_s, frame_rate_hz)
+    if frames_per_clip > source_frame_count:
+        return []
+    if policy == "full_run":
+        return [FrameWindow(0, source_frame_count)]
+    if policy == "non_overlap":
+        stride = frames_per_clip
+    elif policy == "overlap":
+        if not 0.0 < overlap_stride_fraction <= 1.0:
+            raise ValueError("overlap_stride_fraction must be in (0, 1]")
+        stride = max(1, int(round(frames_per_clip * overlap_stride_fraction)))
+    else:
+        raise ValueError(f"Unsupported window policy: {policy}")
+
+    return [
+        FrameWindow(start, start + frames_per_clip)
+        for start in range(0, source_frame_count - frames_per_clip + 1, stride)
+    ]

--- a/tests/test_phase3_gt_passthrough_pipeline.py
+++ b/tests/test_phase3_gt_passthrough_pipeline.py
@@ -14,7 +14,10 @@ from flagella_estimation.phase3.pipeline import (
     validate_training_candidate,
 )
 from flagella_estimation.phase3.render import render_clip_array
-from flagella_estimation.phase3.splits import assert_no_group_leakage
+from flagella_estimation.phase3.splits import (
+    assign_grouped_splits,
+    assert_no_group_leakage,
+)
 from flagella_estimation.phase3.windows import FrameWindow, generate_windows
 from sim_swim.analysis.flagella_count_behavior import save_state_archive
 from sim_swim.sim.core import SimulationState
@@ -91,6 +94,28 @@ def test_phase3_grouped_split_rejects_cross_split_group_key() -> None:
                 {"group_key": "phase2:v1:run-a", "split": "val"},
             ]
         )
+
+
+@pytest.mark.light
+def test_phase3_grouped_split_can_stratify_by_n_flagella() -> None:
+    group_labels = {
+        f"phase2:v1:nf{n_flagella:02d}_run{run_index}": n_flagella
+        for n_flagella in (1, 2, 3)
+        for run_index in range(3)
+    }
+
+    assignments = assign_grouped_splits(
+        group_labels.keys(),
+        group_labels=group_labels,
+    )
+
+    for n_flagella in (1, 2, 3):
+        label_splits = {
+            assignments[group_key]
+            for group_key, label in group_labels.items()
+            if label == n_flagella
+        }
+        assert label_splits == {"train", "val", "test"}
 
 
 @pytest.mark.light

--- a/tests/test_phase3_gt_passthrough_pipeline.py
+++ b/tests/test_phase3_gt_passthrough_pipeline.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flagella_estimation.phase3.metadata import build_gt_passthrough_metadata
+from flagella_estimation.phase3.pipeline import (
+    Phase3Config,
+    build_clip_dataset,
+    validate_training_candidate,
+)
+from flagella_estimation.phase3.render import render_clip_array
+from flagella_estimation.phase3.splits import assert_no_group_leakage
+from flagella_estimation.phase3.windows import FrameWindow, generate_windows
+from sim_swim.analysis.flagella_count_behavior import save_state_archive
+from sim_swim.sim.core import SimulationState
+
+
+def _state(index: int) -> SimulationState:
+    t_s = index / 25.0
+    x_um = index * 0.01
+    beads = np.asarray(
+        [
+            [x_um - 0.2, -0.05, 0.0],
+            [x_um, 0.0, 0.0],
+            [x_um + 0.2, 0.05, 0.0],
+        ],
+        dtype=float,
+    )
+    return SimulationState(
+        t=t_s,
+        position_um=(x_um, 0.0, 0.0),
+        quaternion=(0.0, 0.0, 0.0, 1.0),
+        velocity_um_s=(1.0, 0.0, 0.0),
+        omega_rad_s=(0.0, 0.0, 0.0),
+        bead_positions_um=beads,
+        flag_states=(),
+        reverse_flagella=(),
+    )
+
+
+@pytest.mark.light
+def test_phase3_window_generation_defaults_to_0p5s_non_overlap() -> None:
+    windows = generate_windows(
+        source_frame_count=26,
+        frame_rate_hz=25.0,
+        duration_s=0.5,
+        policy="non_overlap",
+    )
+
+    assert windows == [FrameWindow(0, 13), FrameWindow(13, 26)]
+
+
+@pytest.mark.light
+def test_phase3_window_generation_supports_0p25s_1p0s_and_overlap() -> None:
+    short = generate_windows(
+        source_frame_count=26,
+        frame_rate_hz=25.0,
+        duration_s=0.25,
+        policy="non_overlap",
+    )
+    long = generate_windows(
+        source_frame_count=26,
+        frame_rate_hz=25.0,
+        duration_s=1.0,
+        policy="non_overlap",
+    )
+    overlap = generate_windows(
+        source_frame_count=26,
+        frame_rate_hz=25.0,
+        duration_s=0.5,
+        policy="overlap",
+        overlap_stride_fraction=0.5,
+    )
+
+    assert [window.frame_count for window in short] == [7, 7, 7]
+    assert long == [FrameWindow(0, 25)]
+    assert overlap[:3] == [FrameWindow(0, 13), FrameWindow(6, 19), FrameWindow(12, 25)]
+
+
+@pytest.mark.light
+def test_phase3_grouped_split_rejects_cross_split_group_key() -> None:
+    with pytest.raises(ValueError, match="group_key leakage"):
+        assert_no_group_leakage(
+            [
+                {"group_key": "phase2:v1:run-a", "split": "train"},
+                {"group_key": "phase2:v1:run-a", "split": "val"},
+            ]
+        )
+
+
+@pytest.mark.light
+def test_phase3_gt_passthrough_metadata_matches_required_schema_fields(
+    tmp_path: Path,
+) -> None:
+    states = [_state(i) for i in range(13)]
+    clip_array, geometries = render_clip_array(
+        states,
+        image_size_px=32,
+        pixel_size_um=0.1,
+    )
+    clip_path = tmp_path / "clip.npy"
+    np.save(clip_path, clip_array)
+    source_path = tmp_path / "state_archive.npz"
+    source_path.write_bytes(b"fixture")
+
+    metadata = build_gt_passthrough_metadata(
+        dataset_id="phase3_fixture",
+        source_video_id="nf01_as000_ps000",
+        source_path=source_path,
+        frame_rate_hz=25.0,
+        source_frame_count=13,
+        source_duration_s=13 / 25.0,
+        run_id="nf01_as000_ps000",
+        raw_run_dir=tmp_path,
+        n_flagella=1,
+        track_id="nf01_as000_ps000:gt_track_0000",
+        group_key="phase2:v1:nf01_as000_ps000",
+        clip_id="nf01_as000_ps000_c0000",
+        clip_index=0,
+        window=FrameWindow(0, 13),
+        window_policy="non_overlap",
+        output_path=clip_path,
+        crop_size_px=32,
+        pixel_size_um=0.1,
+        frame_geometries=geometries,
+    )
+
+    assert metadata["schema_version"] == "phase3_clip_metadata/v0"
+    assert metadata["processing_mode"] == "gt_passthrough"
+    assert metadata["labels"] == {"n_flagella": 1, "label_source": "phase2_gt"}
+    assert metadata["provenance"]["run_id"] == "nf01_as000_ps000"
+    assert metadata["track"]["group_key"] == "phase2:v1:nf01_as000_ps000"
+    assert metadata["clip"]["frame_count"] == 13
+    assert len(metadata["frames"]) == 13
+
+
+@pytest.mark.light
+def test_phase3_training_freeze_rejects_torque_variation_for_mvp(
+    tmp_path: Path,
+) -> None:
+    cfg = Phase3Config(
+        dataset_id="phase3_fixture",
+        input_dataset=tmp_path,
+        output_dir=tmp_path / "out",
+    )
+    baseline = {
+        "n_flagella": "2",
+        "use_for_ml_candidate": "True",
+        "torque_Nm": "2e-20",
+    }
+    varied = dict(baseline)
+    varied["torque_Nm"] = "4e-20"
+    nf4 = dict(baseline)
+    nf4["n_flagella"] = "4"
+
+    assert validate_training_candidate(baseline, cfg) == (True, None)
+    assert validate_training_candidate(varied, cfg) == (
+        False,
+        "torque_variation_diagnostic_only",
+    )
+    assert validate_training_candidate(nf4, cfg) == (
+        False,
+        "n_flagella_not_in_mvp_scope",
+    )
+
+
+@pytest.mark.light
+def test_phase3_pipeline_writes_clips_manifest_and_summaries(tmp_path: Path) -> None:
+    input_dataset = tmp_path / "dataset"
+    raw_dir = tmp_path / "raw" / "nf01_as000_ps000"
+    raw_dir.mkdir(parents=True)
+    save_state_archive(raw_dir / "state_archive.npz", [_state(i) for i in range(26)])
+    input_dataset.mkdir()
+    with (input_dataset / "summary.csv").open(
+        "w", encoding="utf-8", newline=""
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "sample_id",
+                "n_flagella",
+                "torque_Nm",
+                "use_for_ml_candidate",
+                "raw_dir",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sample_id": "nf01_as000_ps000",
+                "n_flagella": "1",
+                "torque_Nm": "2e-20",
+                "use_for_ml_candidate": "True",
+                "raw_dir": str(raw_dir),
+            }
+        )
+
+    output_dir = tmp_path / "out"
+    cfg = Phase3Config(
+        dataset_id="phase3_fixture",
+        input_dataset=input_dataset,
+        output_dir=output_dir,
+        crop_size_px=32,
+    )
+    result_dir = build_clip_dataset(cfg)
+
+    assert result_dir == output_dir
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    metadata_lines = (
+        (output_dir / "clip_metadata.jsonl").read_text(encoding="utf-8").splitlines()
+    )
+    clip = np.load(output_dir / "clips" / "nf01_as000_ps000_c0000.npy")
+
+    assert manifest["schema_version"] == "phase3_clip_metadata/v0"
+    assert manifest["sample_count"] == 1
+    assert manifest["clip_count"] == 2
+    assert len(metadata_lines) == 2
+    assert clip.shape == (13, 32, 32)
+    assert clip.dtype == np.uint8
+    assert (output_dir / "run.log").is_file()
+    assert (output_dir / "split_summary.csv").is_file()
+    assert (output_dir / "qc_summary.csv").is_file()

--- a/tests/test_phase3_gt_passthrough_pipeline.py
+++ b/tests/test_phase3_gt_passthrough_pipeline.py
@@ -160,7 +160,11 @@ def test_phase3_gt_passthrough_metadata_matches_required_schema_fields(
     assert metadata["labels"] == {"n_flagella": 1, "label_source": "phase2_gt"}
     assert metadata["provenance"]["run_id"] == "nf01_as000_ps000"
     assert metadata["track"]["group_key"] == "phase2:v1:nf01_as000_ps000"
+    assert metadata["track"]["source_frame_end"] == 12
+    assert metadata["track"]["t_end_s"] == 12 / 25.0
     assert metadata["clip"]["frame_count"] == 13
+    assert metadata["clip"]["source_frame_end"] == 12
+    assert metadata["clip"]["t_end_s"] == 12 / 25.0
     assert len(metadata["frames"]) == 13
 
 
@@ -230,6 +234,8 @@ def test_phase3_pipeline_writes_clips_manifest_and_summaries(tmp_path: Path) -> 
         dataset_id="phase3_fixture",
         input_dataset=input_dataset,
         output_dir=output_dir,
+        config_path=Path("conf/phase3/fixture.yaml"),
+        cli_overrides=("clip.duration_s=0.5",),
         crop_size_px=32,
     )
     result_dir = build_clip_dataset(cfg)
@@ -242,6 +248,12 @@ def test_phase3_pipeline_writes_clips_manifest_and_summaries(tmp_path: Path) -> 
     clip = np.load(output_dir / "clips" / "nf01_as000_ps000_c0000.npy")
 
     assert manifest["schema_version"] == "phase3_clip_metadata/v0"
+    assert manifest["invocation"] == {
+        "config_path": "conf/phase3/fixture.yaml",
+        "cli_overrides": ["clip.duration_s=0.5"],
+    }
+    assert manifest["filters"]["max_per_class"] is None
+    assert "python" in manifest["environment"]
     assert manifest["sample_count"] == 1
     assert manifest["clip_count"] == 2
     assert len(metadata_lines) == 2


### PR DESCRIPTION
## Summary
- Refs #6
- Add the first Phase 3 pseudo-GT passthrough pipeline under src/flagella_estimation/phase3.
- Add a CLI/config to convert Phase 2 state_archive.npz samples into uint8 .npy clips plus #127-compatible metadata JSONL, grouped split summary, QC summary, manifest, and run.log.
- Keep real-video detection/tracking out of scope for #8/#9.

## Checks
- git diff --check
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest -q tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py
- uv run pytest -q
- pre-commit: ruff format/check and uv run pytest -q -m light
- GitHub CI: pass
- codex-review-gate: pass

## Pilot outputs
- 0.25 s: outputs/2026-07-24/phase3_compare_0p25/phase3_gt_passthrough_v1, sample_count=9, clip_count=27, clip shape=(7, 96, 96), no group_key leakage, each n_flagella class has 3 train / 3 val / 3 test clips.
- 0.5 s: outputs/2026-07-24/001500/phase3_gt_passthrough_v1, sample_count=9, clip_count=18, clip shape=(13, 96, 96), no group_key leakage, each n_flagella class has 2 train / 2 val / 2 test clips.
- 1.0 s: outputs/2026-07-24/phase3_compare_1p0/phase3_gt_passthrough_v1, sample_count=9, clip_count=9, clip shape=(25, 96, 96), no group_key leakage, each n_flagella class has 1 train / 1 val / 1 test clip.

## Notes
- review_result: docs/codex-runs/20260724_001249_phase3_0006_gt_passthrough/review_result.json
- User visual review is not required for this implementation PR.
- This PR is a first implementation slice of #6 and does not complete the long-running parent issue.