### PR TITLE
[Phase4] Add 3 s duration and seed study for #129

### DIFF
--- a/conf/phase2_multi_run/README.md
+++ b/conf/phase2_multi_run/README.md
@@ -12,6 +12,7 @@
 | `conf/phase2_multi_run/latest_model_torque_shape_stability.yaml` | 最新モデルの torque 複数条件 shape stability 比較 |
 | `conf/phase2_multi_run/flagella_count_behavior_v0.yaml` | Issue #71 / #117 / #118 の RUN 固定べん毛本数差 diagnostic dataset v0 canonical config |
 | `conf/phase2_multi_run/flagella_count_behavior_v1.yaml` | Issue #119 の改善モデル analysis dataset v1 canonical config |
+| `conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml` | Issue #129 のv1 r1 3 s duration / seed study |
 | `conf/phase2_multi_run/flagella_count_failure_boundary_seed00.yaml` | Issue #113 の n=4,5,6 seed固定多べん毛破綻境界診断 |
 | `conf/phase2_multi_run/flagella_count_stability_narrow_seed00.yaml` | Issue #116 の n=4,5,6 seed固定 `flag_spring/body` 狭域 sweep |
 | `conf/phase2_multi_run/flagella_count_stability_smoke_seed00.yaml` | Issue #116 の候補通過後に使う n=1,2,3 seed固定 smoke check |
@@ -19,6 +20,8 @@
 各 profile は run / plot / replay の設定を 1 枚にまとめる。
 `flagella_count_behavior_v0.yaml` と `flagella_count_behavior_v1.yaml` はさらに `dataset:` section を持ち，dataset 作成にも同じ config を使う。
 旧 `flagella_count_behavior_diagnostic.yaml` は既存出力との互換用 historical alias として残す。
+
+`flagella_count_duration_3s_r1.yaml`はcanonical dataset更新ではなく，v1と同じ物理条件のsource durationを3 sへ延長した比較用revisionである。`n_flagella=1,2,3`とattach / phase seed各3のfull factorial 27 runを生成し，#129 / #155のwindow時間長・seed差・初期過渡状態評価へ渡す。
 
 ## analysis dataset naming
 

--- a/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
+++ b/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
@@ -61,7 +61,7 @@ dataset:
   dataset_version: v1
   dataset_revision: r1
   feature_schema: conf/phase2_analysis/flagella_count_behavior_features.yaml
-  output_dir: outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s
+  output_dir: outputs/phase2_multi_run/flagella_count_duration_3s_r1/dataset/v1_r1_duration_3s
   sample_id_template: "nf{n_flagella:02d}_as{attach_seed:03d}_ps{phase_seed:03d}"
   timeseries_sampling: all_steps
 

--- a/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
+++ b/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
@@ -1,0 +1,89 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: Phase 4 Issue 129 three-second duration and seed study
+  source_issue: https://github.com/Kenta-morimori/prj-flagella-estimation/issues/129
+  model_id: flag_spring2p25_body2p5_candidate
+  dataset_version: v1
+  dataset_revision: r1
+  dataset_scope: nf1_2_3_as3_ps3_dur3p0
+  model_revision: flag_spring2p25_body2p5_candidate
+  version_role: duration_seed_study
+  training_candidate: pending_window_study
+  model_notes:
+    - Physical and rendering conditions match dataset v1.
+    - Only source duration and dataset revision differ from v1 r0.
+    - RUN fixed with motor.enable_switching=false.
+    - Body-centered 2D rendering is accepted for this study.
+
+base_config: conf/sim_swim.yaml
+
+base_overrides:
+  time.duration_s: 3.0
+  time.dt_star: 1.0e-4
+  motor.torque_Nm: 2.0e-20
+  motor.enable_switching: false
+  motor.force_distribution: root_torque_segment_couples
+  motor.local_first_second_spring_scale: 1.0
+  stiffness_scales.flag_spring: 2.25
+  stiffness_scales.body: 2.5
+  flagella.placement_mode: seeded_surface
+  flagella.initial_phase_mode: seeded
+  flagella.initial_helix_axis_from_rear_deg: 0
+  output_sampling.out_all_steps_3d: false
+  output_sampling.fps_out_3d: 25.0
+  output_sampling.fps_out_2d: 25.0
+
+sweep:
+  axes:
+    attach_seed:
+      key: seed.attach_seed
+      short_name: as
+      values: [0, 1, 2]
+      labels: ["0", "1", "2"]
+      ids: [as000, as001, as002]
+    phase_seed:
+      key: seed.phase_seed
+      short_name: ps
+      values: [0, 1, 2]
+      labels: ["0", "1", "2"]
+      ids: [ps000, ps001, ps002]
+    n_flagella:
+      key: flagella.n_flagella
+      short_name: nf
+      values: [1, 2, 3]
+      labels: ["1", "2", "3"]
+      ids: [nf01, nf02, nf03]
+
+dataset:
+  dataset_id: v1_r1_duration_3s
+  dataset_version: v1
+  dataset_revision: r1
+  feature_schema: conf/phase2_analysis/flagella_count_behavior_features.yaml
+  output_dir: outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s
+  sample_id_template: "nf{n_flagella:02d}_as{attach_seed:03d}_ps{phase_seed:03d}"
+  timeseries_sampling: all_steps
+
+replay:
+  mode: both
+  fps_out_3d: 10.0
+  max_panels_per_grid: 9
+  output_subdir: replay
+
+plot:
+  default_x_axis: n_flagella
+  default_y_axis: attach_seed
+  filter_axes:
+    phase_seed: "0"
+  metrics:
+    - first_fail_t_s
+    - hook_len_rel_err_max
+    - max_flag_bond_rel_err
+    - body_spring_max_stretch_ratio
+
+output:
+  base_dir: outputs/phase2_multi_run/flagella_count_duration_3s_r1
+  timestamp_subdir: false
+  save_state_archive: true
+  progress_interval: 1000

--- a/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
+++ b/conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml
@@ -83,7 +83,7 @@ plot:
     - body_spring_max_stretch_ratio
 
 output:
-  base_dir: outputs/phase2_multi_run/flagella_count_duration_3s_r1
-  timestamp_subdir: false
+  base_dir: outputs
+  timestamp_subdir: true
   save_state_archive: true
   progress_interval: 1000

--- a/conf/phase4/duration_seed_study_v1_r1.yaml
+++ b/conf/phase4/duration_seed_study_v1_r1.yaml
@@ -1,0 +1,10 @@
+dataset_dir: outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s
+output_dir:
+overwrite: false
+study:
+  allowed_n_flagella: [1, 2, 3]
+  durations_s: [0.25, 0.5, 1.0]
+clip:
+  frame_rate_hz: 25.0
+  crop_size_px: 96
+  pixel_size_um: 0.1

--- a/conf/phase4/duration_seed_study_v1_r1.yaml
+++ b/conf/phase4/duration_seed_study_v1_r1.yaml
@@ -1,5 +1,5 @@
-dataset_dir: outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s
-output_dir:
+dataset_dir: outputs/phase2_multi_run/flagella_count_duration_3s_r1/dataset/v1_r1_duration_3s
+output_dir: outputs/phase2_multi_run/flagella_count_duration_3s_r1/analysis/phase4_duration_seed_study
 overwrite: false
 study:
   allowed_n_flagella: [1, 2, 3]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,6 +96,7 @@ Current baseline:
 | #127 | closed | #6 | 実動画・擬似動画の共通clip / metadata schema。PR #142 merged |
 | #128 | closed | #133 | 学習datasetへ混ぜてよい条件変更とPhase 4 freeze gate。PR #152 merged |
 | #129 | open | Phase 3→4 context | 1 clip時間長と必要な独立run数 |
+| #155 | open | #133 | 初期過渡状態とattach / phase seed差が識別性へ与える影響 |
 | #146 | closed | #133 | Phase 3 common clip dataset loader smoke test。PR #147 merged |
 | #148 | closed | #133 | common clip baseline classifier。PR #149 merged |
 | #150 | closed | #133 | grouped learning curve evaluator。PR #151 merged |
@@ -103,8 +104,9 @@ Current baseline:
 
 Recommended order:
 
-1. #129: `k=4`をpseudo-v1 MVP下限として採択するか，protected評価用run追加後に決める。
-2. #145: RUN-TUMBLE dataset v2はProject `TODO`のままMVP後へ残す。
+1. #129: v1 r1の3 s full-factorial duration / seed studyを実行し，`0.5 s`と必要run数を判断する。
+2. #155: 初期過渡状態とseed差から`warmup_s`とearly clipの用途を判断する。
+3. #145: RUN-TUMBLE dataset v2はProject `TODO`のままMVP後へ残す。
 
 #127 common clip schemaはPR #142，#6 GT passthroughはPR #144，#146 loader smokeはPR #147，#148 baseline classifierはPR #149，#150 grouped learning curveはPR #151，#128 freeze gateはPR #152でmerge済み。現在の直近判断は #129 である。
 

--- a/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
+++ b/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
@@ -32,6 +32,10 @@
     {
       "command": "./scripts/04_phase4/run_duration_seed_study.sh probe",
       "result": "PASS (n_flagella=1,2,3 at attach_seed=0, phase_seed=0; full profile dry-run separately expanded all 27 conditions)"
+    },
+    {
+      "command": "uv run pytest -q tests/test_phase4_duration_study.py",
+      "result": "PASS (3 passed; includes shell full-path regression without OVERWRITE)"
     }
   ],
   "user_review_required": false,

--- a/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
+++ b/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
@@ -1,9 +1,9 @@
 {
   "status": "PASS",
-  "summary": "Issue #129の3 s duration / seed study実行導線を実装し、ユーザー実行によるfull factorial 27 runの完了後に解析plotと出力配置を改善した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2を評価する。時間推移plotは同一特徴量の0.25/0.5/1.0 sパネルで共通y軸を使い、seed heatmapはduration 3行 x n_flagella 3列へ統合しつつdurationごとの独立color scaleとQC fail labelを保持する。raw run、dataset revision、Phase 4解析、replayをoutputs/phase2_multi_run/flagella_count_duration_3s_r1配下へ集約し、既存raw runからsimulationなしで再構築するCLIをscripts/README.mdへ記載した。",
+  "summary": "Issue #129の3 s duration / seed study実行導線を実装し、ユーザー実行によるfull factorial 27 runの完了後に解析plotと出力配置を改善した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2を評価する。時間推移plotは同一特徴量の0.25/0.5/1.0 sパネルで共通y軸を使い、seed heatmapはduration 3行 x n_flagella 3列へ統合しつつdurationごとの独立color scaleとQC fail labelを保持する。Codex review対応として、新規full実行はJST timestamp付きcampaign rootへraw・dataset・analysisを集約し、不完全factorialではseed寄与率を出力せず、解析manifest/run.logへconfig、CLI override、seed、Git、environmentを記録するよう修正した。既存raw runは明示したRUN_DIRからsimulationなしで再解析できる。",
   "blocking_issues": [],
   "non_blocking_issues": [
-    "0.5 s採択時の許容性能差は未決定であり、Issue #129で実データplotを確認してから決める。",
+    "dataset v1のclip durationは0.5 sに決定済みだが、必要な独立run数の採用判断はIssue #129に残る。",
     "初期過渡状態、warmup_s、early clipの用途はIssue #155で判断する。",
     "最終評価用protected runsは今回の27 runと分離するが、具体的なseed / condition差は未決定である。",
     "n_flagella=3の4/9 runにflag strict QC failがあり、dataset v2の形状・QC採択条件の一部としてPhase 2側の原因確認と修正が必要である。"
@@ -46,6 +46,14 @@
       "result": "PASS (shell syntax valid; n_flagella=1,2,3 probe expanded)"
     },
     {
+      "command": "uv run ruff format --check . && uv run ruff check . && uv run pytest -q tests/test_phase4_duration_study.py tests/test_phase2_generic_multi_run.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase4_baseline_classifier.py",
+      "result": "PASS (54 passed)"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS (416 passed)"
+    },
+    {
       "command": "uv run python scripts/04_phase4/evaluate_duration_seed_study.py config=conf/phase4/duration_seed_study_v1_r1.yaml output_dir=outputs/2026-07-30/111006/phase4_duration_seed_study",
       "result": "PASS (27 user-generated runs reanalyzed; 12 plots generated and representative time/heatmap PNGs visually checked)"
     }
@@ -61,7 +69,7 @@
   "push_status": "not_pushed",
   "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/156",
   "next_actions": [
-    "既存27 runからcampaign配下のdataset revisionとanalysisを再生成し、CSVとplotを確認してIssue #129で0.5 sと必要run数の採用範囲を決める。",
+    "Issue #159で既存27 runから0.5 s clip datasetを生成し、replay / freeze / ML handoffを整備する。",
     "既存replay CLIで27条件をrenderし、n_flagella=3の4 fail条件を定性評価する。",
     "n_flagella=3のflag strict QC failをPhase 2側で診断し、dataset v2の形状・QC採択条件の一部として9/9 strict passを確認する。",
     "Issue #155で初期過渡状態とwarmup_sを判断する。",

--- a/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
+++ b/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "summary": "Issue #129の3 s duration / seed study実行導線を実装し、ユーザー実行によるfull factorial 27 runの完了後に解析plotを改善した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2を評価する。時間推移plotは同一特徴量の0.25/0.5/1.0 sパネルで共通y軸を使い、seed heatmapはduration 3行 x n_flagella 3列へ統合しつつdurationごとの独立color scaleとQC fail labelを保持する。既存raw runから再解析するCLIと、PASSまたはFAIL category@first_fail_t_sを表示する既存3D replayコマンドをscripts/README.mdへ記載した。",
+  "summary": "Issue #129の3 s duration / seed study実行導線を実装し、ユーザー実行によるfull factorial 27 runの完了後に解析plotと出力配置を改善した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2を評価する。時間推移plotは同一特徴量の0.25/0.5/1.0 sパネルで共通y軸を使い、seed heatmapはduration 3行 x n_flagella 3列へ統合しつつdurationごとの独立color scaleとQC fail labelを保持する。raw run、dataset revision、Phase 4解析、replayをoutputs/phase2_multi_run/flagella_count_duration_3s_r1配下へ集約し、既存raw runからsimulationなしで再構築するCLIをscripts/README.mdへ記載した。",
   "blocking_issues": [],
   "non_blocking_issues": [
     "0.5 s採択時の許容性能差は未決定であり、Issue #129で実データplotを確認してから決める。",
@@ -42,6 +42,10 @@
       "result": "PASS (181 passed, 235 deselected)"
     },
     {
+      "command": "bash -n scripts/04_phase4/run_duration_seed_study.sh && ./scripts/04_phase4/run_duration_seed_study.sh probe",
+      "result": "PASS (shell syntax valid; n_flagella=1,2,3 probe expanded)"
+    },
+    {
       "command": "uv run python scripts/04_phase4/evaluate_duration_seed_study.py config=conf/phase4/duration_seed_study_v1_r1.yaml output_dir=outputs/2026-07-30/111006/phase4_duration_seed_study",
       "result": "PASS (27 user-generated runs reanalyzed; 12 plots generated and representative time/heatmap PNGs visually checked)"
     }
@@ -51,13 +55,13 @@
   "user_review_outputs": [],
   "user_review_points": [],
   "adr_required": false,
-  "adr_reason": "物理モデル、dataset version、Phase境界、dataset v2の採択条件全体は変更していない。既存のduration / seed解析plotと利用手順の改善である。",
+  "adr_reason": "物理モデル、dataset version、Phase境界、dataset v2の採択条件全体は変更していない。既存のduration / seed解析plot、campaign内の出力配置、利用手順の改善である。",
   "commit_type": "complete",
   "commit_hash": null,
   "push_status": "not_pushed",
   "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/156",
   "next_actions": [
-    "outputs/2026-07-30/111006/phase4_duration_seed_studyのCSVとplotを確認し、Issue #129で0.5 sと必要run数の採用範囲を決める。",
+    "既存27 runからcampaign配下のdataset revisionとanalysisを再生成し、CSVとplotを確認してIssue #129で0.5 sと必要run数の採用範囲を決める。",
     "既存replay CLIで27条件をrenderし、n_flagella=3の4 fail条件を定性評価する。",
     "n_flagella=3のflag strict QC failをPhase 2側で診断し、dataset v2の形状・QC採択条件の一部として9/9 strict passを確認する。",
     "Issue #155で初期過渡状態とwarmup_sを判断する。",

--- a/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
+++ b/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
@@ -1,0 +1,53 @@
+{
+  "status": "PASS",
+  "summary": "Issue #129の3 s duration / seed study実行導線を実装した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2のfull factorial 27 runを生成できる。解析CLIは同じ時間窓についてraw all-step 3D特徴と25 Hz body-centered 2D clip特徴を出力し、run全体とwindow個別のshape/QC label、attach×phase run平均、seed分散寄与、時間推移plot、seed heatmapを保存する。長時間simulationはrepository方針に従いユーザー実行へ渡した。",
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "3 s full-factorial 27 runは長時間simulationのため未実行であり、科学的な時間長・run数判断はartifact生成後に行う。",
+    "0.5 s採択時の許容性能差は未決定であり、Issue #129で実データplotを確認してから決める。",
+    "初期過渡状態、warmup_s、early clipの用途はIssue #155で判断する。",
+    "最終評価用protected runsは今回の27 runと分離するが、具体的なseed / condition差は未決定である。"
+  ],
+  "tests_reviewed": [
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest -q tests/test_phase4_duration_study.py tests/test_phase4_baseline_classifier.py tests/test_phase3_gt_passthrough_pipeline.py tests/test_phase2_generic_multi_run.py",
+      "result": "PASS (53 passed)"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS (415 passed)"
+    },
+    {
+      "command": "./scripts/04_phase4/run_duration_seed_study.sh probe",
+      "result": "PASS (n_flagella=1,2,3 at attach_seed=0, phase_seed=0; full profile dry-run separately expanded all 27 conditions)"
+    }
+  ],
+  "user_review_required": false,
+  "user_review_command": null,
+  "user_review_outputs": [],
+  "user_review_points": [],
+  "adr_required": false,
+  "adr_reason": "物理モデル、dataset version、Phase境界、学習採択基準は変更していない。既存v1条件のsource duration延長をr1として記録し、承認済みのgroup_key独立性とbody-centered描画方針に従う解析導線の追加である。",
+  "commit_type": "complete",
+  "commit_hash": null,
+  "push_status": "not_pushed",
+  "pull_request_url": null,
+  "next_actions": [
+    "./scripts/04_phase4/run_duration_seed_study.sh fullをユーザーが実行する。",
+    "window_features_3d.csv、window_features_2d.csv、run_feature_means.csv、seed_effects.csv、plotsを確認し、Issue #129で0.5 sと必要run数の採用範囲を決める。",
+    "Issue #155で初期過渡状態とwarmup_sを判断する。",
+    "最終評価用protected runsのseed / condition設計を別途決める。"
+  ]
+}

--- a/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
+++ b/docs/codex-runs/20260729_144915_phase4_0129_duration_seed_study/review_result.json
@@ -1,12 +1,12 @@
 {
   "status": "PASS",
-  "summary": "Issue #129の3 s duration / seed study実行導線を実装した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2のfull factorial 27 runを生成できる。解析CLIは同じ時間窓についてraw all-step 3D特徴と25 Hz body-centered 2D clip特徴を出力し、run全体とwindow個別のshape/QC label、attach×phase run平均、seed分散寄与、時間推移plot、seed heatmapを保存する。長時間simulationはrepository方針に従いユーザー実行へ渡した。",
+  "summary": "Issue #129の3 s duration / seed study実行導線を実装し、ユーザー実行によるfull factorial 27 runの完了後に解析plotを改善した。dataset v1と同じ物理条件をdataset_revision r1として延長し、n_flagella=1,2,3、attach_seed=0,1,2、phase_seed=0,1,2を評価する。時間推移plotは同一特徴量の0.25/0.5/1.0 sパネルで共通y軸を使い、seed heatmapはduration 3行 x n_flagella 3列へ統合しつつdurationごとの独立color scaleとQC fail labelを保持する。既存raw runから再解析するCLIと、PASSまたはFAIL category@first_fail_t_sを表示する既存3D replayコマンドをscripts/README.mdへ記載した。",
   "blocking_issues": [],
   "non_blocking_issues": [
-    "3 s full-factorial 27 runは長時間simulationのため未実行であり、科学的な時間長・run数判断はartifact生成後に行う。",
     "0.5 s採択時の許容性能差は未決定であり、Issue #129で実データplotを確認してから決める。",
     "初期過渡状態、warmup_s、early clipの用途はIssue #155で判断する。",
-    "最終評価用protected runsは今回の27 runと分離するが、具体的なseed / condition差は未決定である。"
+    "最終評価用protected runsは今回の27 runと分離するが、具体的なseed / condition差は未決定である。",
+    "n_flagella=3の4/9 runにflag strict QC failがあり、dataset v2の形状・QC採択条件の一部としてPhase 2側の原因確認と修正が必要である。"
   ],
   "tests_reviewed": [
     {
@@ -36,6 +36,14 @@
     {
       "command": "uv run pytest -q tests/test_phase4_duration_study.py",
       "result": "PASS (3 passed; includes shell full-path regression without OVERWRITE)"
+    },
+    {
+      "command": "uv run ruff format --check . && uv run ruff check . && uv run pytest -q -m light",
+      "result": "PASS (181 passed, 235 deselected)"
+    },
+    {
+      "command": "uv run python scripts/04_phase4/evaluate_duration_seed_study.py config=conf/phase4/duration_seed_study_v1_r1.yaml output_dir=outputs/2026-07-30/111006/phase4_duration_seed_study",
+      "result": "PASS (27 user-generated runs reanalyzed; 12 plots generated and representative time/heatmap PNGs visually checked)"
     }
   ],
   "user_review_required": false,
@@ -43,14 +51,15 @@
   "user_review_outputs": [],
   "user_review_points": [],
   "adr_required": false,
-  "adr_reason": "物理モデル、dataset version、Phase境界、学習採択基準は変更していない。既存v1条件のsource duration延長をr1として記録し、承認済みのgroup_key独立性とbody-centered描画方針に従う解析導線の追加である。",
+  "adr_reason": "物理モデル、dataset version、Phase境界、dataset v2の採択条件全体は変更していない。既存のduration / seed解析plotと利用手順の改善である。",
   "commit_type": "complete",
   "commit_hash": null,
   "push_status": "not_pushed",
-  "pull_request_url": null,
+  "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/156",
   "next_actions": [
-    "./scripts/04_phase4/run_duration_seed_study.sh fullをユーザーが実行する。",
-    "window_features_3d.csv、window_features_2d.csv、run_feature_means.csv、seed_effects.csv、plotsを確認し、Issue #129で0.5 sと必要run数の採用範囲を決める。",
+    "outputs/2026-07-30/111006/phase4_duration_seed_studyのCSVとplotを確認し、Issue #129で0.5 sと必要run数の採用範囲を決める。",
+    "既存replay CLIで27条件をrenderし、n_flagella=3の4 fail条件を定性評価する。",
+    "n_flagella=3のflag strict QC failをPhase 2側で診断し、dataset v2の形状・QC採択条件の一部として9/9 strict passを確認する。",
     "Issue #155で初期過渡状態とwarmup_sを判断する。",
     "最終評価用protected runsのseed / condition設計を別途決める。"
   ]

--- a/docs/phase3/phase3_2_clip_duration_run_count.md
+++ b/docs/phase3/phase3_2_clip_duration_run_count.md
@@ -100,6 +100,14 @@ overlap window は，情報量や安定性の比較には使えるが，learning
 
 #150 で軽量なgrouped learning curve evaluatorを実装した。Phase 2 dataset v1の既存state archiveから`n_flagella=1,2,3`全27 candidateを`0.5 s` non-overlap clipへ変換する処理は追加simulationを伴わないため，実行済みである。
 
+## Planned 3 s Duration / Seed Study
+
+既存1 s sourceだけではwindow開始時刻と初期過渡状態を十分に比較できないため，#129ではdataset v1と同じ物理条件を`dataset_revision=r1`として3 sへ延長する。対象は`n_flagella=1,2,3`，`attach_seed=0,1,2`，`phase_seed=0,1,2`のfull factorial 27 independent runsとする。
+
+各duration / time windowについて，3D raw all-step特徴，25 Hz body-centered 2D clip特徴，run / window shape QCを記録する。attach / phase seed差は同一run内windowを独立sampleとして扱わず，run平均へ集約して主効果と残差を比較する。
+
+初期過渡状態の採用可否は別Issueで扱い，early / middle / late windowのclass分離性から`warmup_s`とearly clipの用途を判断する。最終性能評価にはこの27 runとは別のprotected runsを用意する。
+
 実行command:
 
 ```bash

--- a/docs/phase4/phase4_current.md
+++ b/docs/phase4/phase4_current.md
@@ -16,7 +16,8 @@ Phase 3 / 4 MVP の標準 clip duration は `0.5 s` に固定する。必要独�
 - #148: common clip baseline classifier。PR #149 で完了した。
 - #150: grouped learning curve evaluator。PR #151 で完了した。
 - #128: 学習datasetへ混ぜてよい条件変更をmachine-readable freeze gateへ接続し，PR #152 で完了した。
-- #129: 1 clip の時間長と必要な独立run数を決める。`0.5 s` defaultとlearning curve評価は完了し，`k=4`の採用範囲を判断する。
+- #129: 1 clip の時間長と必要な独立run数を決める。`0.5 s` defaultとlearning curve評価に加え，v1 r1の3 s full-factorial duration / seed studyをユーザー実行して採用範囲を判断する。
+- #155: 初期過渡状態とattach / phase seed差がべん毛数識別性へ与える影響を評価し，`warmup_s`とearly clipの用途を決める。
 - #145: RUN-TUMBLE を含む dataset v2。Project Status は `TODO` だが，Phase 3 / 4 MVP 後に後回し。
 
 ## Input Contract
@@ -88,9 +89,38 @@ macro F1 mean:
 
 ## Next Actions
 
-1. #129で`k=4`をpseudo-v1 MVP dataset-size下限として採用するか判断する。
-2. 一般的な必要run数を主張する場合はprotected評価用runを追加する。
-3. #145 RUN-TUMBLE dataset v2はProject `TODO`のまま後回しにする。
+1. #129の3 s studyを`probe`後にユーザー実行し，3D / 2D window特徴，attach / phase seed寄与，window QCを確認する。
+2. `0.5 s`相当windowの採択基準と`k=4`のpseudo-v1 MVP適用範囲を判断する。
+3. 一般的な必要run数を主張するための新規protected run条件を別途決める。
+4. #145 RUN-TUMBLE dataset v2はProject `TODO`のまま後回しにする。
+
+## Duration And Seed Study
+
+#129の追加評価は，dataset v1と同じ物理条件を`dataset_revision=r1`として3 sへ延長し，`n_flagella=1,2,3`，`attach_seed=0,1,2`，`phase_seed=0,1,2`のfull factorial 27 runを対象とする。dataset v2には上げない。
+
+3D特徴はraw all-step state / `step_summary.csv`を各windowで再集計し，2D特徴は25 Hzへdownsampleしたbody-centered clipから抽出する。各windowは`run_id` / `group_key`，attach / phase seed，requested / actual duration，開始・終了時刻，run全体とwindow個別のshape/QC labelを保持する。同一run内windowは独立run数へ加えない。
+
+25 Hzではrequested durationがframeへ量子化され，`0.25 s -> 7 frames / 0.28 s`，`0.5 s -> 13 frames / 0.52 s`，`1.0 s -> 25 frames / 1.0 s`となる。CSVとplotではrequested値とactual値を分ける。
+
+実行:
+
+```bash
+./scripts/04_phase4/run_duration_seed_study.sh probe
+./scripts/04_phase4/run_duration_seed_study.sh full
+```
+
+本実行は長時間simulationのためユーザー実行とする。既存出力を確認の上で再生成する場合だけ`OVERWRITE=true`を指定する。
+
+主要artifact:
+
+```text
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/window_features_3d.csv
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/window_features_2d.csv
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/run_feature_means.csv
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/seed_effects.csv
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/plots/
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/manifest.json
+```
 
 ## Key References
 
@@ -98,5 +128,6 @@ macro F1 mean:
 - Loader smoke test issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/146`
 - Baseline classifier issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/148`
 - Grouped learning curve issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/150`
+- Initial transient evaluation issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/155`
 - Phase 3 metadata schema: `schemas/phase3_clip_metadata.schema.json`
 - Phase 3 GT passthrough pipeline: `src/flagella_estimation/phase3/`

--- a/docs/phase4/phase4_tasks.md
+++ b/docs/phase4/phase4_tasks.md
@@ -105,3 +105,25 @@
 - verification:
   - `uv run pytest -q tests/test_phase4_dataset_freeze.py tests/test_phase4_learning_curve.py tests/test_phase4_baseline_classifier.py tests/test_phase4_clip_dataset_loader.py`
   - `uv run python scripts/04_phase4/audit_dataset_freeze.py config=conf/phase4/dataset_freeze_v1.yaml dataset_dir=outputs/2026-07-24/143640/phase3_gt_passthrough_v1_full_candidates output_dir=outputs/2026-07-24/153000/phase4_dataset_freeze_audit_source_verified`
+
+## Phase 4.5: duration and seed study
+
+### P4-5-001: Issue #129 3 s full-factorial解析導線
+
+- status: implementation complete / user long run pending
+- branch: `feature/phase4-129-duration-seed-study`
+- goal: dataset v1の物理条件を3 sへ延長したr1について，clip時間長，開始時刻，attach / phase seed差，shape/QCを同じwindow contractで比較できるようにする。
+- implementation:
+  - `conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml`で`n_flagella=1,2,3`，attach / phase seed各3の27 runを固定した。
+  - 3D all-step特徴と25 Hz body-centered 2D clip特徴を同一windowへ対応付けるduration study evaluatorを追加した。
+  - run全体とwindow個別のstrict / relaxed shape/QC labelをCSVへ記録する。
+  - windowをrun単位へ集約し，attach×phaseセル平均を`run_feature_means.csv`，attach / phase seedの分散寄与と残差を`seed_effects.csv`へ記録する。全label付きとstrict-pass限定を分ける。
+  - 時間推移plotではQC failを印で示し，主要特徴量はattach×phase seed heatmapも保存する。
+  - 長時間simulationをユーザーが`probe` / `full`の2段階で実行するshellを追加した。
+- verification:
+  - `uv run pytest -q tests/test_phase4_duration_study.py`
+  - `./scripts/04_phase4/run_duration_seed_study.sh probe`
+- remaining decision:
+  - `0.5 s`相当windowの許容性能差は本実行結果を見て別途決める。
+  - 最終評価用protected runのseed / condition差は別途決める。
+  - 初期過渡状態，`warmup_s`，early clipの用途はIssue #155で判断する。

--- a/scripts/04_phase4/evaluate_duration_seed_study.py
+++ b/scripts/04_phase4/evaluate_duration_seed_study.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Evaluate Phase 4 clip durations and attach/phase seed effects."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from flagella_estimation.phase4.duration_study import (
+    analyze_duration_seed_study,
+    load_duration_study_config,
+)
+
+
+def _split_config_key(argv: list[str]) -> tuple[Path | None, list[str]]:
+    rest: list[str] = []
+    config: Path | None = None
+    for item in argv:
+        if item.startswith("config="):
+            config = Path(item.split("=", 1)[1])
+        else:
+            rest.append(item)
+    return config, rest
+
+
+def main(argv: list[str] | None = None) -> None:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    config_from_key, parser_argv = _split_config_key(raw_argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("overrides", nargs="*", help="Optional KEY=VALUE overrides")
+    args = parser.parse_args(parser_argv)
+    if config_from_key is not None and args.config is not None:
+        parser.error("Use either config=PATH or --config PATH (not both)")
+    cfg = load_duration_study_config(config_from_key or args.config, args.overrides)
+    output_dir = analyze_duration_seed_study(cfg)
+    print(output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/04_phase4/run_duration_seed_study.sh
+++ b/scripts/04_phase4/run_duration_seed_study.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+if [[ "${mode}" != "probe" && "${mode}" != "full" ]]; then
+  printf 'Usage: %s {probe|full}\n' "$0" >&2
+  exit 2
+fi
+
+campaign_config="conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml"
+study_config="conf/phase4/duration_seed_study_v1_r1.yaml"
+run_dir="outputs/phase2_multi_run/flagella_count_duration_3s_r1"
+dataset_dir="outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s"
+
+if [[ "${mode}" == "probe" ]]; then
+  uv run python scripts/01_simulate_swimming/run_multi_run.py \
+    config="${campaign_config}" \
+    dry_run=true \
+    sample_limit=3
+  exit 0
+fi
+
+overwrite_args=()
+if [[ -e "${run_dir}" || -e "${dataset_dir}" ]]; then
+  if [[ "${OVERWRITE:-false}" != "true" ]]; then
+    printf 'Existing output found. Re-run with OVERWRITE=true after inspection.\n' >&2
+    exit 2
+  fi
+  overwrite_args=(overwrite=true)
+fi
+
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config="${campaign_config}" \
+  "${overwrite_args[@]}"
+
+uv run python scripts/02_phase2_analysis/build_dataset.py \
+  config="${campaign_config}" \
+  run_dir="${run_dir}" \
+  "${overwrite_args[@]}"
+
+run_timestamp="$(TZ=Asia/Tokyo date +%Y-%m-%d/%H%M%S)"
+output_dir="outputs/${run_timestamp}/phase4_duration_seed_study"
+uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
+  config="${study_config}" \
+  output_dir="${output_dir}"
+
+printf 'Study output: %s\n' "${output_dir}"

--- a/scripts/04_phase4/run_duration_seed_study.sh
+++ b/scripts/04_phase4/run_duration_seed_study.sh
@@ -20,23 +20,29 @@ if [[ "${mode}" == "probe" ]]; then
   exit 0
 fi
 
-overwrite_args=()
+overwrite_requested="${OVERWRITE:-false}"
 if [[ -e "${run_dir}" || -e "${dataset_dir}" ]]; then
-  if [[ "${OVERWRITE:-false}" != "true" ]]; then
+  if [[ "${overwrite_requested}" != "true" ]]; then
     printf 'Existing output found. Re-run with OVERWRITE=true after inspection.\n' >&2
     exit 2
   fi
-  overwrite_args=(overwrite=true)
 fi
 
-uv run python scripts/01_simulate_swimming/run_multi_run.py \
-  config="${campaign_config}" \
-  "${overwrite_args[@]}"
-
-uv run python scripts/02_phase2_analysis/build_dataset.py \
-  config="${campaign_config}" \
-  run_dir="${run_dir}" \
-  "${overwrite_args[@]}"
+if [[ "${overwrite_requested}" == "true" ]]; then
+  uv run python scripts/01_simulate_swimming/run_multi_run.py \
+    config="${campaign_config}" \
+    overwrite=true
+  uv run python scripts/02_phase2_analysis/build_dataset.py \
+    config="${campaign_config}" \
+    run_dir="${run_dir}" \
+    overwrite=true
+else
+  uv run python scripts/01_simulate_swimming/run_multi_run.py \
+    config="${campaign_config}"
+  uv run python scripts/02_phase2_analysis/build_dataset.py \
+    config="${campaign_config}" \
+    run_dir="${run_dir}"
+fi
 
 run_timestamp="$(TZ=Asia/Tokyo date +%Y-%m-%d/%H%M%S)"
 output_dir="outputs/${run_timestamp}/phase4_duration_seed_study"

--- a/scripts/04_phase4/run_duration_seed_study.sh
+++ b/scripts/04_phase4/run_duration_seed_study.sh
@@ -10,7 +10,8 @@ fi
 campaign_config="conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml"
 study_config="conf/phase4/duration_seed_study_v1_r1.yaml"
 run_dir="outputs/phase2_multi_run/flagella_count_duration_3s_r1"
-dataset_dir="outputs/phase2_analysis/flagella_count_behavior/datasets/v1_r1_duration_3s"
+dataset_dir="${run_dir}/dataset/v1_r1_duration_3s"
+study_dir="${run_dir}/analysis/phase4_duration_seed_study"
 
 if [[ "${mode}" == "probe" ]]; then
   uv run python scripts/01_simulate_swimming/run_multi_run.py \
@@ -44,10 +45,7 @@ else
     run_dir="${run_dir}"
 fi
 
-run_timestamp="$(TZ=Asia/Tokyo date +%Y-%m-%d/%H%M%S)"
-output_dir="outputs/${run_timestamp}/phase4_duration_seed_study"
 uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
-  config="${study_config}" \
-  output_dir="${output_dir}"
+  config="${study_config}"
 
-printf 'Study output: %s\n' "${output_dir}"
+printf 'Study output: %s\n' "${study_dir}"

--- a/scripts/04_phase4/run_duration_seed_study.sh
+++ b/scripts/04_phase4/run_duration_seed_study.sh
@@ -9,7 +9,8 @@ fi
 
 campaign_config="conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml"
 study_config="conf/phase4/duration_seed_study_v1_r1.yaml"
-run_dir="outputs/phase2_multi_run/flagella_count_duration_3s_r1"
+timestamp="$(TZ=Asia/Tokyo date +'%Y-%m-%d/%H%M%S')"
+run_dir="${RUN_DIR:-outputs/${timestamp}/phase4_duration_seed_study}"
 dataset_dir="${run_dir}/dataset/v1_r1_duration_3s"
 study_dir="${run_dir}/analysis/phase4_duration_seed_study"
 
@@ -22,30 +23,43 @@ if [[ "${mode}" == "probe" ]]; then
 fi
 
 overwrite_requested="${OVERWRITE:-false}"
-if [[ -e "${run_dir}" || -e "${dataset_dir}" ]]; then
+if [[ -e "${run_dir}" ]]; then
   if [[ "${overwrite_requested}" != "true" ]]; then
     printf 'Existing output found. Re-run with OVERWRITE=true after inspection.\n' >&2
     exit 2
   fi
 fi
 
+campaign_overrides=(
+  "output.base_dir=${run_dir}"
+  "output.timestamp_subdir=false"
+  "dataset.output_dir=${dataset_dir}"
+)
+
 if [[ "${overwrite_requested}" == "true" ]]; then
   uv run python scripts/01_simulate_swimming/run_multi_run.py \
     config="${campaign_config}" \
+    "${campaign_overrides[@]}" \
     overwrite=true
   uv run python scripts/02_phase2_analysis/build_dataset.py \
     config="${campaign_config}" \
     run_dir="${run_dir}" \
+    "${campaign_overrides[@]}" \
     overwrite=true
 else
   uv run python scripts/01_simulate_swimming/run_multi_run.py \
-    config="${campaign_config}"
+    config="${campaign_config}" \
+    "${campaign_overrides[@]}"
   uv run python scripts/02_phase2_analysis/build_dataset.py \
     config="${campaign_config}" \
-    run_dir="${run_dir}"
+    run_dir="${run_dir}" \
+    "${campaign_overrides[@]}"
 fi
 
 uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
-  config="${study_config}"
+  config="${study_config}" \
+  dataset_dir="${dataset_dir}" \
+  output_dir="${study_dir}"
 
+printf 'Campaign root: %s\n' "${run_dir}"
 printf 'Study output: %s\n' "${study_dir}"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -215,3 +215,36 @@ uv run python scripts/02_phase2_analysis/analyze_2d_separability.py \
   --output-dir outputs/phase2_analysis/flagella_count_behavior/datasets/v1/analysis/projection_2d \
   --overwrite
 ```
+
+## 04_phase4
+
+### Duration / Seed Study
+
+Issue #129 のサンプル時間長・run数検討では、3秒raw run、dataset revision、duration / seed解析を順番に実行します。条件だけを確認する場合は `probe`、full factorial 27 runを実行する場合は `full` を指定します。
+
+```bash
+./scripts/04_phase4/run_duration_seed_study.sh probe
+caffeinate -i ./scripts/04_phase4/run_duration_seed_study.sh full
+```
+
+3秒raw runとdataset revisionがすでに存在する場合は、シミュレーションを再実行せず解析だけを新しい出力先へ生成できます。
+
+```bash
+uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
+  config=conf/phase4/duration_seed_study_v1_r1.yaml \
+  output_dir=outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study
+```
+
+同一特徴量のtime plotは `0.25 / 0.5 / 1.0 s` で共通y軸を使います。seed heatmapはdurationを行、`n_flagella` を列とする1枚にまとめ、durationごとに独立したcolor scaleを使います。`x` と `!` はそれぞれQC fail windowとQC fail runを示します。
+
+3秒raw runを再シミュレーションせず3D比較renderする場合:
+
+```bash
+uv run python scripts/01_simulate_swimming/render_shape_stability_grid_replay.py \
+  config=conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml \
+  mode=render-only \
+  max_panels_per_grid=9 \
+  overwrite=true
+```
+
+27条件は最大9条件ずつ複数pageへ出力されます。各パネルにはconditionとともに `PASS`、または `FAIL <category>@<first_fail_t_s>` が表示されます。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -227,10 +227,10 @@ Issue #129 のサンプル時間長・run数検討では、3秒raw run、dataset
 caffeinate -i ./scripts/04_phase4/run_duration_seed_study.sh full
 ```
 
-raw run、dataset revision、duration / seed解析は、同じcampaign rootの `dataset/`、`analysis/` 配下へ保存されます。
+raw run、dataset revision、duration / seed解析は、実行ごとのJST timestampを持つ同じcampaign rootの `dataset/`、`analysis/` 配下へ保存されます。
 
 ```text
-outputs/phase2_multi_run/flagella_count_duration_3s_r1/
+outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study/
 ├── dataset/v1_r1_duration_3s/
 ├── analysis/phase4_duration_seed_study/
 └── replay/
@@ -238,14 +238,18 @@ outputs/phase2_multi_run/flagella_count_duration_3s_r1/
 
 同一特徴量のtime plotは `0.25 / 0.5 / 1.0 s` で共通y軸を使います。seed heatmapはdurationを行、`n_flagella` を列とする1枚にまとめ、durationごとに独立したcolor scaleを使います。`x` と `!` はそれぞれQC fail windowとQC fail runを示します。
 
-3秒raw runがすでに存在する場合は、シミュレーションを再実行せずdataset revisionと解析結果だけを生成できます。
+3秒raw runがすでに存在する場合は、`RUN_DIR`にcampaign rootを指定し、シミュレーションを再実行せずdataset revisionと解析結果だけを生成できます。以下は既存のcanonical campaignを再解析する例です。
 
 ```bash
+RUN_DIR=outputs/phase2_multi_run/flagella_count_duration_3s_r1
 uv run python scripts/02_phase2_analysis/build_dataset.py \
   config=conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml \
-  run_dir=outputs/phase2_multi_run/flagella_count_duration_3s_r1
+  run_dir="${RUN_DIR}" \
+  dataset.output_dir="${RUN_DIR}/dataset/v1_r1_duration_3s"
 uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
-  config=conf/phase4/duration_seed_study_v1_r1.yaml
+  config=conf/phase4/duration_seed_study_v1_r1.yaml \
+  dataset_dir="${RUN_DIR}/dataset/v1_r1_duration_3s" \
+  output_dir="${RUN_DIR}/analysis/phase4_duration_seed_study"
 ```
 
 3秒raw runを再シミュレーションせず3D比較renderする場合:
@@ -253,6 +257,7 @@ uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
 ```bash
 uv run python scripts/01_simulate_swimming/render_shape_stability_grid_replay.py \
   config=conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml \
+  run_dir="${RUN_DIR}" \
   mode=render-only \
   max_panels_per_grid=9 \
   overwrite=true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -227,15 +227,26 @@ Issue #129 のサンプル時間長・run数検討では、3秒raw run、dataset
 caffeinate -i ./scripts/04_phase4/run_duration_seed_study.sh full
 ```
 
-3秒raw runとdataset revisionがすでに存在する場合は、シミュレーションを再実行せず解析だけを新しい出力先へ生成できます。
+raw run、dataset revision、duration / seed解析は、同じcampaign rootの `dataset/`、`analysis/` 配下へ保存されます。
 
-```bash
-uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
-  config=conf/phase4/duration_seed_study_v1_r1.yaml \
-  output_dir=outputs/YYYY-MM-DD/HHMMSS/phase4_duration_seed_study
+```text
+outputs/phase2_multi_run/flagella_count_duration_3s_r1/
+├── dataset/v1_r1_duration_3s/
+├── analysis/phase4_duration_seed_study/
+└── replay/
 ```
 
 同一特徴量のtime plotは `0.25 / 0.5 / 1.0 s` で共通y軸を使います。seed heatmapはdurationを行、`n_flagella` を列とする1枚にまとめ、durationごとに独立したcolor scaleを使います。`x` と `!` はそれぞれQC fail windowとQC fail runを示します。
+
+3秒raw runがすでに存在する場合は、シミュレーションを再実行せずdataset revisionと解析結果だけを生成できます。
+
+```bash
+uv run python scripts/02_phase2_analysis/build_dataset.py \
+  config=conf/phase2_multi_run/flagella_count_duration_3s_r1.yaml \
+  run_dir=outputs/phase2_multi_run/flagella_count_duration_3s_r1
+uv run python scripts/04_phase4/evaluate_duration_seed_study.py \
+  config=conf/phase4/duration_seed_study_v1_r1.yaml
+```
 
 3秒raw runを再シミュレーションせず3D比較renderする場合:
 

--- a/src/flagella_estimation/phase4/duration_study.py
+++ b/src/flagella_estimation/phase4/duration_study.py
@@ -7,8 +7,11 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import math
+import platform
 from pathlib import Path
 import shutil
+import subprocess
+import sys
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -87,6 +90,8 @@ COMMON_FIELDS = (
 class DurationStudyConfig:
     dataset_dir: Path
     output_dir: Path
+    config_path: Path | None = None
+    cli_overrides: tuple[str, ...] = ()
     durations_s: tuple[float, ...] = (0.25, 0.5, 1.0)
     frame_rate_hz: float = 25.0
     crop_size_px: int = 96
@@ -137,6 +142,8 @@ def load_duration_study_config(
     return DurationStudyConfig(
         dataset_dir=Path(str(data.get("dataset_dir", ""))),
         output_dir=Path(str(output_dir)) if output_dir else default_output_dir(),
+        config_path=path,
+        cli_overrides=tuple(overrides or ()),
         durations_s=tuple(
             float(value) for value in study.get("durations_s", [0.25, 0.5, 1.0])
         ),
@@ -176,6 +183,37 @@ def _to_float(value: Any, default: float = float("nan")) -> float:
 
 def _to_bool(value: Any) -> bool:
     return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def _git_info() -> dict[str, Any]:
+    def run(command: list[str]) -> str:
+        return subprocess.check_output(
+            command, stderr=subprocess.STDOUT, text=True
+        ).strip()
+
+    try:
+        return {
+            "commit": run(["git", "rev-parse", "HEAD"]),
+            "commit_short": run(["git", "rev-parse", "--short", "HEAD"]),
+            "branch": run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+            "is_clean": run(["git", "status", "--porcelain"]) == "",
+        }
+    except Exception:
+        return {
+            "commit": "unknown",
+            "commit_short": "unknown",
+            "branch": "unknown",
+            "is_clean": False,
+        }
+
+
+def _environment_info() -> dict[str, Any]:
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "numpy": np.__version__,
+        "matplotlib": matplotlib.__version__,
+    }
 
 
 def _mean(values: list[float]) -> float:
@@ -420,15 +458,9 @@ def _run_feature_mean_rows(
 def _seed_effect_rows(
     run_means: list[dict[str, Any]], *, qc_scope: str
 ) -> list[dict[str, Any]]:
-    if qc_scope == "strict_run_and_windows":
-        run_means = [
-            row
-            for row in run_means
-            if bool(row["run_shape_pass"]) and bool(row["all_windows_shape_pass"])
-        ]
-    elif qc_scope != "all_labeled":
+    if qc_scope not in {"all_labeled", "strict_run_and_windows"}:
         raise ValueError(f"Unsupported seed-effect QC scope: {qc_scope}")
-    groups: dict[tuple[Any, ...], list[tuple[int, int, float]]] = {}
+    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
     for row in run_means:
         key = (
             row["domain"],
@@ -437,13 +469,7 @@ def _seed_effect_rows(
             row["n_flagella"],
             row["feature"],
         )
-        groups.setdefault(key, []).append(
-            (
-                int(row["attach_seed"]),
-                int(row["phase_seed"]),
-                float(row["run_mean"]),
-            )
-        )
+        groups.setdefault(key, []).append(row)
 
     output: list[dict[str, Any]] = []
     for (
@@ -452,23 +478,63 @@ def _seed_effect_rows(
         actual,
         n_flagella,
         feature,
-    ), values in sorted(groups.items()):
+    ), all_rows in sorted(groups.items()):
+        expected_attach_levels = sorted({int(row["attach_seed"]) for row in all_rows})
+        expected_phase_levels = sorted({int(row["phase_seed"]) for row in all_rows})
+        selected_rows = (
+            [
+                row
+                for row in all_rows
+                if bool(row["run_shape_pass"]) and bool(row["all_windows_shape_pass"])
+            ]
+            if qc_scope == "strict_run_and_windows"
+            else all_rows
+        )
+        values = [
+            (
+                int(row["attach_seed"]),
+                int(row["phase_seed"]),
+                float(row["run_mean"]),
+            )
+            for row in selected_rows
+        ]
+        if not values:
+            continue
         observed = np.asarray([value for _, _, value in values], dtype=float)
         grand = float(np.mean(observed))
         total_ss = float(np.sum((observed - grand) ** 2))
-        attach_levels = sorted({attach for attach, _, _ in values})
-        phase_levels = sorted({phase for _, phase, _ in values})
-        attach_ss = sum(
-            sum(1 for a, _, _ in values if a == attach)
-            * (np.mean([value for a, _, value in values if a == attach]) - grand) ** 2
-            for attach in attach_levels
+        observed_cells = {(attach, phase) for attach, phase, _ in values}
+        expected_cells = {
+            (attach, phase)
+            for attach in expected_attach_levels
+            for phase in expected_phase_levels
+        }
+        factorial_complete = (
+            len(values) == len(expected_cells) and observed_cells == expected_cells
         )
-        phase_ss = sum(
-            sum(1 for _, p, _ in values if p == phase)
-            * (np.mean([value for _, p, value in values if p == phase]) - grand) ** 2
-            for phase in phase_levels
-        )
-        residual_ss = max(total_ss - float(attach_ss) - float(phase_ss), 0.0)
+        attach_eta: float | None = None
+        phase_eta: float | None = None
+        residual_eta: float | None = None
+        if factorial_complete:
+            attach_ss = sum(
+                sum(1 for a, _, _ in values if a == attach)
+                * (np.mean([value for a, _, value in values if a == attach]) - grand)
+                ** 2
+                for attach in expected_attach_levels
+            )
+            phase_ss = sum(
+                sum(1 for _, p, _ in values if p == phase)
+                * (np.mean([value for _, p, value in values if p == phase]) - grand)
+                ** 2
+                for phase in expected_phase_levels
+            )
+            residual_ss = max(total_ss - float(attach_ss) - float(phase_ss), 0.0)
+            if total_ss > 0.0:
+                attach_eta = float(attach_ss / total_ss)
+                phase_eta = float(phase_ss / total_ss)
+                residual_eta = residual_ss / total_ss
+            else:
+                attach_eta = phase_eta = residual_eta = 0.0
         output.append(
             {
                 "domain": domain,
@@ -478,23 +544,16 @@ def _seed_effect_rows(
                 "actual_duration_s": actual,
                 "n_flagella": n_flagella,
                 "run_count": len(values),
-                "attach_level_count": len(attach_levels),
-                "phase_level_count": len(phase_levels),
-                "factorial_complete": len(values)
-                == len(attach_levels) * len(phase_levels),
+                "attach_level_count": len(expected_attach_levels),
+                "phase_level_count": len(expected_phase_levels),
+                "factorial_complete": factorial_complete,
                 "mean": grand,
                 "between_run_std": float(np.std(observed, ddof=1))
                 if len(observed) > 1
                 else 0.0,
-                "attach_eta_squared": float(attach_ss / total_ss)
-                if total_ss > 0.0
-                else 0.0,
-                "phase_eta_squared": float(phase_ss / total_ss)
-                if total_ss > 0.0
-                else 0.0,
-                "residual_eta_squared": residual_ss / total_ss
-                if total_ss > 0.0
-                else 0.0,
+                "attach_eta_squared": attach_eta,
+                "phase_eta_squared": phase_eta,
+                "residual_eta_squared": residual_eta,
             }
         )
     return output
@@ -878,14 +937,39 @@ def analyze_duration_seed_study(cfg: DurationStudyConfig) -> Path:
     for row in rows_2d:
         key = f"{float(row['requested_duration_s']):g}"
         window_counts[key] = window_counts.get(key, 0) + 1
+    created_at = datetime.now(ZoneInfo("Asia/Tokyo")).isoformat()
+    attach_seeds = sorted({int(row["attach_seed"]) for row in eligible_samples})
+    phase_seeds = sorted({int(row["phase_seed"]) for row in eligible_samples})
     manifest = {
-        "created_at": datetime.now(ZoneInfo("Asia/Tokyo")).isoformat(),
+        "pipeline_name": "phase4_duration_seed_study",
+        "created_at": created_at,
         "dataset_dir": str(cfg.dataset_dir),
         "dataset_version": dataset_version,
         "dataset_revision": dataset_revision,
         "durations_s_requested": list(cfg.durations_s),
         "frame_rate_hz": cfg.frame_rate_hz,
         "body_centered_2d": True,
+        "study": {
+            "allowed_n_flagella": list(cfg.allowed_n_flagella),
+            "durations_s": list(cfg.durations_s),
+        },
+        "clip": {
+            "frame_rate_hz": cfg.frame_rate_hz,
+            "crop_size_px": cfg.crop_size_px,
+            "pixel_size_um": cfg.pixel_size_um,
+        },
+        "seeds": {
+            "attach": attach_seeds,
+            "phase": phase_seeds,
+        },
+        "invocation": {
+            "config_path": str(cfg.config_path) if cfg.config_path else None,
+            "cli_overrides": list(cfg.cli_overrides),
+        },
+        "source_dataset_manifest": {
+            "path": str(dataset_manifest_path),
+            "git": dataset_manifest.get("git"),
+        },
         "independent_unit": "run_id / group_key",
         "within_run_windows_are_independent": False,
         "sample_count": len(eligible_samples),
@@ -897,8 +981,27 @@ def analyze_duration_seed_study(cfg: DurationStudyConfig) -> Path:
             "seed_effects_csv": str(seed_effects_path),
             "plots": plot_paths,
         },
+        "git": _git_info(),
+        "environment": _environment_info(),
     }
     (cfg.output_dir / "manifest.json").write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (cfg.output_dir / "run.log").write_text(
+        "\n".join(
+            [
+                f"created_at={created_at}",
+                f"config_path={manifest['invocation']['config_path']}",
+                f"cli_overrides={json.dumps(list(cfg.cli_overrides))}",
+                f"dataset_dir={cfg.dataset_dir}",
+                f"output_dir={cfg.output_dir}",
+                f"attach_seeds={attach_seeds}",
+                f"phase_seeds={phase_seeds}",
+                f"sample_count={len(eligible_samples)}",
+                f"git_commit={manifest['git']['commit']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
     )
     return cfg.output_dir

--- a/src/flagella_estimation/phase4/duration_study.py
+++ b/src/flagella_estimation/phase4/duration_study.py
@@ -516,13 +516,19 @@ def _plot_seed_heatmaps(
             durations = sorted(
                 {float(row["requested_duration_s"]) for row in matching_feature}
             )
-            for duration in durations:
+            classes = sorted({int(row["n_flagella"]) for row in matching_feature})
+            figure, axes = plt.subplots(
+                len(durations),
+                len(classes),
+                figsize=(4.2 * len(classes), 3.6 * len(durations)),
+                squeeze=False,
+            )
+            for duration_index, duration in enumerate(durations):
                 duration_rows = [
                     row
                     for row in matching_feature
                     if float(row["requested_duration_s"]) == duration
                 ]
-                classes = sorted({int(row["n_flagella"]) for row in duration_rows})
                 observed = np.asarray(
                     [float(row["run_mean"]) for row in duration_rows], dtype=float
                 )
@@ -530,19 +536,17 @@ def _plot_seed_heatmaps(
                 vmax = float(np.max(observed))
                 if math.isclose(vmin, vmax):
                     vmax = vmin + 1.0
-                figure, axes = plt.subplots(
-                    1,
-                    len(classes),
-                    figsize=(4.2 * len(classes), 3.8),
-                    squeeze=False,
-                )
                 image = None
-                for axis, n_flagella in zip(axes[0], classes, strict=True):
+                for class_index, n_flagella in enumerate(classes):
+                    axis = axes[duration_index, class_index]
                     class_rows = [
                         row
                         for row in duration_rows
                         if int(row["n_flagella"]) == n_flagella
                     ]
+                    if not class_rows:
+                        axis.set_visible(False)
+                        continue
                     attach_levels = sorted(
                         {int(row["attach_seed"]) for row in class_rows}
                     )
@@ -579,16 +583,19 @@ def _plot_seed_heatmaps(
                     axis.set_yticks(range(len(attach_levels)), attach_levels)
                     axis.set_xlabel("phase seed")
                     axis.set_ylabel("attach seed")
-                    axis.set_title(f"n={n_flagella}")
+                    axis.set_title(f"requested {duration:g} s, n={n_flagella}")
                 if image is not None:
-                    figure.colorbar(image, ax=list(axes[0]), shrink=0.8)
-                figure.suptitle(f"{feature}, requested {duration:g} s (! = QC fail)")
-                path = output_dir / (
-                    f"{domain}_{feature}_seed_heatmap_{duration:g}s.png"
-                )
-                figure.savefig(path, dpi=150, bbox_inches="tight")
-                plt.close(figure)
-                paths.append(str(path))
+                    figure.colorbar(
+                        image,
+                        ax=list(axes[duration_index]),
+                        shrink=0.8,
+                        label=f"{duration:g} s scale",
+                    )
+            figure.suptitle(f"{feature} by duration and seed (! = QC fail)")
+            path = output_dir / f"{domain}_{feature}_seed_heatmap.png"
+            figure.savefig(path, dpi=150, bbox_inches="tight")
+            plt.close(figure)
+            paths.append(str(path))
     return paths
 
 
@@ -604,7 +611,11 @@ def _plot_time_features(
     colors = {1: "#0072B2", 2: "#D55E00", 3: "#009E73"}
     for feature in features:
         figure, axes = plt.subplots(
-            1, len(durations), figsize=(5.0 * len(durations), 4.0), squeeze=False
+            1,
+            len(durations),
+            figsize=(5.0 * len(durations), 4.0),
+            squeeze=False,
+            sharey=True,
         )
         for axis, duration in zip(axes[0], durations, strict=True):
             duration_rows = [

--- a/src/flagella_estimation/phase4/duration_study.py
+++ b/src/flagella_estimation/phase4/duration_study.py
@@ -1,0 +1,893 @@
+"""Window-duration and seed-effect analysis for Phase 4 pseudo clips."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import math
+from pathlib import Path
+import shutil
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import yaml
+
+from flagella_estimation.phase3.render import render_clip_array, select_frames
+from flagella_estimation.phase3.windows import generate_windows
+from flagella_estimation.phase4.baseline import FEATURE_NAMES, extract_clip_features
+from sim_swim.analysis.flagella_count_behavior import load_state_archive
+
+
+THREE_D_FEATURE_NAMES = (
+    "cell_displacement_um",
+    "cell_path_length_um",
+    "cell_mean_speed_um_s",
+    "cell_speed_std_um_s",
+    "cell_speed_cv",
+    "cell_straightness",
+    "cell_angular_velocity_mean_rad_s",
+    "cell_angular_velocity_std_rad_s",
+    "cell_angular_velocity_rms_rad_s",
+    "body_axis_angle_change_deg",
+    "flagella_axis_alignment_mean",
+    "cell_flagella_axis_angle_mean_deg",
+    "cell_flagella_axis_angle_std_deg",
+    "hook_len_rel_err_max",
+)
+
+PLOT_FEATURES = {
+    "3d": (
+        "cell_mean_speed_um_s",
+        "cell_angular_velocity_rms_rad_s",
+        "flagella_axis_alignment_mean",
+    ),
+    "2d": (
+        "temporal_diff_mean",
+        "centroid_step_mean",
+        "radial_spread_mean",
+    ),
+}
+
+COMMON_FIELDS = (
+    "sample_id",
+    "run_id",
+    "group_key",
+    "dataset_id",
+    "dataset_version",
+    "dataset_revision",
+    "n_flagella",
+    "attach_seed",
+    "phase_seed",
+    "requested_duration_s",
+    "actual_duration_s",
+    "window_index",
+    "frame_count",
+    "frame_rate_hz",
+    "t_start_s",
+    "t_end_s",
+    "run_quality_class",
+    "run_shape_pass",
+    "run_relaxed_pass",
+    "window_quality_class",
+    "window_shape_pass",
+    "window_relaxed_pass",
+    "window_first_fail_t_s",
+    "window_first_fail_category",
+)
+
+
+@dataclass(frozen=True)
+class DurationStudyConfig:
+    dataset_dir: Path
+    output_dir: Path
+    durations_s: tuple[float, ...] = (0.25, 0.5, 1.0)
+    frame_rate_hz: float = 25.0
+    crop_size_px: int = 96
+    pixel_size_um: float = 0.1
+    allowed_n_flagella: tuple[int, ...] = (1, 2, 3)
+    overwrite: bool = False
+
+
+def default_output_dir() -> Path:
+    now = datetime.now(ZoneInfo("Asia/Tokyo"))
+    return (
+        Path("outputs")
+        / now.strftime("%Y-%m-%d")
+        / now.strftime("%H%M%S")
+        / "phase4_duration_seed_study"
+    )
+
+
+def _coerce_override(raw: str) -> tuple[list[str], Any]:
+    if "=" not in raw:
+        raise ValueError(f"Invalid override; expected KEY=VALUE: {raw}")
+    key, value = raw.split("=", 1)
+    parts = key.strip().split(".")
+    if not all(parts):
+        raise ValueError(f"Invalid override path: {raw}")
+    return parts, yaml.safe_load(value)
+
+
+def load_duration_study_config(
+    path: Path | None, overrides: list[str] | None = None
+) -> DurationStudyConfig:
+    data = (
+        yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if path is not None
+        else {}
+    )
+    for raw in overrides or []:
+        parts, value = _coerce_override(raw)
+        node = data
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+            if not isinstance(node, dict):
+                raise ValueError(f"Override path conflicts with scalar: {raw}")
+        node[parts[-1]] = value
+    clip = dict(data.get("clip", {}) or {})
+    study = dict(data.get("study", {}) or {})
+    output_dir = data.get("output_dir")
+    return DurationStudyConfig(
+        dataset_dir=Path(str(data.get("dataset_dir", ""))),
+        output_dir=Path(str(output_dir)) if output_dir else default_output_dir(),
+        durations_s=tuple(
+            float(value) for value in study.get("durations_s", [0.25, 0.5, 1.0])
+        ),
+        frame_rate_hz=float(clip.get("frame_rate_hz", 25.0)),
+        crop_size_px=int(clip.get("crop_size_px", 96)),
+        pixel_size_um=float(clip.get("pixel_size_um", 0.1)),
+        allowed_n_flagella=tuple(
+            int(value) for value in study.get("allowed_n_flagella", [1, 2, 3])
+        ),
+        overwrite=bool(data.get("overwrite", False)),
+    )
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_csv(
+    path: Path, rows: list[dict[str, Any]], fieldnames: tuple[str, ...] | list[str]
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _to_float(value: Any, default: float = float("nan")) -> float:
+    try:
+        if value in (None, ""):
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def _mean(values: list[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    return float(np.mean(finite)) if finite else float("nan")
+
+
+def _std(values: list[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    if not finite:
+        return float("nan")
+    return float(np.std(finite, ddof=1)) if len(finite) > 1 else 0.0
+
+
+def _body_axis(quaternion: tuple[float, float, float, float]) -> np.ndarray:
+    x, y, z, w = np.asarray(quaternion, dtype=float)
+    norm = math.sqrt(x * x + y * y + z * z + w * w)
+    if not math.isfinite(norm) or norm <= 0.0:
+        return np.full(3, np.nan)
+    x, y, z, w = (x / norm, y / norm, z / norm, w / norm)
+    return np.asarray(
+        [
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y + z * w),
+            2.0 * (x * z - y * w),
+        ],
+        dtype=float,
+    )
+
+
+def _angle_deg(first: np.ndarray, last: np.ndarray) -> float:
+    if not np.isfinite(first).all() or not np.isfinite(last).all():
+        return float("nan")
+    denominator = float(np.linalg.norm(first) * np.linalg.norm(last))
+    if denominator <= 0.0:
+        return float("nan")
+    cosine = float(np.clip(np.dot(first, last) / denominator, -1.0, 1.0))
+    return float(np.rad2deg(np.arccos(cosine)))
+
+
+def summarize_states_3d(states: list[Any]) -> dict[str, float]:
+    if len(states) < 2:
+        return {name: float("nan") for name in THREE_D_FEATURE_NAMES}
+    positions = np.asarray([state.position_um for state in states], dtype=float)
+    velocities = np.asarray([state.velocity_um_s for state in states], dtype=float)
+    omega = np.linalg.norm(
+        np.asarray([state.omega_rad_s for state in states], dtype=float), axis=1
+    )
+    segments = np.linalg.norm(np.diff(positions, axis=0), axis=1)
+    displacement = float(np.linalg.norm(positions[-1] - positions[0]))
+    path_length = float(np.sum(segments))
+    speed = np.linalg.norm(velocities, axis=1)
+    speed_mean = float(np.mean(speed))
+    speed_std = float(np.std(speed, ddof=1)) if len(speed) > 1 else 0.0
+    result = {
+        "cell_displacement_um": displacement,
+        "cell_path_length_um": path_length,
+        "cell_mean_speed_um_s": speed_mean,
+        "cell_speed_std_um_s": speed_std,
+        "cell_speed_cv": speed_std / speed_mean
+        if abs(speed_mean) > 1.0e-30
+        else float("nan"),
+        "cell_straightness": displacement / path_length
+        if path_length > 0.0
+        else float("nan"),
+        "cell_angular_velocity_mean_rad_s": float(np.mean(omega)),
+        "cell_angular_velocity_std_rad_s": float(np.std(omega, ddof=1))
+        if len(omega) > 1
+        else 0.0,
+        "cell_angular_velocity_rms_rad_s": float(np.sqrt(np.mean(omega**2))),
+        "body_axis_angle_change_deg": _angle_deg(
+            _body_axis(states[0].quaternion), _body_axis(states[-1].quaternion)
+        ),
+    }
+    return result
+
+
+def _step_rows_for_window(
+    rows: list[dict[str, str]], *, start_s: float, end_s: float
+) -> list[dict[str, str]]:
+    return [
+        row
+        for row in rows
+        if start_s - 1.0e-12 <= _to_float(row.get("t_s")) < end_s - 1.0e-12
+    ]
+
+
+def _window_quality(rows: list[dict[str, str]]) -> dict[str, Any]:
+    if not rows:
+        return {
+            "window_quality_class": "missing",
+            "window_shape_pass": False,
+            "window_relaxed_pass": False,
+            "window_first_fail_t_s": float("nan"),
+            "window_first_fail_category": "missing",
+        }
+    finite_pass = all(_to_bool(row.get("finite_pass")) for row in rows)
+    shape_pass = finite_pass and all(
+        _to_bool(row.get("shape_pass_nonbody_strict")) for row in rows
+    )
+    relaxed_pass = finite_pass and all(
+        _to_bool(row.get("shape_pass_nonbody_hook_len_relaxed")) for row in rows
+    )
+    failed = next(
+        (
+            row
+            for row in rows
+            if not _to_bool(row.get("finite_pass"))
+            or not _to_bool(row.get("shape_pass_nonbody_strict"))
+        ),
+        None,
+    )
+    if not finite_pass:
+        quality_class = "invalid_numeric"
+    elif shape_pass:
+        quality_class = "strict_pass"
+    elif relaxed_pass:
+        quality_class = "relaxed_pass"
+    else:
+        quality_class = "fail"
+    return {
+        "window_quality_class": quality_class,
+        "window_shape_pass": shape_pass,
+        "window_relaxed_pass": relaxed_pass,
+        "window_first_fail_t_s": _to_float(failed.get("t_s"))
+        if failed
+        else float("nan"),
+        "window_first_fail_category": str(
+            failed.get("first_fail_category_nonbody_strict")
+            or failed.get("first_fail_category_nonbody")
+            or "unknown"
+        )
+        if failed
+        else "none",
+    }
+
+
+def _step_features(rows: list[dict[str, str]]) -> dict[str, float]:
+    relation = [
+        _to_float(row.get("bundle_axis_vs_body_axis_angle_deg")) for row in rows
+    ]
+    hook_error = [_to_float(row.get("hook_len_rel_err_max")) for row in rows]
+    finite_hook = [value for value in hook_error if math.isfinite(value)]
+    return {
+        "flagella_axis_alignment_mean": _mean(
+            [_to_float(row.get("flag_helix_axis_alignment_order")) for row in rows]
+        ),
+        "cell_flagella_axis_angle_mean_deg": _mean(relation),
+        "cell_flagella_axis_angle_std_deg": _std(relation),
+        "hook_len_rel_err_max": max(finite_hook) if finite_hook else float("nan"),
+    }
+
+
+def _common_row(
+    sample: dict[str, str],
+    *,
+    requested_duration_s: float,
+    actual_duration_s: float,
+    window_index: int,
+    frame_count: int,
+    frame_rate_hz: float,
+    t_start_s: float,
+    t_end_s: float,
+    quality: dict[str, Any],
+    dataset_version: str,
+    dataset_revision: str,
+) -> dict[str, Any]:
+    sample_id = str(sample["sample_id"])
+    return {
+        "sample_id": sample_id,
+        "run_id": sample_id,
+        "group_key": f"phase2:v1:{sample_id}",
+        "dataset_id": sample.get("dataset_id", ""),
+        "dataset_version": dataset_version,
+        "dataset_revision": dataset_revision,
+        "n_flagella": int(_to_float(sample.get("n_flagella"))),
+        "attach_seed": int(_to_float(sample.get("attach_seed"))),
+        "phase_seed": int(_to_float(sample.get("phase_seed"))),
+        "requested_duration_s": requested_duration_s,
+        "actual_duration_s": actual_duration_s,
+        "window_index": window_index,
+        "frame_count": frame_count,
+        "frame_rate_hz": frame_rate_hz,
+        "t_start_s": t_start_s,
+        "t_end_s": t_end_s,
+        "run_quality_class": sample.get("quality_class", ""),
+        "run_shape_pass": _to_bool(sample.get("shape_pass")),
+        "run_relaxed_pass": _to_bool(sample.get("relaxed_pass")),
+        **quality,
+    }
+
+
+def _run_feature_mean_rows(
+    rows: list[dict[str, Any]], feature_names: tuple[str, ...], domain: str
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[Any, ...], list[tuple[float, bool]]] = {}
+    for row in rows:
+        for feature in feature_names:
+            value = _to_float(row.get(feature))
+            if not math.isfinite(value):
+                continue
+            key = (
+                row["requested_duration_s"],
+                row["actual_duration_s"],
+                row["n_flagella"],
+                row["attach_seed"],
+                row["phase_seed"],
+                feature,
+            )
+            grouped.setdefault(key, []).append((value, bool(row["window_shape_pass"])))
+    output: list[dict[str, Any]] = []
+    for key, values in sorted(grouped.items()):
+        requested, actual, n_flagella, attach_seed, phase_seed, feature = key
+        sample = next(
+            row
+            for row in rows
+            if row["requested_duration_s"] == requested
+            and row["actual_duration_s"] == actual
+            and row["n_flagella"] == n_flagella
+            and row["attach_seed"] == attach_seed
+            and row["phase_seed"] == phase_seed
+        )
+        output.append(
+            {
+                "domain": domain,
+                "feature": feature,
+                "requested_duration_s": requested,
+                "actual_duration_s": actual,
+                "n_flagella": n_flagella,
+                "attach_seed": attach_seed,
+                "phase_seed": phase_seed,
+                "run_id": sample["run_id"],
+                "run_shape_pass": sample["run_shape_pass"],
+                "all_windows_shape_pass": all(passed for _, passed in values),
+                "window_count": len(values),
+                "run_mean": float(np.mean([value for value, _ in values])),
+            }
+        )
+    return output
+
+
+def _seed_effect_rows(
+    run_means: list[dict[str, Any]], *, qc_scope: str
+) -> list[dict[str, Any]]:
+    if qc_scope == "strict_run_and_windows":
+        run_means = [
+            row
+            for row in run_means
+            if bool(row["run_shape_pass"]) and bool(row["all_windows_shape_pass"])
+        ]
+    elif qc_scope != "all_labeled":
+        raise ValueError(f"Unsupported seed-effect QC scope: {qc_scope}")
+    groups: dict[tuple[Any, ...], list[tuple[int, int, float]]] = {}
+    for row in run_means:
+        key = (
+            row["domain"],
+            row["requested_duration_s"],
+            row["actual_duration_s"],
+            row["n_flagella"],
+            row["feature"],
+        )
+        groups.setdefault(key, []).append(
+            (
+                int(row["attach_seed"]),
+                int(row["phase_seed"]),
+                float(row["run_mean"]),
+            )
+        )
+
+    output: list[dict[str, Any]] = []
+    for (
+        domain,
+        requested,
+        actual,
+        n_flagella,
+        feature,
+    ), values in sorted(groups.items()):
+        observed = np.asarray([value for _, _, value in values], dtype=float)
+        grand = float(np.mean(observed))
+        total_ss = float(np.sum((observed - grand) ** 2))
+        attach_levels = sorted({attach for attach, _, _ in values})
+        phase_levels = sorted({phase for _, phase, _ in values})
+        attach_ss = sum(
+            sum(1 for a, _, _ in values if a == attach)
+            * (np.mean([value for a, _, value in values if a == attach]) - grand) ** 2
+            for attach in attach_levels
+        )
+        phase_ss = sum(
+            sum(1 for _, p, _ in values if p == phase)
+            * (np.mean([value for _, p, value in values if p == phase]) - grand) ** 2
+            for phase in phase_levels
+        )
+        residual_ss = max(total_ss - float(attach_ss) - float(phase_ss), 0.0)
+        output.append(
+            {
+                "domain": domain,
+                "qc_scope": qc_scope,
+                "feature": feature,
+                "requested_duration_s": requested,
+                "actual_duration_s": actual,
+                "n_flagella": n_flagella,
+                "run_count": len(values),
+                "attach_level_count": len(attach_levels),
+                "phase_level_count": len(phase_levels),
+                "factorial_complete": len(values)
+                == len(attach_levels) * len(phase_levels),
+                "mean": grand,
+                "between_run_std": float(np.std(observed, ddof=1))
+                if len(observed) > 1
+                else 0.0,
+                "attach_eta_squared": float(attach_ss / total_ss)
+                if total_ss > 0.0
+                else 0.0,
+                "phase_eta_squared": float(phase_ss / total_ss)
+                if total_ss > 0.0
+                else 0.0,
+                "residual_eta_squared": residual_ss / total_ss
+                if total_ss > 0.0
+                else 0.0,
+            }
+        )
+    return output
+
+
+def _plot_seed_heatmaps(
+    run_means: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+) -> list[str]:
+    paths: list[str] = []
+    for domain, features in PLOT_FEATURES.items():
+        for feature in features:
+            matching_feature = [
+                row
+                for row in run_means
+                if row["domain"] == domain and row["feature"] == feature
+            ]
+            durations = sorted(
+                {float(row["requested_duration_s"]) for row in matching_feature}
+            )
+            for duration in durations:
+                duration_rows = [
+                    row
+                    for row in matching_feature
+                    if float(row["requested_duration_s"]) == duration
+                ]
+                classes = sorted({int(row["n_flagella"]) for row in duration_rows})
+                observed = np.asarray(
+                    [float(row["run_mean"]) for row in duration_rows], dtype=float
+                )
+                vmin = float(np.min(observed))
+                vmax = float(np.max(observed))
+                if math.isclose(vmin, vmax):
+                    vmax = vmin + 1.0
+                figure, axes = plt.subplots(
+                    1,
+                    len(classes),
+                    figsize=(4.2 * len(classes), 3.8),
+                    squeeze=False,
+                )
+                image = None
+                for axis, n_flagella in zip(axes[0], classes, strict=True):
+                    class_rows = [
+                        row
+                        for row in duration_rows
+                        if int(row["n_flagella"]) == n_flagella
+                    ]
+                    attach_levels = sorted(
+                        {int(row["attach_seed"]) for row in class_rows}
+                    )
+                    phase_levels = sorted(
+                        {int(row["phase_seed"]) for row in class_rows}
+                    )
+                    matrix = np.full(
+                        (len(attach_levels), len(phase_levels)), np.nan, dtype=float
+                    )
+                    strict = np.zeros_like(matrix, dtype=bool)
+                    for row in class_rows:
+                        attach_index = attach_levels.index(int(row["attach_seed"]))
+                        phase_index = phase_levels.index(int(row["phase_seed"]))
+                        matrix[attach_index, phase_index] = float(row["run_mean"])
+                        strict[attach_index, phase_index] = bool(
+                            row["run_shape_pass"]
+                        ) and bool(row["all_windows_shape_pass"])
+                    image = axis.imshow(matrix, vmin=vmin, vmax=vmax, cmap="viridis")
+                    for row_index in range(matrix.shape[0]):
+                        for column_index in range(matrix.shape[1]):
+                            if not math.isfinite(matrix[row_index, column_index]):
+                                continue
+                            suffix = "" if strict[row_index, column_index] else " !"
+                            axis.text(
+                                column_index,
+                                row_index,
+                                f"{matrix[row_index, column_index]:.3g}{suffix}",
+                                ha="center",
+                                va="center",
+                                color="white",
+                                fontsize=8,
+                            )
+                    axis.set_xticks(range(len(phase_levels)), phase_levels)
+                    axis.set_yticks(range(len(attach_levels)), attach_levels)
+                    axis.set_xlabel("phase seed")
+                    axis.set_ylabel("attach seed")
+                    axis.set_title(f"n={n_flagella}")
+                if image is not None:
+                    figure.colorbar(image, ax=list(axes[0]), shrink=0.8)
+                figure.suptitle(f"{feature}, requested {duration:g} s (! = QC fail)")
+                path = output_dir / (
+                    f"{domain}_{feature}_seed_heatmap_{duration:g}s.png"
+                )
+                figure.savefig(path, dpi=150, bbox_inches="tight")
+                plt.close(figure)
+                paths.append(str(path))
+    return paths
+
+
+def _plot_time_features(
+    rows: list[dict[str, Any]],
+    *,
+    domain: str,
+    features: tuple[str, ...],
+    output_dir: Path,
+) -> list[str]:
+    paths: list[str] = []
+    durations = sorted({float(row["requested_duration_s"]) for row in rows})
+    colors = {1: "#0072B2", 2: "#D55E00", 3: "#009E73"}
+    for feature in features:
+        figure, axes = plt.subplots(
+            1, len(durations), figsize=(5.0 * len(durations), 4.0), squeeze=False
+        )
+        for axis, duration in zip(axes[0], durations, strict=True):
+            duration_rows = [
+                row for row in rows if float(row["requested_duration_s"]) == duration
+            ]
+            for n_flagella in sorted({int(row["n_flagella"]) for row in duration_rows}):
+                class_rows = [
+                    row for row in duration_rows if int(row["n_flagella"]) == n_flagella
+                ]
+                by_run: dict[str, list[dict[str, Any]]] = {}
+                for row in class_rows:
+                    by_run.setdefault(str(row["run_id"]), []).append(row)
+                for run_rows in by_run.values():
+                    run_rows.sort(key=lambda row: float(row["t_start_s"]))
+                    axis.plot(
+                        [float(row["t_start_s"]) for row in run_rows],
+                        [_to_float(row.get(feature)) for row in run_rows],
+                        color=colors.get(n_flagella, "#666666"),
+                        alpha=0.22,
+                        linewidth=0.8,
+                    )
+                time_values = sorted({float(row["t_start_s"]) for row in class_rows})
+                means = [
+                    _mean(
+                        [
+                            _to_float(row.get(feature))
+                            for row in class_rows
+                            if math.isclose(
+                                float(row["t_start_s"]), time_value, abs_tol=1.0e-9
+                            )
+                        ]
+                    )
+                    for time_value in time_values
+                ]
+                axis.plot(
+                    time_values,
+                    means,
+                    color=colors.get(n_flagella, "#666666"),
+                    linewidth=2.2,
+                    marker="o",
+                    markersize=3,
+                    label=f"n={n_flagella}",
+                )
+            failed_rows = [
+                row
+                for row in duration_rows
+                if not bool(row["window_shape_pass"])
+                and math.isfinite(_to_float(row.get(feature)))
+            ]
+            if failed_rows:
+                axis.scatter(
+                    [float(row["t_start_s"]) for row in failed_rows],
+                    [_to_float(row.get(feature)) for row in failed_rows],
+                    marker="x",
+                    color="#111111",
+                    s=18,
+                    linewidths=0.8,
+                    label="QC fail" if axis is axes[0, 0] else None,
+                )
+            axis.set_title(f"requested {duration:g} s")
+            axis.set_xlabel("window start (s)")
+            axis.set_ylabel(feature)
+            axis.grid(alpha=0.25)
+        axes[0, 0].legend(frameon=False)
+        figure.tight_layout()
+        path = output_dir / f"{domain}_{feature}_by_time.png"
+        figure.savefig(path, dpi=150)
+        plt.close(figure)
+        paths.append(str(path))
+    return paths
+
+
+def analyze_duration_seed_study(cfg: DurationStudyConfig) -> Path:
+    summary_path = cfg.dataset_dir / "summary.csv"
+    if not summary_path.is_file():
+        raise FileNotFoundError(summary_path)
+    if cfg.output_dir.exists():
+        if not cfg.overwrite:
+            raise FileExistsError(cfg.output_dir)
+        shutil.rmtree(cfg.output_dir)
+    cfg.output_dir.mkdir(parents=True)
+    plots_dir = cfg.output_dir / "plots"
+    plots_dir.mkdir()
+
+    dataset_manifest_path = cfg.dataset_dir / "dataset_manifest.json"
+    dataset_manifest = (
+        json.loads(dataset_manifest_path.read_text(encoding="utf-8"))
+        if dataset_manifest_path.is_file()
+        else {}
+    )
+    effective = dataset_manifest.get("effective_campaign_config", {})
+    metadata = effective.get("metadata", {})
+    dataset_cfg = effective.get("dataset", {})
+    dataset_version = str(
+        dataset_cfg.get("dataset_version", metadata.get("dataset_version", "v1"))
+    )
+    dataset_revision = str(
+        dataset_cfg.get("dataset_revision", metadata.get("dataset_revision", ""))
+    )
+
+    rows_3d: list[dict[str, Any]] = []
+    rows_2d: list[dict[str, Any]] = []
+    eligible_samples = [
+        row
+        for row in _read_csv(summary_path)
+        if int(_to_float(row.get("n_flagella"), default=-1)) in cfg.allowed_n_flagella
+    ]
+    if not eligible_samples:
+        raise ValueError("No eligible samples found")
+
+    for sample in eligible_samples:
+        raw_dir = Path(str(sample.get("raw_dir", "")))
+        archive_path = raw_dir / "state_archive.npz"
+        step_path = raw_dir / "step_summary.csv"
+        if not archive_path.is_file():
+            raise FileNotFoundError(archive_path)
+        if not step_path.is_file():
+            raise FileNotFoundError(step_path)
+        states_all = load_state_archive(archive_path)
+        states_2d = select_frames(states_all, cfg.frame_rate_hz)
+        step_rows = _read_csv(step_path)
+        for requested_duration in cfg.durations_s:
+            windows = generate_windows(
+                source_frame_count=len(states_2d),
+                frame_rate_hz=cfg.frame_rate_hz,
+                duration_s=requested_duration,
+                policy="non_overlap",
+            )
+            for window_index, window in enumerate(windows):
+                frame_states = states_2d[window.start : window.end]
+                if not frame_states:
+                    continue
+                actual_duration = window.frame_count / cfg.frame_rate_hz
+                t_start = float(frame_states[0].t)
+                t_end = t_start + actual_duration
+                raw_states = [
+                    state
+                    for state in states_all
+                    if t_start - 1.0e-12 <= float(state.t) < t_end - 1.0e-12
+                ]
+                step_window = _step_rows_for_window(
+                    step_rows, start_s=t_start, end_s=t_end
+                )
+                quality = _window_quality(step_window)
+                common = _common_row(
+                    sample,
+                    requested_duration_s=requested_duration,
+                    actual_duration_s=actual_duration,
+                    window_index=window_index,
+                    frame_count=window.frame_count,
+                    frame_rate_hz=cfg.frame_rate_hz,
+                    t_start_s=t_start,
+                    t_end_s=t_end,
+                    quality=quality,
+                    dataset_version=dataset_version,
+                    dataset_revision=dataset_revision,
+                )
+                rows_3d.append(
+                    {
+                        **common,
+                        **summarize_states_3d(raw_states),
+                        **_step_features(step_window),
+                    }
+                )
+                clip, _ = render_clip_array(
+                    frame_states,
+                    image_size_px=cfg.crop_size_px,
+                    pixel_size_um=cfg.pixel_size_um,
+                )
+                rows_2d.append(
+                    {
+                        **common,
+                        **dict(
+                            zip(
+                                FEATURE_NAMES,
+                                extract_clip_features(clip).tolist(),
+                                strict=True,
+                            )
+                        ),
+                    }
+                )
+
+    features_3d_path = cfg.output_dir / "window_features_3d.csv"
+    features_2d_path = cfg.output_dir / "window_features_2d.csv"
+    run_means_path = cfg.output_dir / "run_feature_means.csv"
+    seed_effects_path = cfg.output_dir / "seed_effects.csv"
+    _write_csv(
+        features_3d_path,
+        rows_3d,
+        [*COMMON_FIELDS, *THREE_D_FEATURE_NAMES],
+    )
+    _write_csv(
+        features_2d_path,
+        rows_2d,
+        [*COMMON_FIELDS, *FEATURE_NAMES],
+    )
+    run_mean_rows = [
+        *_run_feature_mean_rows(rows_3d, THREE_D_FEATURE_NAMES, "3d"),
+        *_run_feature_mean_rows(rows_2d, FEATURE_NAMES, "2d"),
+    ]
+    _write_csv(
+        run_means_path,
+        run_mean_rows,
+        [
+            "domain",
+            "feature",
+            "requested_duration_s",
+            "actual_duration_s",
+            "n_flagella",
+            "attach_seed",
+            "phase_seed",
+            "run_id",
+            "run_shape_pass",
+            "all_windows_shape_pass",
+            "window_count",
+            "run_mean",
+        ],
+    )
+    seed_rows = [
+        *(_seed_effect_rows(run_mean_rows, qc_scope="all_labeled")),
+        *(_seed_effect_rows(run_mean_rows, qc_scope="strict_run_and_windows")),
+    ]
+    _write_csv(
+        seed_effects_path,
+        seed_rows,
+        [
+            "domain",
+            "qc_scope",
+            "feature",
+            "requested_duration_s",
+            "actual_duration_s",
+            "n_flagella",
+            "run_count",
+            "attach_level_count",
+            "phase_level_count",
+            "factorial_complete",
+            "mean",
+            "between_run_std",
+            "attach_eta_squared",
+            "phase_eta_squared",
+            "residual_eta_squared",
+        ],
+    )
+    plot_paths = [
+        *_plot_time_features(
+            rows_3d,
+            domain="3d",
+            features=PLOT_FEATURES["3d"],
+            output_dir=plots_dir,
+        ),
+        *_plot_seed_heatmaps(run_mean_rows, output_dir=plots_dir),
+        *_plot_time_features(
+            rows_2d,
+            domain="2d",
+            features=PLOT_FEATURES["2d"],
+            output_dir=plots_dir,
+        ),
+    ]
+    window_counts: dict[str, int] = {}
+    for row in rows_2d:
+        key = f"{float(row['requested_duration_s']):g}"
+        window_counts[key] = window_counts.get(key, 0) + 1
+    manifest = {
+        "created_at": datetime.now(ZoneInfo("Asia/Tokyo")).isoformat(),
+        "dataset_dir": str(cfg.dataset_dir),
+        "dataset_version": dataset_version,
+        "dataset_revision": dataset_revision,
+        "durations_s_requested": list(cfg.durations_s),
+        "frame_rate_hz": cfg.frame_rate_hz,
+        "body_centered_2d": True,
+        "independent_unit": "run_id / group_key",
+        "within_run_windows_are_independent": False,
+        "sample_count": len(eligible_samples),
+        "window_counts_2d": window_counts,
+        "outputs": {
+            "window_features_3d_csv": str(features_3d_path),
+            "window_features_2d_csv": str(features_2d_path),
+            "run_feature_means_csv": str(run_means_path),
+            "seed_effects_csv": str(seed_effects_path),
+            "plots": plot_paths,
+        },
+    }
+    (cfg.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return cfg.output_dir

--- a/tests/test_phase4_duration_study.py
+++ b/tests/test_phase4_duration_study.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from pathlib import Path
+import subprocess
 
 import numpy as np
 import pytest
@@ -209,3 +211,43 @@ def test_duration_study_config_accepts_key_value_overrides(tmp_path: Path) -> No
     assert cfg.durations_s == (0.25, 0.5, 1.0)
     assert cfg.frame_rate_hz == pytest.approx(20.0)
     assert cfg.overwrite is True
+
+
+@pytest.mark.light
+def test_duration_study_shell_full_path_supports_empty_overwrite(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "${COMMAND_LOG}"\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "COMMAND_LOG": str(command_log),
+    }
+    script = (
+        Path(__file__).parents[1]
+        / "scripts"
+        / "04_phase4"
+        / "run_duration_seed_study.sh"
+    )
+
+    completed = subprocess.run(
+        ["bash", str(script), "full"],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    commands = command_log.read_text(encoding="utf-8").splitlines()
+    assert len(commands) == 3
+    assert all("overwrite=true" not in command for command in commands)

--- a/tests/test_phase4_duration_study.py
+++ b/tests/test_phase4_duration_study.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flagella_estimation.phase4.duration_study import (
+    DurationStudyConfig,
+    analyze_duration_seed_study,
+    load_duration_study_config,
+)
+from sim_swim.analysis.flagella_count_behavior import save_state_archive
+from sim_swim.sim.core import SimulationState
+
+
+def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_fixture(dataset_dir: Path) -> None:
+    summary_rows: list[dict[str, object]] = []
+    for attach_seed in (0, 1):
+        for phase_seed in (0, 1):
+            sample_id = f"nf01_as{attach_seed:03d}_ps{phase_seed:03d}"
+            raw_dir = dataset_dir / "raw" / sample_id
+            states = [
+                SimulationState(
+                    t=index * 0.1,
+                    position_um=(index * (0.01 + attach_seed * 0.002), 0.0, 0.0),
+                    quaternion=(0.0, 0.0, 0.0, 1.0),
+                    velocity_um_s=(0.1 + phase_seed * 0.02, 0.0, 0.0),
+                    omega_rad_s=(0.0, 0.0, 0.2 + attach_seed * 0.1),
+                    bead_positions_um=np.asarray(
+                        [[0.0, 0.0, 0.0], [0.5, 0.1 + phase_seed * 0.05, 0.0]]
+                    ),
+                )
+                for index in range(21)
+            ]
+            save_state_archive(raw_dir / "state_archive.npz", states)
+            step_rows = []
+            for index, state in enumerate(states):
+                strict_pass = not (
+                    attach_seed == 1 and phase_seed == 1 and state.t >= 1.0
+                )
+                step_rows.append(
+                    {
+                        "t_s": state.t,
+                        "finite_pass": True,
+                        "shape_pass_nonbody_strict": strict_pass,
+                        "shape_pass_nonbody_hook_len_relaxed": True,
+                        "first_fail_category_nonbody_strict": (
+                            "flag" if not strict_pass else "none"
+                        ),
+                        "flag_helix_axis_alignment_order": 0.7 + attach_seed * 0.1,
+                        "bundle_axis_vs_body_axis_angle_deg": 10.0 + phase_seed,
+                        "hook_len_rel_err_max": index * 0.001,
+                    }
+                )
+            _write_csv(raw_dir / "step_summary.csv", step_rows)
+            run_pass = not (attach_seed == 1 and phase_seed == 1)
+            summary_rows.append(
+                {
+                    "sample_id": sample_id,
+                    "dataset_id": "v1_r1_duration_3s",
+                    "n_flagella": 1,
+                    "attach_seed": attach_seed,
+                    "phase_seed": phase_seed,
+                    "quality_class": "strict_pass" if run_pass else "relaxed_pass",
+                    "shape_pass": run_pass,
+                    "relaxed_pass": True,
+                    "raw_dir": raw_dir,
+                }
+            )
+    _write_csv(dataset_dir / "summary.csv", summary_rows)
+    (dataset_dir / "dataset_manifest.json").write_text(
+        json.dumps(
+            {
+                "effective_campaign_config": {
+                    "metadata": {
+                        "dataset_version": "v1",
+                        "dataset_revision": "r1",
+                    },
+                    "dataset": {
+                        "dataset_version": "v1",
+                        "dataset_revision": "r1",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.light
+def test_duration_study_writes_window_qc_and_seed_artifacts(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    output_dir = tmp_path / "study"
+    _write_fixture(dataset_dir)
+
+    result = analyze_duration_seed_study(
+        DurationStudyConfig(
+            dataset_dir=dataset_dir,
+            output_dir=output_dir,
+            durations_s=(0.5, 1.0),
+            frame_rate_hz=2.0,
+            crop_size_px=32,
+            pixel_size_um=0.1,
+        )
+    )
+
+    assert result == output_dir
+    rows_3d = list(
+        csv.DictReader(
+            (output_dir / "window_features_3d.csv").open(
+                "r", encoding="utf-8", newline=""
+            )
+        )
+    )
+    rows_2d = list(
+        csv.DictReader(
+            (output_dir / "window_features_2d.csv").open(
+                "r", encoding="utf-8", newline=""
+            )
+        )
+    )
+    assert rows_3d and len(rows_3d) == len(rows_2d)
+    assert {row["dataset_revision"] for row in rows_3d} == {"r1"}
+    assert {row["group_key"] for row in rows_3d} == {
+        f"phase2:v1:nf01_as{attach:03d}_ps{phase:03d}"
+        for attach in (0, 1)
+        for phase in (0, 1)
+    }
+    failed = [
+        row
+        for row in rows_3d
+        if row["run_id"] == "nf01_as001_ps001" and float(row["t_start_s"]) >= 1.0
+    ]
+    assert failed
+    assert {row["window_shape_pass"] for row in failed} == {"False"}
+    assert {row["window_first_fail_category"] for row in failed} == {"flag"}
+
+    seed_rows = list(
+        csv.DictReader(
+            (output_dir / "seed_effects.csv").open("r", encoding="utf-8", newline="")
+        )
+    )
+    assert seed_rows
+    assert {row["qc_scope"] for row in seed_rows} == {
+        "all_labeled",
+        "strict_run_and_windows",
+    }
+    assert {
+        row["run_count"] for row in seed_rows if row["qc_scope"] == "all_labeled"
+    } == {"4"}
+    assert all(0.0 <= float(row["attach_eta_squared"]) <= 1.0 for row in seed_rows)
+    run_means = list(
+        csv.DictReader(
+            (output_dir / "run_feature_means.csv").open(
+                "r", encoding="utf-8", newline=""
+            )
+        )
+    )
+    assert run_means
+    assert {
+        row["all_windows_shape_pass"]
+        for row in run_means
+        if row["run_id"] == "nf01_as001_ps001"
+    } == {"False"}
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["dataset_version"] == "v1"
+    assert manifest["dataset_revision"] == "r1"
+    assert manifest["within_run_windows_are_independent"] is False
+    assert len(manifest["outputs"]["plots"]) >= 6
+
+
+@pytest.mark.light
+def test_duration_study_config_accepts_key_value_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "study.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "dataset_dir: input",
+                "output_dir: output",
+                "study:",
+                "  durations_s: [0.5]",
+                "clip:",
+                "  frame_rate_hz: 25.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_duration_study_config(
+        config_path,
+        [
+            "study.durations_s=[0.25,0.5,1.0]",
+            "clip.frame_rate_hz=20.0",
+            "overwrite=true",
+        ],
+    )
+
+    assert cfg.durations_s == (0.25, 0.5, 1.0)
+    assert cfg.frame_rate_hz == pytest.approx(20.0)
+    assert cfg.overwrite is True

--- a/tests/test_phase4_duration_study.py
+++ b/tests/test_phase4_duration_study.py
@@ -180,6 +180,11 @@ def test_duration_study_writes_window_qc_and_seed_artifacts(tmp_path: Path) -> N
     assert manifest["dataset_revision"] == "r1"
     assert manifest["within_run_windows_are_independent"] is False
     assert len(manifest["outputs"]["plots"]) >= 6
+    plot_names = {Path(path).name for path in manifest["outputs"]["plots"]}
+    assert "2d_centroid_step_mean_seed_heatmap.png" in plot_names
+    assert not any(
+        name.startswith("2d_centroid_step_mean_seed_heatmap_") for name in plot_names
+    )
 
 
 @pytest.mark.light

--- a/tests/test_phase4_duration_study.py
+++ b/tests/test_phase4_duration_study.py
@@ -256,3 +256,4 @@ def test_duration_study_shell_full_path_supports_empty_overwrite(
     commands = command_log.read_text(encoding="utf-8").splitlines()
     assert len(commands) == 3
     assert all("overwrite=true" not in command for command in commands)
+    assert "output_dir=" not in commands[2]

--- a/tests/test_phase4_duration_study.py
+++ b/tests/test_phase4_duration_study.py
@@ -161,7 +161,20 @@ def test_duration_study_writes_window_qc_and_seed_artifacts(tmp_path: Path) -> N
     assert {
         row["run_count"] for row in seed_rows if row["qc_scope"] == "all_labeled"
     } == {"4"}
-    assert all(0.0 <= float(row["attach_eta_squared"]) <= 1.0 for row in seed_rows)
+    complete_seed_rows = [
+        row for row in seed_rows if row["factorial_complete"] == "True"
+    ]
+    incomplete_seed_rows = [
+        row for row in seed_rows if row["factorial_complete"] == "False"
+    ]
+    assert complete_seed_rows
+    assert incomplete_seed_rows
+    assert all(
+        0.0 <= float(row["attach_eta_squared"]) <= 1.0 for row in complete_seed_rows
+    )
+    assert all(row["attach_eta_squared"] == "" for row in incomplete_seed_rows)
+    assert all(row["phase_eta_squared"] == "" for row in incomplete_seed_rows)
+    assert all(row["residual_eta_squared"] == "" for row in incomplete_seed_rows)
     run_means = list(
         csv.DictReader(
             (output_dir / "run_feature_means.csv").open(
@@ -179,6 +192,11 @@ def test_duration_study_writes_window_qc_and_seed_artifacts(tmp_path: Path) -> N
     assert manifest["dataset_version"] == "v1"
     assert manifest["dataset_revision"] == "r1"
     assert manifest["within_run_windows_are_independent"] is False
+    assert manifest["invocation"]["config_path"] is None
+    assert manifest["seeds"] == {"attach": [0, 1], "phase": [0, 1]}
+    assert manifest["git"]["commit"]
+    assert manifest["environment"]["python"]
+    assert (output_dir / "run.log").is_file()
     assert len(manifest["outputs"]["plots"]) >= 6
     plot_names = {Path(path).name for path in manifest["outputs"]["plots"]}
     assert "2d_centroid_step_mean_seed_heatmap.png" in plot_names
@@ -256,4 +274,8 @@ def test_duration_study_shell_full_path_supports_empty_overwrite(
     commands = command_log.read_text(encoding="utf-8").splitlines()
     assert len(commands) == 3
     assert all("overwrite=true" not in command for command in commands)
-    assert "output_dir=" not in commands[2]
+    assert "output.base_dir=outputs/" in commands[0]
+    assert "output.timestamp_subdir=false" in commands[0]
+    assert "dataset.output_dir=outputs/" in commands[1]
+    assert "dataset_dir=outputs/" in commands[2]
+    assert "output_dir=outputs/" in commands[2]


### PR DESCRIPTION
## Summary

- add a v1 r1 3 s full-factorial profile for `n_flagella=1,2,3` and attach / phase seeds `0,1,2`
- add aligned raw all-step 3D and 25 Hz body-centered 2D window feature analysis
- label run/window shape QC and report attach / phase seed effects for all labeled and strict-pass data
- align duration plot y-axes and combine duration×flagella-count seed heatmaps
- colocate raw run, dataset revision, analysis, and replay under the campaign root
- add user-facing shell, replay command, tests, and Phase 3/4 docs

## Completed user run

- 3 s full factorial: 27/27 completed
- strict QC: `n=1:9/9`, `n=2:9/9`, `n=3:5/9`
- four `n=3` failures are `flag` category and retained with first-fail/window QC provenance
- canonical root: `outputs/phase2_multi_run/flagella_count_duration_3s_r1`
- duration/seed analysis: `outputs/phase2_multi_run/flagella_count_duration_3s_r1/analysis/phase4_duration_seed_study`
- MVP clip duration decision: `0.5 s`

## Verification

- `./scripts/04_phase4/run_duration_seed_study.sh probe`
- `uv run pytest -q tests/test_phase4_duration_study.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q -m light` (`181 passed`)
- full test at initial implementation: `415 passed`

## Follow-up

- #159 converts all 3 s runs into a 0.5 s Phase 3 clip dataset with pre-first-fail/window QC provenance and clip replay.
- #158 diagnoses the `n=3` long-duration nonstationary rotation and proximal failures.
- #157 tracks dataset v2 quality improvement and staged RUN–TUMBLE adoption.
- protected-run seed design and the general run-count claim remain separate from the empirical pseudo-v1 lower bound.

Refs #129
Refs #155
Refs #157
Refs #158
Refs #159