### PR TITLE
feat(phase4): add common clip dataset loader smoke test

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,7 +47,7 @@ Project MVP
 
 | PR | State | Purpose | Next |
 | ---: | --- | --- | --- |
-| - | - | 現時点で roadmap 上に固定して追跡する active PR はない | #129 / #128 の設計を固め，#6 の最小 GT passthrough pipeline へ進める |
+| - | - | 現時点で roadmap 上に固定して追跡する active PR はない | #146 の Phase 4 loader smoke test から進める |
 
 ## Issue Hierarchy
 
@@ -96,15 +96,17 @@ Current baseline:
 | #127 | closed | #6 | 実動画・擬似動画の共通clip / metadata schema。PR #142 merged |
 | #128 | open | Phase 2→4 context | 学習datasetへ混ぜてよい条件変更 |
 | #129 | open | Phase 3→4 context | 1 clip時間長と必要な独立run数 |
+| #146 | open | #133 | Phase 3 common clip dataset loader smoke test |
+| #145 | open | #133 | RUN-TUMBLE dataset v2。Project Status TODO / 後回し |
 
 Recommended order:
 
-1. #129: clip時間長と独立run数を評価する。
-2. #126 の初期2D投影特徴量解析を受け，frame由来特徴量の確認を #129 に接続する。
-3. #128: augmentation / domain variation / dataset version規則を固定する。
-4. #6: Phase 3 clip pipeline を実装する。
+1. #146: Phase 4 loader smoke test で Phase 3 output を再検出なしに読めることを確認する。
+2. Phase 4 baseline classifier の小Issueを #133 配下に作成する。
+3. #129: grouped learning curve で必要独立run数を評価する。
+4. #128: augmentation / domain variation / dataset version規則を Phase 4 freeze gate へ接続する。
 
-#127 の common clip / metadata schema は `docs/phase3/phase3_1_clip_metadata_schema.md` と `schemas/phase3_clip_metadata.schema.json` に固定し，PR #142 で merge 済み。次は #129 / #128 の設計と #6 の最小 GT passthrough pipeline 実装準備を進める。
+#127 の common clip / metadata schema は `docs/phase3/phase3_1_clip_metadata_schema.md` と `schemas/phase3_clip_metadata.schema.json` に固定し，PR #142 で merge 済み。#6 の最小 GT passthrough pipeline は PR #144 で merge 済み。次は #146 で Phase 4 loader smoke test を進める。
 
 ### Phase 2 Physics Extensions
 
@@ -187,6 +189,6 @@ helical shape が保たれているか
 
 ## Next Three Actions
 
-1. #129 の `docs/phase3/phase3_2_clip_duration_run_count.md` に沿って，`0.5 s` default と `0.25 s` / `1.0 s` 比較用の軽量 window / grouped split fixture を実装する。
-2. #128 の `docs/phase3/phase3_3_dataset_mixing_versioning.md` に沿って，torque variation 除外，軽い render augmentation，Phase 4 dataset freeze checklist と provenance audit を実装へ接続する。
-3. #6 の `docs/phase3/phase3_4_common_clip_pipeline_plan.md` に沿って，#127 schema 対応の最小 GT passthrough pipeline 実装へ進む。
+1. #146 の Phase 4 loader smoke test を実装し，`.npy` clip / `clip_metadata.jsonl` / `split_summary.csv` の contract を loader 側で検査する。
+2. Phase 4 baseline classifier の小Issueを #133 配下に作成し，training loop / metrics / artifacts を最小実装する。
+3. #129 の grouped learning curve へ接続し，`n_flagella` ごとの必要独立run数を評価する。

--- a/docs/codex-runs/20260724_101232_phase4_0146_loader_smoke/review_result.json
+++ b/docs/codex-runs/20260724_101232_phase4_0146_loader_smoke/review_result.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "summary": "Implemented the Phase 4 Issue #146 dataset loader smoke test. The new Phase 4 loader reads Phase 3 common clip datasets without running training, checks manifest/metadata/split consistency, loads uint8 .npy clips, verifies clip frame count and crop shape, validates labels and splits, and audits group_key leakage. Phase 4 docs now record the loader contract and the next step toward a baseline classifier.",
+  "summary": "Implemented the Phase 4 Issue #146 dataset loader smoke test. The new Phase 4 loader reads Phase 3 common clip datasets without running training, checks manifest/metadata/split consistency, requires metadata and split_summary clip_id sets to match exactly, loads uint8 .npy clips, verifies clip frame count and crop shape, validates labels and splits, and audits group_key leakage. Phase 4 docs now record the loader contract and the next step toward a baseline classifier.",
   "blocking_issues": [],
   "non_blocking_issues": [
     "Baseline classifier, training metrics, artifacts, and grouped learning curves are intentionally left for follow-up issues under #133.",
@@ -21,11 +21,15 @@
     },
     {
       "command": "uv run pytest -q tests/test_phase4_clip_dataset_loader.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py",
-      "result": "PASS (16 passed)"
+      "result": "PASS (17 passed)"
     },
     {
       "command": "uv run pytest -q",
-      "result": "PASS (398 passed)"
+      "result": "PASS (399 passed)"
+    },
+    {
+      "command": "Codex review feedback",
+      "result": "PASS (added exact metadata/split_summary clip_id set matching and regression test)"
     }
   ],
   "user_review_required": false,

--- a/docs/codex-runs/20260724_101232_phase4_0146_loader_smoke/review_result.json
+++ b/docs/codex-runs/20260724_101232_phase4_0146_loader_smoke/review_result.json
@@ -1,0 +1,46 @@
+{
+  "status": "PASS",
+  "summary": "Implemented the Phase 4 Issue #146 dataset loader smoke test. The new Phase 4 loader reads Phase 3 common clip datasets without running training, checks manifest/metadata/split consistency, loads uint8 .npy clips, verifies clip frame count and crop shape, validates labels and splits, and audits group_key leakage. Phase 4 docs now record the loader contract and the next step toward a baseline classifier.",
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "Baseline classifier, training metrics, artifacts, and grouped learning curves are intentionally left for follow-up issues under #133.",
+    "The loader currently validates the Phase 3 contract with library-level fixtures; large real/pilot output adoption remains a separate decision."
+  ],
+  "tests_reviewed": [
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest -q tests/test_phase4_clip_dataset_loader.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py",
+      "result": "PASS (16 passed)"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS (398 passed)"
+    }
+  ],
+  "user_review_required": false,
+  "user_review_command": null,
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "This is a small Phase 4 loader and smoke-test implementation following the accepted Phase 3 common clip output contract. It does not add dependencies, change the physical model, change the accepted schema, or start model training.",
+  "commit_type": "complete",
+  "commit_hash": null,
+  "push_status": "not_pushed",
+  "pull_request_url": null,
+  "next_actions": [
+    "Create the next Phase 4 baseline classifier issue under #133 after this loader smoke test is reviewed.",
+    "Use baseline classifier results to feed #129 grouped learning curve and independent-run-count evaluation.",
+    "Keep RUN-TUMBLE dataset v2 in #145 as TODO / deferred."
+  ]
+}

--- a/docs/phase4/phase4_current.md
+++ b/docs/phase4/phase4_current.md
@@ -1,0 +1,51 @@
+# Phase 4 Current
+
+このファイルは，Phase 4 作業の入口として読む短い現在地ドキュメントである。
+
+## Goal
+
+Phase 4 の目的は，Phase 3 common clip dataset を読み込み，べん毛数 `n_flagella` の学習・評価へ進むことである。
+
+## Current Status
+
+Phase 3 / 4 MVP の標準 clip duration は `0.5 s` に固定する。必要独立run数は，Phase 4 の loader / baseline classifier / grouped learning curve からの feedback を使って #129 で判断する。
+
+現在の主対象:
+
+- #146: Phase 3 common clip dataset loader smoke test。Phase 4 が `.npy` clip と `clip_metadata.jsonl` を再検出なしに読めることを確認する。
+- #128: 学習datasetへ混ぜてよい条件変更を整理する。
+- #129: 1 clip の時間長と必要な独立run数を決める。`0.5 s` default は決定済みで，必要run数評価は Phase 4 feedback 待ち。
+- #145: RUN-TUMBLE を含む dataset v2。Project Status は `TODO` だが，Phase 3 / 4 MVP 後に後回し。
+
+## Input Contract
+
+Phase 4 loader の最小入力:
+
+- `manifest.json`
+- `clip_metadata.jsonl`
+- `split_summary.csv`
+- `qc_summary.csv`
+- `clips/<clip_id>.npy`
+
+Loader は training を開始しない。最初に確認する contract は次の通り:
+
+- `.npy` clip は `uint8`，shape `(T, H, W)`。
+- `clip.frame_count` と `.npy` の `T` が一致する。
+- `normalization.crop_size_px` と `.npy` の `(H, W)` が一致する。
+- `labels.n_flagella` と `split_summary.csv` の class label が一致する。
+- `track.group_key` が train / val / test をまたがない。
+
+## Next Actions
+
+1. #146 loader smoke test を merge する。
+2. Phase 4 baseline classifier の小Issueを #133 配下に作成し，training loop / metrics / artifacts を最小実装する。
+3. grouped learning curve を #129 に接続し，`n_flagella` ごとの必要独立run数を判断する。
+4. #128 の freeze checklist を Phase 4 dataset build 前の gate として接続する。
+
+## Key References
+
+- Phase 4 roadmap issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/133`
+- Loader smoke test issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/146`
+- Phase 3 metadata schema: `schemas/phase3_clip_metadata.schema.json`
+- Phase 3 GT passthrough pipeline: `src/flagella_estimation/phase3/`
+

--- a/docs/phase4/phase4_tasks.md
+++ b/docs/phase4/phase4_tasks.md
@@ -1,0 +1,29 @@
+# Phase 4 Tasks
+
+このファイルは Phase 4 の採択済みタスクを管理する。
+
+チェックボックスは review PASS 後にのみ更新する。
+
+## Phase 4.1: dataset loading contract
+
+### P4-1-001: Issue #146 Phase 3 common clip dataset loader smoke test
+
+- status: complete
+- source issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/146`
+- branch: `feature/phase4-146-clip-loader-smoke`
+- goal: Phase 3 common clip dataset (`.npy` clips + `clip_metadata.jsonl`) を Phase 4 が再検出なしに読めることを，学習前の smoke test として確認する。
+- result:
+  - `src/flagella_estimation/phase4/dataset.py` に Phase 3 common clip dataset loader と audit helper を追加した。
+  - loader は `manifest.json`，`clip_metadata.jsonl`，`split_summary.csv`，`.npy` clip を読み，label / split / `group_key` / shape / dtype の contract を検査する。
+  - `group_key` leakage，clip frame count mismatch，crop shape mismatch を loader 側で検出できるようにした。
+  - training loop / baseline classifier は次Issueへ残した。
+- acceptance criteria:
+  - [x] Phase 4 が Phase 3 output を再検出なしに読み込める。
+  - [x] loader-level test が PASS する。
+  - [x] split leakage と label/class count の基本監査が PASS する。
+  - [x] baseline classifier へ進むための入力 contract が文書化されている。
+- verification:
+  - `uv run pytest -q tests/test_phase4_clip_dataset_loader.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py`
+- docs:
+  - `docs/phase4/phase4_current.md`
+  - `docs/phase4/phase4_tasks.md`

--- a/src/flagella_estimation/phase4/__init__.py
+++ b/src/flagella_estimation/phase4/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4 dataset loading and evaluation helpers."""

--- a/src/flagella_estimation/phase4/dataset.py
+++ b/src/flagella_estimation/phase4/dataset.py
@@ -53,6 +53,19 @@ def load_phase3_common_clip_dataset(dataset_dir: Path) -> list[Phase4ClipSample]
     if len(split_by_clip_id) != len(split_rows):
         raise ValueError("split_summary.csv contains duplicate clip_id values")
 
+    metadata_clip_ids = {
+        str(_required_mapping(record, "clip")["clip_id"]) for record in records
+    }
+    split_clip_ids = set(split_by_clip_id)
+    if metadata_clip_ids != split_clip_ids:
+        missing_from_split = sorted(metadata_clip_ids - split_clip_ids)
+        missing_from_metadata = sorted(split_clip_ids - metadata_clip_ids)
+        raise ValueError(
+            "metadata and split_summary clip_id sets differ: "
+            f"missing_from_split={missing_from_split}, "
+            f"missing_from_metadata={missing_from_metadata}"
+        )
+
     samples: list[Phase4ClipSample] = []
     seen_clip_ids: set[str] = set()
     for record in records:

--- a/src/flagella_estimation/phase4/dataset.py
+++ b/src/flagella_estimation/phase4/dataset.py
@@ -1,0 +1,187 @@
+"""Phase 4 loader for Phase 3 common clip datasets."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+VALID_SPLITS = {"train", "val", "test"}
+
+
+@dataclass(frozen=True)
+class Phase4ClipSample:
+    clip_id: str
+    clip_path: Path
+    split: str
+    n_flagella: int
+    group_key: str
+    frame_count: int
+    frame_shape: tuple[int, int]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Phase4DatasetAudit:
+    dataset_dir: Path
+    sample_count: int
+    split_counts: dict[str, int]
+    class_counts: dict[int, int]
+    split_class_counts: dict[tuple[str, int], int]
+    group_count: int
+
+
+def load_phase3_common_clip_dataset(dataset_dir: Path) -> list[Phase4ClipSample]:
+    """Load Phase 3 common clip records without starting model training."""
+
+    dataset_dir = Path(dataset_dir)
+    manifest = _load_json(dataset_dir / "manifest.json")
+    records = _load_metadata_jsonl(dataset_dir / "clip_metadata.jsonl")
+    split_rows = _load_split_summary(dataset_dir / "split_summary.csv")
+    split_by_clip_id = {row["clip_id"]: row for row in split_rows}
+
+    expected_clip_count = int(manifest.get("clip_count", len(records)))
+    if expected_clip_count != len(records):
+        raise ValueError(
+            f"manifest clip_count={expected_clip_count} but metadata has {len(records)}"
+        )
+    if len(split_by_clip_id) != len(split_rows):
+        raise ValueError("split_summary.csv contains duplicate clip_id values")
+
+    samples: list[Phase4ClipSample] = []
+    seen_clip_ids: set[str] = set()
+    for record in records:
+        clip = _required_mapping(record, "clip")
+        labels = _required_mapping(record, "labels")
+        track = _required_mapping(record, "track")
+        normalization = _required_mapping(record, "normalization")
+
+        clip_id = str(clip["clip_id"])
+        if clip_id in seen_clip_ids:
+            raise ValueError(f"duplicate clip_id in metadata: {clip_id}")
+        seen_clip_ids.add(clip_id)
+        if clip_id not in split_by_clip_id:
+            raise ValueError(f"clip_id missing from split_summary.csv: {clip_id}")
+
+        split_row = split_by_clip_id[clip_id]
+        split = str(split_row["split"])
+        if split not in VALID_SPLITS:
+            raise ValueError(f"unsupported split for {clip_id}: {split}")
+
+        group_key = str(track["group_key"])
+        if str(split_row["group_key"]) != group_key:
+            raise ValueError(f"group_key mismatch for {clip_id}")
+
+        n_flagella = int(labels["n_flagella"])
+        if int(split_row["n_flagella"]) != n_flagella:
+            raise ValueError(f"n_flagella mismatch for {clip_id}")
+
+        clip_path = _resolve_clip_path(dataset_dir, str(clip["output_path"]))
+        arr = np.load(clip_path)
+        if arr.dtype != np.uint8:
+            raise ValueError(f"{clip_id} dtype must be uint8, got {arr.dtype}")
+        if arr.ndim != 3:
+            raise ValueError(f"{clip_id} must have shape (T, H, W), got {arr.shape}")
+
+        frame_count = int(clip["frame_count"])
+        if arr.shape[0] != frame_count:
+            raise ValueError(
+                f"{clip_id} frame_count mismatch: metadata={frame_count}, array={arr.shape[0]}"
+            )
+        crop_size = normalization.get("crop_size_px")
+        if crop_size is not None and list(arr.shape[1:]) != list(crop_size):
+            raise ValueError(
+                f"{clip_id} crop_size_px mismatch: {crop_size} vs {arr.shape[1:]}"
+            )
+        if len(record.get("frames", [])) != frame_count:
+            raise ValueError(f"{clip_id} frames metadata length mismatch")
+
+        samples.append(
+            Phase4ClipSample(
+                clip_id=clip_id,
+                clip_path=clip_path,
+                split=split,
+                n_flagella=n_flagella,
+                group_key=group_key,
+                frame_count=frame_count,
+                frame_shape=(int(arr.shape[1]), int(arr.shape[2])),
+                metadata=record,
+            )
+        )
+
+    return samples
+
+
+def audit_phase4_clip_dataset(samples: list[Phase4ClipSample]) -> Phase4DatasetAudit:
+    """Return counts and raise if group_key leakage is detected."""
+
+    split_by_group: dict[str, str] = {}
+    split_counts: dict[str, int] = {}
+    class_counts: dict[int, int] = {}
+    split_class_counts: dict[tuple[str, int], int] = {}
+    dataset_dir = samples[0].clip_path.parents[1] if samples else Path(".")
+
+    for sample in samples:
+        previous_split = split_by_group.setdefault(sample.group_key, sample.split)
+        if previous_split != sample.split:
+            raise ValueError(
+                f"group_key leakage: {sample.group_key} appears in "
+                f"{previous_split} and {sample.split}"
+            )
+        split_counts[sample.split] = split_counts.get(sample.split, 0) + 1
+        class_counts[sample.n_flagella] = class_counts.get(sample.n_flagella, 0) + 1
+        key = (sample.split, sample.n_flagella)
+        split_class_counts[key] = split_class_counts.get(key, 0) + 1
+
+    return Phase4DatasetAudit(
+        dataset_dir=dataset_dir,
+        sample_count=len(samples),
+        split_counts=split_counts,
+        class_counts=class_counts,
+        split_class_counts=split_class_counts,
+        group_count=len(split_by_group),
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_metadata_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            records.append(json.loads(line))
+    return records
+
+
+def _load_split_summary(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _required_mapping(record: dict[str, Any], key: str) -> dict[str, Any]:
+    value = record.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"metadata field must be an object: {key}")
+    return value
+
+
+def _resolve_clip_path(dataset_dir: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    candidates = [path] if path.is_absolute() else [path, dataset_dir / path]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(raw_path)

--- a/tests/test_phase4_clip_dataset_loader.py
+++ b/tests/test_phase4_clip_dataset_loader.py
@@ -156,6 +156,47 @@ def test_phase4_loader_rejects_group_key_leakage(tmp_path: Path) -> None:
 
 
 @pytest.mark.light
+def test_phase4_loader_rejects_split_rows_without_metadata(tmp_path: Path) -> None:
+    input_dataset = tmp_path / "phase2_dataset"
+    raw_dir = tmp_path / "raw" / "nf01_run0"
+    raw_dir.mkdir(parents=True)
+    save_state_archive(raw_dir / "state_archive.npz", [_state(i) for i in range(26)])
+    _write_phase2_summary(
+        input_dataset,
+        [
+            {
+                "sample_id": "nf01_run0",
+                "n_flagella": "1",
+                "torque_Nm": "2e-20",
+                "use_for_ml_candidate": "True",
+                "raw_dir": str(raw_dir),
+            }
+        ],
+    )
+    dataset_dir = build_clip_dataset(
+        Phase3Config(
+            dataset_id="phase4_loader_fixture",
+            input_dataset=input_dataset,
+            output_dir=tmp_path / "phase3_clips",
+            crop_size_px=32,
+        )
+    )
+
+    split_path = dataset_dir / "split_summary.csv"
+    rows = list(csv.DictReader(split_path.open("r", encoding="utf-8", newline="")))
+    extra = dict(rows[0])
+    extra["clip_id"] = "missing_metadata_clip"
+    rows.append(extra)
+    with split_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    with pytest.raises(ValueError, match="missing_from_metadata"):
+        load_phase3_common_clip_dataset(dataset_dir)
+
+
+@pytest.mark.light
 def test_phase4_loader_rejects_clip_shape_mismatch(tmp_path: Path) -> None:
     input_dataset = tmp_path / "phase2_dataset"
     raw_dir = tmp_path / "raw" / "nf01_run0"

--- a/tests/test_phase4_clip_dataset_loader.py
+++ b/tests/test_phase4_clip_dataset_loader.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flagella_estimation.phase3.pipeline import Phase3Config, build_clip_dataset
+from flagella_estimation.phase4.dataset import (
+    audit_phase4_clip_dataset,
+    load_phase3_common_clip_dataset,
+)
+from sim_swim.analysis.flagella_count_behavior import save_state_archive
+from sim_swim.sim.core import SimulationState
+
+
+def _state(index: int) -> SimulationState:
+    t_s = index / 25.0
+    x_um = index * 0.01
+    beads = np.asarray(
+        [
+            [x_um - 0.2, -0.05, 0.0],
+            [x_um, 0.0, 0.0],
+            [x_um + 0.2, 0.05, 0.0],
+        ],
+        dtype=float,
+    )
+    return SimulationState(
+        t=t_s,
+        position_um=(x_um, 0.0, 0.0),
+        quaternion=(0.0, 0.0, 0.0, 1.0),
+        velocity_um_s=(1.0, 0.0, 0.0),
+        omega_rad_s=(0.0, 0.0, 0.0),
+        bead_positions_um=beads,
+        flag_states=(),
+        reverse_flagella=(),
+    )
+
+
+def _write_phase2_summary(input_dataset: Path, rows: list[dict[str, str]]) -> None:
+    input_dataset.mkdir(parents=True)
+    with (input_dataset / "summary.csv").open(
+        "w", encoding="utf-8", newline=""
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "sample_id",
+                "n_flagella",
+                "torque_Nm",
+                "use_for_ml_candidate",
+                "raw_dir",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+@pytest.mark.light
+def test_phase4_loader_reads_phase3_common_clip_dataset(tmp_path: Path) -> None:
+    input_dataset = tmp_path / "phase2_dataset"
+    phase2_rows: list[dict[str, str]] = []
+    for n_flagella in (1, 2, 3):
+        for run_index in range(3):
+            sample_id = f"nf{n_flagella:02d}_run{run_index}"
+            raw_dir = tmp_path / "raw" / sample_id
+            raw_dir.mkdir(parents=True)
+            save_state_archive(
+                raw_dir / "state_archive.npz", [_state(i) for i in range(26)]
+            )
+            phase2_rows.append(
+                {
+                    "sample_id": sample_id,
+                    "n_flagella": str(n_flagella),
+                    "torque_Nm": "2e-20",
+                    "use_for_ml_candidate": "True",
+                    "raw_dir": str(raw_dir),
+                }
+            )
+    _write_phase2_summary(input_dataset, phase2_rows)
+
+    dataset_dir = build_clip_dataset(
+        Phase3Config(
+            dataset_id="phase4_loader_fixture",
+            input_dataset=input_dataset,
+            output_dir=tmp_path / "phase3_clips",
+            crop_size_px=32,
+            max_per_class=3,
+        )
+    )
+
+    samples = load_phase3_common_clip_dataset(dataset_dir)
+    audit = audit_phase4_clip_dataset(samples)
+
+    assert len(samples) == 18
+    assert audit.sample_count == 18
+    assert audit.group_count == 9
+    assert audit.split_counts == {"train": 6, "val": 6, "test": 6}
+    assert audit.class_counts == {1: 6, 2: 6, 3: 6}
+    assert audit.split_class_counts == {
+        ("train", 1): 2,
+        ("train", 2): 2,
+        ("train", 3): 2,
+        ("val", 1): 2,
+        ("val", 2): 2,
+        ("val", 3): 2,
+        ("test", 1): 2,
+        ("test", 2): 2,
+        ("test", 3): 2,
+    }
+    assert {sample.frame_count for sample in samples} == {13}
+    assert {sample.frame_shape for sample in samples} == {(32, 32)}
+    assert {sample.n_flagella for sample in samples} == {1, 2, 3}
+
+
+@pytest.mark.light
+def test_phase4_loader_rejects_group_key_leakage(tmp_path: Path) -> None:
+    input_dataset = tmp_path / "phase2_dataset"
+    raw_dir = tmp_path / "raw" / "nf01_run0"
+    raw_dir.mkdir(parents=True)
+    save_state_archive(raw_dir / "state_archive.npz", [_state(i) for i in range(26)])
+    _write_phase2_summary(
+        input_dataset,
+        [
+            {
+                "sample_id": "nf01_run0",
+                "n_flagella": "1",
+                "torque_Nm": "2e-20",
+                "use_for_ml_candidate": "True",
+                "raw_dir": str(raw_dir),
+            }
+        ],
+    )
+    dataset_dir = build_clip_dataset(
+        Phase3Config(
+            dataset_id="phase4_loader_fixture",
+            input_dataset=input_dataset,
+            output_dir=tmp_path / "phase3_clips",
+            crop_size_px=32,
+        )
+    )
+
+    split_path = dataset_dir / "split_summary.csv"
+    rows = list(csv.DictReader(split_path.open("r", encoding="utf-8", newline="")))
+    rows[1]["split"] = "val"
+    with split_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    samples = load_phase3_common_clip_dataset(dataset_dir)
+    with pytest.raises(ValueError, match="group_key leakage"):
+        audit_phase4_clip_dataset(samples)
+
+
+@pytest.mark.light
+def test_phase4_loader_rejects_clip_shape_mismatch(tmp_path: Path) -> None:
+    input_dataset = tmp_path / "phase2_dataset"
+    raw_dir = tmp_path / "raw" / "nf01_run0"
+    raw_dir.mkdir(parents=True)
+    save_state_archive(raw_dir / "state_archive.npz", [_state(i) for i in range(26)])
+    _write_phase2_summary(
+        input_dataset,
+        [
+            {
+                "sample_id": "nf01_run0",
+                "n_flagella": "1",
+                "torque_Nm": "2e-20",
+                "use_for_ml_candidate": "True",
+                "raw_dir": str(raw_dir),
+            }
+        ],
+    )
+    dataset_dir = build_clip_dataset(
+        Phase3Config(
+            dataset_id="phase4_loader_fixture",
+            input_dataset=input_dataset,
+            output_dir=tmp_path / "phase3_clips",
+            crop_size_px=32,
+        )
+    )
+
+    first_record = json.loads(
+        (dataset_dir / "clip_metadata.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()[0]
+    )
+    np.save(
+        Path(first_record["clip"]["output_path"]),
+        np.zeros((12, 32, 32), dtype=np.uint8),
+    )
+
+    with pytest.raises(ValueError, match="frame_count mismatch"):
+        load_phase3_common_clip_dataset(dataset_dir)


### PR DESCRIPTION
## Summary
- Closes #146
- Add a Phase 4 loader for Phase 3 common clip datasets without starting training.
- Validate manifest/metadata/split consistency, uint8 .npy clip shape, labels, split rows, and group_key leakage.
- Add Phase 4 current/tasks docs and refresh the roadmap toward baseline classifier and grouped learning curve follow-ups.

## Checks
- git diff --check
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest -q tests/test_phase4_clip_dataset_loader.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase3_clip_metadata_schema.py
- uv run pytest -q
- pre-commit: ruff format/check and uv run pytest -q -m light

## Review result
- docs/codex-runs/20260724_101232_phase4_0146_loader_smoke/review_result.json

## Notes
- No user visual review required.
- Baseline classifier / metrics / grouped learning curve remain follow-up work under #133/#129.