### PR TITLE
[Phase2] 2010年potential式を照合しFENE-Fraenkelを採用

### DIFF
--- a/conf/phase2_multi_run/spring_formulation_motor_off.yaml
+++ b/conf/phase2_multi_run/spring_formulation_motor_off.yaml
@@ -1,0 +1,39 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: true
+  description: Issue #163 spring formulation comparison under motor-off conditions
+
+base_config: conf/sim_swim.yaml
+
+base_overrides:
+  time.duration_s: 0.1
+  time.dt_star: 1.0e-4
+  motor.torque_Nm: 0.0
+  motor.torque_for_forces_override_Nm: 2.5e-20
+  motor.enable_switching: false
+  seed.attach_seed: 0
+  seed.phase_seed: 0
+
+sweep:
+  axes:
+    formulation:
+      key: potentials.spring.formulation
+      short_name: formulation
+      values: [legacy, fene_fraenkel]
+      labels: [legacy, fene_fraenkel]
+      ids: [legacy, fene_fraenkel]
+
+plot:
+  default_x_axis: formulation
+  default_y_axis: null
+  metrics:
+    - first_fail_t_s
+    - body_shape_pass
+    - max_flag_bond_rel_err
+
+output:
+  base_dir: outputs/phase2_multi_run/spring_formulation_motor_off
+  timestamp_subdir: true
+  save_state_archive: false
+  progress_interval: 1000

--- a/conf/phase2_multi_run/spring_formulation_motor_on.yaml
+++ b/conf/phase2_multi_run/spring_formulation_motor_on.yaml
@@ -1,0 +1,38 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: true
+  description: Issue #163 spring formulation comparison under motor-on RUN conditions
+
+base_config: conf/sim_swim.yaml
+
+base_overrides:
+  time.duration_s: 1.0
+  time.dt_star: 1.0e-4
+  motor.torque_Nm: 2.5e-20
+  motor.enable_switching: false
+  seed.attach_seed: 0
+  seed.phase_seed: 0
+
+sweep:
+  axes:
+    formulation:
+      key: potentials.spring.formulation
+      short_name: formulation
+      values: [legacy, fene_fraenkel]
+      labels: [legacy, fene_fraenkel]
+      ids: [legacy, fene_fraenkel]
+
+plot:
+  default_x_axis: formulation
+  default_y_axis: null
+  metrics:
+    - first_fail_t_s
+    - body_shape_pass
+    - max_flag_bond_rel_err
+
+output:
+  base_dir: outputs/phase2_multi_run/spring_formulation_motor_on
+  timestamp_subdir: true
+  save_state_archive: false
+  progress_interval: 1000

--- a/conf/sim_swim.yaml
+++ b/conf/sim_swim.yaml
@@ -59,7 +59,7 @@ motor:
 
 potentials:
   spring:
-    formulation: "legacy"      # legacy: 過去run互換。fene_fraenkel: Watari & Larson (2010) の相対伸長式
+    formulation: "fene_fraenkel"  # Issue #163比較で採用。legacyは過去run互換用
     H_over_T_over_b: 10.0      # [-] 係数値H=10*T/b。式自体のpaper準拠はformulationで選択
     s: 0.1                     # legacyでは絶対限界s*b、fene_fraenkelではbond長に対する相対限界
   bend:

--- a/conf/sim_swim.yaml
+++ b/conf/sim_swim.yaml
@@ -59,8 +59,9 @@ motor:
 
 potentials:
   spring:
-    H_over_T_over_b: 10.0      # [-] H = 10 * Torque / b（paper-aligned default）
-    s: 0.1                     # [-] 伸長限界 s/b（paper-aligned default）
+    formulation: "legacy"      # legacy: 過去run互換。fene_fraenkel: Watari & Larson (2010) の相対伸長式
+    H_over_T_over_b: 10.0      # [-] 係数値H=10*T/b。式自体のpaper準拠はformulationで選択
+    s: 0.1                     # legacyでは絶対限界s*b、fene_fraenkelではbond長に対する相対限界
   bend:
     kb_over_T: 20.0            # [-] kb = 20 * T
     theta0_deg:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,6 +120,9 @@ Recommended order:
 | #100 | closed | #82 | sweep / multi-run / replay導線整理 |
 | #103 | closed | #82 | basal freedom / attach-frame剛体回転診断 |
 | #124 | open | #10 | `n>=4` 根元付近過伸長改善 |
+| #163 | open | #10 | Watari & Larson (2010) potential式照合とspring formulation選択。長時間比較はuser-run |
+| #164 | open | #154 | 2010年/2015年baseline config再編。#163のpotential照合結果を前提にする |
+| #165 | open | #154 | `tau` duration指定の正式化。#164と連携する |
 | #69 | open | #10 | Tumble状態の段階実装 |
 | #15 | open | #10 | Brownian項追加 |
 | #41 | open | #10 | 参照論文 contour length 矛盾対応 |
@@ -166,31 +169,32 @@ MVPでは #124 / #69 / #15 は Phase 3 baseline をblockしない。必要なら
 
 ## User-Run Required Queue
 
-現時点でユーザー実行が必須の項目はない。
-
-今後ユーザー実行が必要になった場合は，この形式で報告する。
+Issue #163 の motor-off `0.1 tau` / motor-on RUN `1 tau` spring formulation比較は、実装・短時間check完了後にユーザー実行する。
 
 ```bash
-uv run python ...
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_off.yaml
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_on.yaml
+uv run python scripts/01_simulate_swimming/analyze_spring_formulations.py \
+  motor_off_summary=<motor-off-run-root>/summary.csv \
+  motor_on_summary=<motor-on-run-root>/summary.csv
 ```
 
-確認先:
+確認先は各campaignの `summary.csv` と、解析runの次のartifactである。
 
 ```text
-outputs/...
+force_extension.csv
+force_extension.png
+default_decision.json
+default_decision.md
 ```
 
-判断ポイント:
+完走・有限値・body/nonbody strict shape gateを自動判定し、動画目視は要求しない。
 
-```text
-body deformation が見えるか
-helical shape が保たれているか
-2D pseudo-microscopy として自然か
-同一run由来clipを独立sampleとして扱っていないか
-```
-
-## Next Three Actions
+## Next Actions
 
 1. #129で`4 training groups/class`をpseudo-v1 MVP lower boundとして採用するか判断する。
 2. 一般的な必要run数を主張する場合はprotected評価用runの追加条件を決める。
 3. #145 dataset v2はProject `TODO`のまま後回しにする。
+4. #163の短時間check後、ユーザー実行の2 formulation比較から2010年baseline defaultを確定する。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,7 +120,7 @@ Recommended order:
 | #100 | closed | #82 | sweep / multi-run / replay導線整理 |
 | #103 | closed | #82 | basal freedom / attach-frame剛体回転診断 |
 | #124 | open | #10 | `n>=4` 根元付近過伸長改善 |
-| #163 | open | #10 | Watari & Larson (2010) potential式照合とspring formulation選択。長時間比較はuser-run |
+| #163 | open | #10 | potential式照合と比較完了。`fene_fraenkel` をdefault採用、PR merge待ち |
 | #164 | open | #154 | 2010年/2015年baseline config再編。#163のpotential照合結果を前提にする |
 | #165 | open | #154 | `tau` duration指定の正式化。#164と連携する |
 | #69 | open | #10 | Tumble状態の段階実装 |
@@ -169,32 +169,10 @@ MVPでは #124 / #69 / #15 は Phase 3 baseline をblockしない。必要なら
 
 ## User-Run Required Queue
 
-Issue #163 の motor-off `0.1 tau` / motor-on RUN `1 tau` spring formulation比較は、実装・短時間check完了後にユーザー実行する。
-
-```bash
-uv run python scripts/01_simulate_swimming/run_multi_run.py \
-  config=conf/phase2_multi_run/spring_formulation_motor_off.yaml
-uv run python scripts/01_simulate_swimming/run_multi_run.py \
-  config=conf/phase2_multi_run/spring_formulation_motor_on.yaml
-uv run python scripts/01_simulate_swimming/analyze_spring_formulations.py \
-  motor_off_summary=<motor-off-run-root>/summary.csv \
-  motor_on_summary=<motor-on-run-root>/summary.csv
-```
-
-確認先は各campaignの `summary.csv` と、解析runの次のartifactである。
-
-```text
-force_extension.csv
-force_extension.png
-default_decision.json
-default_decision.md
-```
-
-完走・有限値・body/nonbody strict shape gateを自動判定し、動画目視は要求しない。
+現時点でユーザー実行が必須の項目はない。Issue #163の比較は `outputs/phase2_potential_comparison/2026-08-02/154149` で完了した。
 
 ## Next Actions
 
 1. #129で`4 training groups/class`をpseudo-v1 MVP lower boundとして採用するか判断する。
 2. 一般的な必要run数を主張する場合はprotected評価用runの追加条件を決める。
 3. #145 dataset v2はProject `TODO`のまま後回しにする。
-4. #163の短時間check後、ユーザー実行の2 formulation比較から2010年baseline defaultを確定する。

--- a/docs/adr/0009_phase2_2010_potential_formulations.md
+++ b/docs/adr/0009_phase2_2010_potential_formulations.md
@@ -29,7 +29,9 @@ spring-spring repulsionは論文がexponential potentialとTable 1の値を与�
 
 比較結果がない段階では `legacy` をdefaultとする。motor-off `0.1 tau` と motor-on RUN `1 tau` の両方について、`fene_fraenkel` が完走し、非有限値・step欠損がなく、body/nonbody strict shape gateを全期間通過した場合だけ、論文一致を優先して2010年baselineの採用候補にする。いずれかを満たさない場合は `legacy` を維持する。
 
-この比較は自動基準で判断し、動画目視を必須にしない。長時間runはユーザー実行とし、結果取得後に本ADRへ出力場所、判定artifact、defaultの最終判断を追記する。
+2026-08-02のuser-runでは、両formulationがmotor-off/onとも予定stepを完走し、body/nonbody strict shape gateを全期間通過した。corrected decision artifact `outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json` は `fene_fraenkel` を選択したため、`conf/sim_swim.yaml` のdefaultを `fene_fraenkel` とする。selector欠落時のparser fallbackは過去互換のため `legacy` のまま維持する。
+
+初回解析 `outputs/phase2_potential_comparison/2026-08-02/153848` は、`step_summary.csv` がstep実行前時刻を記録する契約を考慮せず、正常な最終時刻 `duration-dt` を途中停止と誤判定したため採否根拠に用いない。判定器は連続step番号、観測dt、予定durationを照合するよう修正した。
 
 ## Consequences
 
@@ -41,5 +43,4 @@ spring-spring repulsionは論文がexponential potentialとTable 1の値を与�
 
 ## Verification status
 
-unit test、force-extension artifact、比較profileのdry-runまではCodexが実行する。motor-off/onの長時間比較結果とdefault最終判断はユーザーrun後に追記する。結果未取得の間、Issue #163のreview resultは `FAIL` のままとする。
-
+unit test、full pytest、force-extension artifact、比較profileのdry-run、motor-off/onの長時間比較、自動default判定まで完了した。動画目視は採否基準に含めない。

--- a/docs/adr/0009_phase2_2010_potential_formulations.md
+++ b/docs/adr/0009_phase2_2010_potential_formulations.md
@@ -1,0 +1,45 @@
+# ADR 0009: Phase 2 2010 potential formulation と既存互換
+
+- status: accepted
+- date: 2026-08-02
+- scope: Phase 2 / Issue #163
+
+## Context
+
+Watari & Larson (2010) の FENE-Fraenkel spring は、bond平衡長に対する相対変形と分母一乗を使う。現行springは `s*b` の絶対変形限界と分母二乗を使っており、式と次元が一致しない。一方、現行springを直接置換すると過去runを再現できない。
+
+bending、torsion、hook potentialは論文表示の負号と現行実装の正号が異なる。ただし現行実装は平衡角への復元力として動作し、論文式の負号だけを通常の `F=-grad U` に適用すると平衡点から離す向きになる。
+
+spring-spring repulsionは論文がexponential potentialとTable 1の値を与えるが、対象segmentと端点への力分配を完全には定めていない。
+
+式・次元・実装対応の正本は `docs/phase2/phase2_163_2010_potential_correspondence.md` とする。
+
+## Decision
+
+- `potentials.spring.formulation` に `legacy` と `fene_fraenkel` を追加する。
+- selector欠落時は `legacy` とし、過去runの数値挙動を維持する。
+- `fene_fraenkel` は `q=(r-L)/L`、`|q|<s`、`H q/(1-q^2/s^2)` を使い、`H=10 T/b` をforceとして扱う。
+- `legacy` は絶対限界 `s*b`、分母二乗、既存clipを変更しない。論文準拠ではなく互換用であることを明記する。
+- bending、torsion、hookの符号は変更せず、平衡角への復元方向をtestで仕様化する。torsionの現行dihedral符号、`[-pi, pi)` wrap、有限差分も維持する。
+- hookは `theta>90 deg` で無効、`theta<=90 deg` で90度へ復元する。
+- repulsionは共有端点segmentを除外し、body-bodyを除外してbody-flagellum/flagellum-flagellumへ適用し、最短点の力を4端点へ線形分配する現行仮定を維持する。
+- repulsionのcutoff不連続と完全交差時の方向退化は既知の数値近似として受容する。
+
+## Default decision gate
+
+比較結果がない段階では `legacy` をdefaultとする。motor-off `0.1 tau` と motor-on RUN `1 tau` の両方について、`fene_fraenkel` が完走し、非有限値・step欠損がなく、body/nonbody strict shape gateを全期間通過した場合だけ、論文一致を優先して2010年baselineの採用候補にする。いずれかを満たさない場合は `legacy` を維持する。
+
+この比較は自動基準で判断し、動画目視を必須にしない。長時間runはユーザー実行とし、結果取得後に本ADRへ出力場所、判定artifact、defaultの最終判断を追記する。
+
+## Consequences
+
+- 既存configは変更なしで読み込め、過去runを再現できる。
+- 論文準拠springを明示的に比較できる。
+- `legacy` と `fene_fraenkel` の `H` は同じconfig値でも式中の次元的役割が異なるため、結果比較ではformulationを必ず記録する。
+- potentialの表示符号より、実装された力の復元方向を契約として優先する。
+- `sim_swim_2010.yaml` の作成とconfig再編はIssue #164、正式な `tau` duration指定はIssue #165で扱う。Issue #163では現行 `tau_s=1.0` 規約を比較profileに限定して用いる。
+
+## Verification status
+
+unit test、force-extension artifact、比較profileのdry-runまではCodexが実行する。motor-off/onの長時間比較結果とdefault最終判断はユーザーrun後に追記する。結果未取得の間、Issue #163のreview resultは `FAIL` のままとする。
+

--- a/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
+++ b/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
@@ -1,64 +1,70 @@
 {
-  "status": "FAIL",
-  "summary": "Issue #163 の実装・文書・自動テストを完了した。Watari & Larson (2010) 準拠の `fene_fraenkel` と過去互換の `legacy` を `potentials.spring.formulation` で選択可能にし、selector欠落時のlegacy互換、potentialの復元方向、repulsion仮定、force-extension比較、motor-off/on比較profile、自動default判定を追加した。default最終採否に必要な長時間比較はリポジトリ方針により未実行のため、現時点のdefaultは `legacy`、task状態はFAIL/WIPとする。",
-  "blocking_issues": [
-    "motor-off 0.1 tau と motor-on RUN 1 tau の両formulation比較が未実行であり、2010年baselineのdefaultを最終確定できない。"
-  ],
+  "status": "PASS",
+  "summary": "Issue #163としてWatari & Larson (2010)のpotential式と現実装を照合し、論文準拠`fene_fraenkel`と過去互換`legacy`を選択可能にした。motor-off 0.1 tauとmotor-on RUN 1 tauでは両formulationが完走し、body/nonbody strict shape gateを全期間通過した。FENEはlegacy比でmax flag bond誤差を49.2%/84.2%、body spring最大伸長を84.4%/81.0%低減したため、採否規則と論文一致に従いdefaultを`fene_fraenkel`とした。selector欠落時は`legacy`へfallbackし、過去config互換を維持する。",
+  "blocking_issues": [],
   "non_blocking_issues": [
     "spring-spring repulsionのcutoff不連続と完全交差時の反発方向退化は既存の数値近似として維持する。",
-    "`sim_swim_2010.yaml` の作成・config再編はIssue #164、正式なtau duration指定はIssue #165で扱う。"
+    "`sim_swim_2010.yaml`の作成・config再編はIssue #164、正式なtau duration指定はIssue #165で扱う。",
+    "初回解析153848は正常なfinal_t_s=duration-dtを途中停止と誤判定したため不採用。判定器を連続step番号・観測dt・予定durationの照合へ修正し、154149で再解析した。"
   ],
   "tests_reviewed": [
     {
       "command": "uv run pytest -q tests/test_potentials.py tests/test_phase2_163_spring_formulation_comparison.py",
-      "result": "PASS: 32 passed"
+      "result": "PASS: 35 passed"
     },
     {
       "command": "uv run pytest -q -m light",
-      "result": "PASS: 225 passed, 240 deselected"
+      "result": "PASS: 228 passed, 240 deselected"
     },
     {
       "command": "uv run pytest -q",
-      "result": "PASS: 465 passed"
+      "result": "PASS: 468 passed"
     },
     {
       "command": "uv run ruff format --check . && uv run ruff check .",
-      "result": "PASS: 123 files formatted, all checks passed"
+      "result": "PASS"
     },
     {
-      "command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_off.yaml dry_run=true; uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_on.yaml dry_run=true",
-      "result": "PASS: 両profileがlegacy / fene_fraenkelの2条件を展開"
+      "command": "inspect outputs/phase2_multi_run/spring_formulation_motor_off/2026-08-02/151207/summary.csv and step_summary.csv",
+      "result": "PASS: legacy/feneとも1000 step完走、nonbody/body gate pass、first failなし"
+    },
+    {
+      "command": "inspect outputs/phase2_multi_run/spring_formulation_motor_on/2026-08-02/151505/summary.csv and step_summary.csv",
+      "result": "PASS: legacy/feneとも10000 step完走、nonbody/body gate pass、first failなし"
+    },
+    {
+      "command": "inspect outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json",
+      "result": "PASS: selected_default=fene_fraenkel; all four evaluations pass"
     },
     {
       "command": "git diff --check",
       "result": "PASS"
     }
   ],
-  "user_review_required": true,
-  "user_review_command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_off.yaml\nuv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_on.yaml\nuv run python scripts/01_simulate_swimming/analyze_spring_formulations.py motor_off_summary=<motor-off-run-root>/summary.csv motor_on_summary=<motor-on-run-root>/summary.csv",
+  "user_review_required": false,
+  "user_review_command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_off.yaml\nuv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_on.yaml\nuv run python scripts/01_simulate_swimming/analyze_spring_formulations.py motor_off_summary=outputs/phase2_multi_run/spring_formulation_motor_off/2026-08-02/151207/summary.csv motor_on_summary=outputs/phase2_multi_run/spring_formulation_motor_on/2026-08-02/151505/summary.csv",
   "user_review_outputs": [
-    "outputs/phase2_multi_run/spring_formulation_motor_off/<JST timestamp>/summary.csv",
-    "outputs/phase2_multi_run/spring_formulation_motor_on/<JST timestamp>/summary.csv",
-    "outputs/phase2_potential_comparison/<JST timestamp>/default_decision.json",
-    "outputs/phase2_potential_comparison/<JST timestamp>/default_decision.md",
-    "outputs/phase2_potential_comparison/<JST timestamp>/force_extension.csv",
-    "outputs/phase2_potential_comparison/<JST timestamp>/force_extension.png"
+    "outputs/phase2_multi_run/spring_formulation_motor_off/2026-08-02/151207/summary.csv",
+    "outputs/phase2_multi_run/spring_formulation_motor_on/2026-08-02/151505/summary.csv",
+    "outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json",
+    "outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.md",
+    "outputs/phase2_potential_comparison/2026-08-02/154149/force_extension.csv",
+    "outputs/phase2_potential_comparison/2026-08-02/154149/force_extension.png"
   ],
   "user_review_points": [
-    "動画の目視判定は不要。2本のcampaignが全条件を完走し、各summary.csvが生成されること。",
-    "解析CLIがdefault_decision.jsonを生成し、selected_defaultと各runのreasonsを記録すること。",
-    "fene_fraenkelは両runで完走、有限値、全期間nonbody gate、body gateを満たす場合だけdefault候補になること。"
+    "動画目視は不要。完走、有限値、全期間body/nonbody strict shape gateを自動判定した。",
+    "corrected decision artifactが両formulationの全run PASSとfene_fraenkel選択を記録している。"
   ],
   "adr_required": true,
-  "adr_reason": "spring式、互換selector、potential符号規約、repulsion仮定、default採否gateは物理解釈と再現性に関わるため、ADR 0009を作成した。",
-  "commit_type": "wip",
+  "adr_reason": "spring式、互換selector、potential符号規約、repulsion仮定、default採否gateは物理解釈と再現性に関わるため、ADR 0009を作成し採否結果を追記した。",
+  "commit_type": "complete",
   "commit_hash": "",
   "push_status": "pushed",
   "pull_request_url": "",
   "related_issue_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/163",
   "next_actions": [
-    "ユーザーがmotor-off/onの比較campaignと解析CLIを実行し、3つのrun rootを共有する。",
-    "default_decision.jsonの結果をADR、config、task docs、review_resultへ反映する。",
-    "最終候補でself-checkとCodex Cloud reviewを行い、review_result PASS後にIssue #163を完了する。"
+    "PR CIとcodex-review-gateを確認する。",
+    "Issue #164で2010年/2015年baseline configを再編する。",
+    "Issue #165でtau duration指定を正式化する。"
   ]
 }

--- a/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
+++ b/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
@@ -10,15 +10,15 @@
   "tests_reviewed": [
     {
       "command": "uv run pytest -q tests/test_potentials.py tests/test_phase2_163_spring_formulation_comparison.py",
-      "result": "PASS: 35 passed"
+      "result": "PASS: 37 passed"
     },
     {
       "command": "uv run pytest -q -m light",
-      "result": "PASS: 228 passed, 240 deselected"
+      "result": "PASS: 230 passed, 240 deselected"
     },
     {
       "command": "uv run pytest -q",
-      "result": "PASS: 468 passed"
+      "result": "PASS: 470 passed"
     },
     {
       "command": "uv run ruff format --check . && uv run ruff check .",
@@ -35,6 +35,10 @@
     {
       "command": "inspect outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json",
       "result": "PASS: selected_default=fene_fraenkel; all four evaluations pass"
+    },
+    {
+      "command": "pytest missing/empty summary decision artifact cases",
+      "result": "PASS: campaign例外でsummaryが欠損・空でも理由付きlegacy decision JSON/Markdownを生成"
     },
     {
       "command": "git diff --check",

--- a/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
+++ b/docs/codex-runs/20260802_150004_phase2_163_2010_potentials/review_result.json
@@ -1,0 +1,64 @@
+{
+  "status": "FAIL",
+  "summary": "Issue #163 の実装・文書・自動テストを完了した。Watari & Larson (2010) 準拠の `fene_fraenkel` と過去互換の `legacy` を `potentials.spring.formulation` で選択可能にし、selector欠落時のlegacy互換、potentialの復元方向、repulsion仮定、force-extension比較、motor-off/on比較profile、自動default判定を追加した。default最終採否に必要な長時間比較はリポジトリ方針により未実行のため、現時点のdefaultは `legacy`、task状態はFAIL/WIPとする。",
+  "blocking_issues": [
+    "motor-off 0.1 tau と motor-on RUN 1 tau の両formulation比較が未実行であり、2010年baselineのdefaultを最終確定できない。"
+  ],
+  "non_blocking_issues": [
+    "spring-spring repulsionのcutoff不連続と完全交差時の反発方向退化は既存の数値近似として維持する。",
+    "`sim_swim_2010.yaml` の作成・config再編はIssue #164、正式なtau duration指定はIssue #165で扱う。"
+  ],
+  "tests_reviewed": [
+    {
+      "command": "uv run pytest -q tests/test_potentials.py tests/test_phase2_163_spring_formulation_comparison.py",
+      "result": "PASS: 32 passed"
+    },
+    {
+      "command": "uv run pytest -q -m light",
+      "result": "PASS: 225 passed, 240 deselected"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS: 465 passed"
+    },
+    {
+      "command": "uv run ruff format --check . && uv run ruff check .",
+      "result": "PASS: 123 files formatted, all checks passed"
+    },
+    {
+      "command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_off.yaml dry_run=true; uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_on.yaml dry_run=true",
+      "result": "PASS: 両profileがlegacy / fene_fraenkelの2条件を展開"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ],
+  "user_review_required": true,
+  "user_review_command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_off.yaml\nuv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/spring_formulation_motor_on.yaml\nuv run python scripts/01_simulate_swimming/analyze_spring_formulations.py motor_off_summary=<motor-off-run-root>/summary.csv motor_on_summary=<motor-on-run-root>/summary.csv",
+  "user_review_outputs": [
+    "outputs/phase2_multi_run/spring_formulation_motor_off/<JST timestamp>/summary.csv",
+    "outputs/phase2_multi_run/spring_formulation_motor_on/<JST timestamp>/summary.csv",
+    "outputs/phase2_potential_comparison/<JST timestamp>/default_decision.json",
+    "outputs/phase2_potential_comparison/<JST timestamp>/default_decision.md",
+    "outputs/phase2_potential_comparison/<JST timestamp>/force_extension.csv",
+    "outputs/phase2_potential_comparison/<JST timestamp>/force_extension.png"
+  ],
+  "user_review_points": [
+    "動画の目視判定は不要。2本のcampaignが全条件を完走し、各summary.csvが生成されること。",
+    "解析CLIがdefault_decision.jsonを生成し、selected_defaultと各runのreasonsを記録すること。",
+    "fene_fraenkelは両runで完走、有限値、全期間nonbody gate、body gateを満たす場合だけdefault候補になること。"
+  ],
+  "adr_required": true,
+  "adr_reason": "spring式、互換selector、potential符号規約、repulsion仮定、default採否gateは物理解釈と再現性に関わるため、ADR 0009を作成した。",
+  "commit_type": "wip",
+  "commit_hash": "",
+  "push_status": "pushed",
+  "pull_request_url": "",
+  "related_issue_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/163",
+  "next_actions": [
+    "ユーザーがmotor-off/onの比較campaignと解析CLIを実行し、3つのrun rootを共有する。",
+    "default_decision.jsonの結果をADR、config、task docs、review_resultへ反映する。",
+    "最終候補でself-checkとCodex Cloud reviewを行い、review_result PASS後にIssue #163を完了する。"
+  ]
+}

--- a/docs/phase2/phase2_163_2010_potential_correspondence.md
+++ b/docs/phase2/phase2_163_2010_potential_correspondence.md
@@ -1,0 +1,131 @@
+# Phase 2 Issue #163: Watari & Larson (2010) potential 式照合
+
+## 目的
+
+Watari & Larson (2010) の bead-spring model と現行実装を、式、変数、SI次元、復元方向まで照合する。論文式をそのまま転記した箇所、現行実装、project-specific extension、数値安定化近似を区別する。
+
+参照一次資料:
+
+- Nobuhiko Watari and Ronald G. Larson, "The hydrodynamics of a run-and-tumble bacterium propelled by polymorphic helical flagella", *Biophysical Journal* 98, 12-17 (2010), DOI: [10.1016/j.bpj.2009.09.044](https://doi.org/10.1016/j.bpj.2009.09.044)
+- 論文本文の Model 節、Eqs. (1)-(4)、Table 1
+
+## 記号と次元
+
+論文では長さを `b`、時間を `tau = eta b^3 / T`、エネルギーを motor torque の大きさ `T` でscaleする。SIでは `b, L, r, D, alpha_ss` は `[m]`、`T, k_b, k_t, A_ss` は `[J] = [N m]`、`H = 10 T/b` は `[N]`、`s` は無次元である。角度は無次元量として扱う。
+
+`r_ij = r_i - r_j`、`r_ij = |r_ij|`、`L` はbondごとの平衡長、`q = r_ij/L - 1` は相対変形とする。現行configの `H_over_T_over_b`, `kb_over_T`, `kt_over_T`, `A_ss_over_T`, `a_ss_over_b`, `cutoff_over_b` は各論文scaleに対する無次元比である。
+
+## Spring
+
+論文 Eq. (1) の FENE-Fraenkel force は、向きの規約を除く大きさとして次である。
+
+```text
+q = r_ij / L - 1
+|F_FF| = H q / (1 - q^2 / s^2)
+1 - s < r_ij / L < 1 + s
+```
+
+Table 1 は `H = 10 T/b`, `s = 0.1`、flagellum の `L = 0.58 b` を与える。したがって `s` は絶対長ではなく、各bondの平衡長に対する相対変形限界である。伸長時はbondを縮め、圧縮時はbondを伸ばす向きを復元方向として固定する。論文のベクトル式は `F_FF(r_ij)` がどちらのbeadに作用する力かを本文中で明示していないため、式先頭の符号だけでは現行配列への加算符号を決めない。
+
+Issue #163 では `potentials.spring.formulation` を追加する。
+
+| formulation | force magnitude | limit | 位置づけ |
+| --- | --- | --- | --- |
+| `fene_fraenkel` | `H q / (1 - q^2/s^2)` | `|q| < s` | 論文 Eq. (1) 準拠。`H` は `[N]` |
+| `legacy` | `H_impl x / (1 - x^2/(s b)^2)^2` | `|x| < s b` | 過去run再現用。`x=r-L`、絶対限界、分母二乗を維持 |
+
+`legacy` の式は論文の FENE-Fraenkel force と次元・関数形が一致しない。既存結果との数値互換だけを目的として変更しない。両式とも特異点で直接発散させず、許容端の内側へclipする。これは数値安定化近似であり、論文由来ではない。
+
+既存configでselectorが欠落した場合と `formulation=legacy` を明示した場合は同一挙動とする。`H <= 0`、`s <= 0`、未知formulationを拒否し、`fene_fraenkel` では圧縮側の許容長を正に保つため `s < 1` も要求する。
+
+## Bending, torsion, hook
+
+論文 Eqs. (2), (3) は次の負号付きpotentialを表示する。
+
+```text
+phi_b(theta) = -0.5 k_b (cos(theta) - cos(theta_0))^2
+phi_t(phi)   = -0.5 k_t (phi - phi_0)^2
+```
+
+一方、現行実装は正の二乗energyを用い、`F = -grad U` により平衡角へ戻す。
+
+```text
+U_b(theta) = +0.5 k_b (cos(theta) - cos(theta_0))^2
+U_t(phi)   = +0.5 k_t wrap(phi - phi_0)^2
+```
+
+論文の負号を通常のpotential energyとしてそのまま `F=-grad(phi)` へ入れると、平衡角は極小ではなく極大になる。論文側のpotential/force符号規約だけでは現行符号の反転を正当化できないため、Issue #163 では現行の復元方向を単体テストで固定し、符号は変更しない。
+
+torsion は4 beadのdihedral angleを現行定義で計算し、`phi-phi_0` を `[-pi, pi)` にwrapした正の二乗energyの勾配を中心有限差分で求める。有限差分幅 `fd_eps_over_b` は実装上の数値近似であり、論文 Table 1 のparameterではない。
+
+hook は論文 Eq. (4) に従い、`theta_hook > 90 deg` ではpotentialを無効、`theta_hook <= 90 deg` では90度へ戻す。論文は有効域を `-0.5 k_b cos^2(theta_hook)` と書くが、現行実装は復元方向を満たす `+0.5 k_b cos^2(theta_hook)` 相当を用いる。境界 `90 deg` は有効側だが力はゼロになる。
+
+Table 1 の値は `k_b=20 T`, `k_t=10 T`、normal/semicoiled/curly1 の平衡角がそれぞれ bending `142/90/105 deg`、torsion `-60/65/120 deg` である。現行configの値はこれと一致する。
+
+## Spring-spring repulsion
+
+論文本文は次のpotentialだけを規定する。
+
+```text
+phi_ss(D) = A_ss exp(-D/alpha_ss)
+|F_ss| = (A_ss/alpha_ss) exp(-D/alpha_ss)
+```
+
+`D` は2 spring segment間の最短距離である。Table 1 の論文由来値は `A_ss=1.0 T`, `alpha_ss=0.2 b`, cutoff `0.2 b` である。cutoffでpotential/forceをshiftしていないため、現行力はcutoffで不連続になる。
+
+論文はsegment列挙とbeadへの分配を完全には規定していない。現行実装では次を実装上の仮定として固定する。
+
+- 端点を共有する隣接segmentは除外する。
+- body-body segment対は除外し、body-flagellum と flagellum-flagellum に適用する。
+- segment上の最短点parameterを使い、反対向きの力を各segmentの2端点へ線形分配する。これにより合力はゼロになる。
+- 最短点が完全に一致する交差では方向ベクトルが退化し、現行実装は有限な反発方向を生成できない。この点はhard non-crossing constraintではなく数値近似として扱う。
+
+## 対応表
+
+| 対象 | 論文 | 現行/Issue #163後 | 判定 |
+| --- | --- | --- | --- |
+| spring `H` | `10 T/b`、force `[N]` | `fene_fraenkel`で同じscale | 論文準拠 |
+| spring `s` | 相対変形限界 `0.1` | `fene_fraenkel`は相対、`legacy`は絶対 `s b` | selectorで分離 |
+| spring 分母 | 一乗 | `fene_fraenkel`一乗、`legacy`二乗 | selectorで分離 |
+| bending | 負号付きcos差二乗 | 正号付きcos差二乗 | 復元方向を優先して維持 |
+| torsion | 負号付き角度差二乗 | 正号、wrap、有限差分 | 復元方向を優先、数値近似あり |
+| hook | `>90 deg`無効、`<=90 deg`負号付きcos二乗 | 同じ有効域、正号相当 | 復元方向を優先して維持 |
+| repulsion式/値 | exponential、`0.2 b` range/cutoff | 一致 | 論文準拠 |
+| repulsion対象/分配 | 詳細規定なし | 共有端点除外、body-body除外、線形端点分配 | 実装仮定 |
+
+## Default採否と比較run
+
+`fene_fraenkel` のdefault採否は、force-extension比較だけでは決めず、同一条件の motor-off `0.1 tau` と motor-on RUN `1 tau` で判断する。Issue #163 では `tau_s=1.0` の現行legacy時間規約により、比較profileをそれぞれ `0.1 s`, `1.0 s` とする。汎用的な `tau` 指定は Issue #165 に分離する。
+
+自動判定は次で固定する。
+
+1. `fene_fraenkel` の両runが例外、非有限値、予定step欠損なしで完走する。
+2. 両runが既存のbody/nonbody strict shape gateを全期間通過する。
+3. 1と2を満たせば、論文一致を優先して `fene_fraenkel` を2010年baselineの採用候補とする。それ以外は `legacy` を維持する。
+4. 両formulationが失敗した場合も、過去互換を優先して `legacy` を維持し、失敗条件を診断結果として保存する。
+
+長時間比較はリポジトリ方針に従いユーザーが実行する。実装側の短時間test、dry-run、force-extension artifact検証が完了した後に、実行コマンド、出力先、確認ファイル、判定結果の取込コマンドを一括提示する。自動基準で採否するため、この比較自体に動画目視は要求しない。
+
+実行導線は次の2 profileと解析CLIに固定する。
+
+```bash
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_off.yaml
+
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_on.yaml
+
+uv run python scripts/01_simulate_swimming/analyze_spring_formulations.py \
+  motor_off_summary=<motor-off-run-root>/summary.csv \
+  motor_on_summary=<motor-on-run-root>/summary.csv
+```
+
+run rootはそれぞれ `outputs/phase2_multi_run/spring_formulation_motor_off/` と `outputs/phase2_multi_run/spring_formulation_motor_on/` のJST timestamp配下に作られる。解析出力はデフォルトで `outputs/phase2_potential_comparison/` のJST timestamp配下に作られ、`force_extension.csv`, `force_extension.png`, `default_decision.json`, `default_decision.md`, `run.log`, `manifest.json` を確認する。
+
+比較結果が未取得の間は `conf/sim_swim.yaml` のdefaultを `legacy` とする。Issue #164 が扱う `sim_swim_2010.yaml` の作成・config再編は本Issueに含めない。
+
+## Issue境界
+
+- Issue #163: potential式照合、spring selector、復元方向test、repulsion仮定、比較導線と採否基準。
+- Issue #164: `sim_swim_2010.yaml` を含む2010年baseline configの再編・命名。
+- Issue #165: `tau` を明示したduration指定と時間scaleの正式なCLI/config契約。

--- a/docs/phase2/phase2_163_2010_potential_correspondence.md
+++ b/docs/phase2/phase2_163_2010_potential_correspondence.md
@@ -122,7 +122,13 @@ uv run python scripts/01_simulate_swimming/analyze_spring_formulations.py \
 
 run rootはそれぞれ `outputs/phase2_multi_run/spring_formulation_motor_off/` と `outputs/phase2_multi_run/spring_formulation_motor_on/` のJST timestamp配下に作られる。解析出力はデフォルトで `outputs/phase2_potential_comparison/` のJST timestamp配下に作られ、`force_extension.csv`, `force_extension.png`, `default_decision.json`, `default_decision.md`, `run.log`, `manifest.json` を確認する。
 
-比較結果が未取得の間は `conf/sim_swim.yaml` のdefaultを `legacy` とする。Issue #164 が扱う `sim_swim_2010.yaml` の作成・config再編は本Issueに含めない。
+2026-08-02の採否runは次である。
+
+- motor-off: `outputs/phase2_multi_run/spring_formulation_motor_off/2026-08-02/151207`
+- motor-on: `outputs/phase2_multi_run/spring_formulation_motor_on/2026-08-02/151505`
+- corrected decision: `outputs/phase2_potential_comparison/2026-08-02/154149`
+
+両formulationは両runで完走し、body/nonbody strict shape gateを全期間通過した。`fene_fraenkel` は `legacy` に対して、motor-off/onの `max_flag_bond_rel_err` をそれぞれ49.2%/84.2%、`body_spring_max_stretch_ratio` を84.4%/81.0%低減した。採否規則と論文一致に従い、`conf/sim_swim.yaml` のdefaultを `fene_fraenkel` とする。selectorを省略した既存configは引き続き `legacy` へfallbackする。Issue #164 が扱う `sim_swim_2010.yaml` の作成・config再編は本Issueに含めない。
 
 ## Issue境界
 

--- a/docs/phase2/phase2_163_2010_potential_correspondence.md
+++ b/docs/phase2/phase2_163_2010_potential_correspondence.md
@@ -104,6 +104,8 @@ phi_ss(D) = A_ss exp(-D/alpha_ss)
 3. 1と2を満たせば、論文一致を優先して `fene_fraenkel` を2010年baselineの採用候補とする。それ以外は `legacy` を維持する。
 4. 両formulationが失敗した場合も、過去互換を優先して `legacy` を維持し、失敗条件を診断結果として保存する。
 
+campaignがcondition例外で `summary.csv` 作成前に停止した場合も、解析CLIは欠損summaryをrun失敗として扱い、理由付きのlegacy判定artifactを生成する。
+
 長時間比較はリポジトリ方針に従いユーザーが実行する。実装側の短時間test、dry-run、force-extension artifact検証が完了した後に、実行コマンド、出力先、確認ファイル、判定結果の取込コマンドを一括提示する。自動基準で採否するため、この比較自体に動画目視は要求しない。
 
 実行導線は次の2 profileと解析CLIに固定する。

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -33,7 +33,7 @@ Phase 2 は，3D物理シミュレーションと2D擬似顕微鏡動画生成�
 
 現在の主対象:
 
-* Phase 2 / Issue #163: Watari & Larson (2010) のpotential式を現行実装と照合し、論文準拠 `fene_fraenkel` と過去互換 `legacy` を `potentials.spring.formulation` で選択可能にする。比較結果取得前のdefaultは `legacy`。bending/torsion/hookは現行の復元方向を維持し、spring-spring repulsionのsegment選別と端点分配は実装仮定として明記する。motor-off `0.1 tau` / motor-on RUN `1 tau` の長時間比較はユーザー実行で、strict shape gateによる自動採否とする。config再編は #164、正式なtau指定は #165へ分離する。
+* Phase 2 / Issue #163: Watari & Larson (2010) potential式照合を完了した。論文準拠 `fene_fraenkel` と過去互換 `legacy` を `potentials.spring.formulation` で選択でき、selector欠落時は `legacy`。motor-off `0.1 tau` / motor-on RUN `1 tau` の両runでFENEが完走・strict shape gateを通過し、defaultは `fene_fraenkel` とした。bending/torsion/hookの復元方向とspring-spring repulsionの実装仮定はADR 0009に記録した。config再編は #164、正式なtau指定は #165へ分離する。
 * Phase 2.8 / Issue #65: 親Issue #71 のRUN固定べん毛数差分析に向けて，特徴量カテゴリとdataset出力方針を定義済み。
 * Phase 2.8 / Issue #72 / #112: 親Issue #71 のRUN固定べん毛数差分析に向けて，raw output は `scripts/01_simulate_swimming/run_multi_run.py` で作り，dataset builder は generic multi-run の `run_manifest.json` から `summary.csv` / `timeseries/<sample_id>.csv` を生成する。
   raw condition には `trajectory.csv` と `state_archive.npz` を残し，後から replay render を再生成できる。

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -33,6 +33,7 @@ Phase 2 は，3D物理シミュレーションと2D擬似顕微鏡動画生成�
 
 現在の主対象:
 
+* Phase 2 / Issue #163: Watari & Larson (2010) のpotential式を現行実装と照合し、論文準拠 `fene_fraenkel` と過去互換 `legacy` を `potentials.spring.formulation` で選択可能にする。比較結果取得前のdefaultは `legacy`。bending/torsion/hookは現行の復元方向を維持し、spring-spring repulsionのsegment選別と端点分配は実装仮定として明記する。motor-off `0.1 tau` / motor-on RUN `1 tau` の長時間比較はユーザー実行で、strict shape gateによる自動採否とする。config再編は #164、正式なtau指定は #165へ分離する。
 * Phase 2.8 / Issue #65: 親Issue #71 のRUN固定べん毛数差分析に向けて，特徴量カテゴリとdataset出力方針を定義済み。
 * Phase 2.8 / Issue #72 / #112: 親Issue #71 のRUN固定べん毛数差分析に向けて，raw output は `scripts/01_simulate_swimming/run_multi_run.py` で作り，dataset builder は generic multi-run の `run_manifest.json` から `summary.csv` / `timeseries/<sample_id>.csv` を生成する。
   raw condition には `trajectory.csv` と `state_archive.npz` を残し，後から replay render を再生成できる。
@@ -92,6 +93,8 @@ Phase 2 task の開始時は，次の順で必要な範囲だけ読む。
 * Phase 2.7 helix axis diagnostics: `docs/phase2/phase2_7_flag_helix_axis_diagnostics.md`
 * Phase 2.8 flagella count feature definitions: `docs/phase2/phase2_8_flagella_count_feature_definitions.md`
 * Phase 2→3 handoff: `docs/phase2/phase2_8_phase2_to_phase3_handoff.md`
+* 2010 potential式照合: `docs/phase2/phase2_163_2010_potential_correspondence.md`
+* 2010 potential ADR: `docs/adr/0009_phase2_2010_potential_formulations.md`
 * Root torque segment-couple ADR: `docs/adr/0004_phase2_material_frame_twist_transmission.md`
 * Codex workflow details: `docs/codex/codex_workflow.md`
 

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -1335,7 +1335,7 @@
 
 ### P2-MODEL-163: 2010年モデルのpotential式を論文と照合し採否を整理する
 
-- status: in progress
+- status: completed
 - source issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/163`
 - parent issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/10`
 - branch: `feature/phase2-163-2010-potentials`
@@ -1345,12 +1345,12 @@
   - [x] 現行springは絶対限界 `s*b` と分母二乗を維持する `legacy` とする。selector欠落時も `legacy`。
   - [x] bending/torsion/hookは論文表示の負号だけで反転せず、現行の平衡角への復元方向を仕様とする。
   - [x] repulsionの `A_ss=1.0 T`, `alpha_ss=0.2 b`, cutoff `0.2 b` は論文由来。共有端点除外、body-body除外、端点への線形分配は実装仮定。
-  - [x] default採否はmotor-off `0.1 tau` とmotor-on RUN `1 tau` の完走・有限性・全期間strict shape gateで自動判定する。結果取得前は `legacy`。
-- remaining:
-  - [ ] spring selector、validation、力–伸長比較、復元方向・wrap・repulsion testを完了する。
-  - [ ] 比較profileのdry-runと短時間checkを完了する。
-  - [ ] ユーザーが長時間比較を実行し、自動判定artifactを生成する。
-  - [ ] 結果をADRとreview resultへ反映し、defaultを確定する。
+  - [x] default採否はmotor-off `0.1 tau` とmotor-on RUN `1 tau` の完走・有限性・全期間strict shape gateで自動判定する。
+  - [x] 両formulationが両runで完走・gate通過したため、論文一致を優先してdefaultを `fene_fraenkel` とする。
+- verification:
+  - [x] spring selector、validation、力-伸長比較、復元方向・wrap・repulsion testを完了した。
+  - [x] 比較profileのdry-run、focused test、light test、full pytestを完了した。
+  - [x] user-run artifact `outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json` が `fene_fraenkel` を選択した。
 - boundaries:
   - `sim_swim_2010.yaml` 作成とconfig再編はIssue #164で扱う。
   - 正式な `tau` duration指定はIssue #165で扱う。本Issueの `0.1 tau` / `1 tau` は現行 `tau_s=1.0` 規約の比較profileに限定する。

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -1331,6 +1331,33 @@
 - docs:
   - `docs/phase2/phase2_158_v1_r1_nf3_proximal_diagnostics.md`
 
+## Phase 2 model correspondence
+
+### P2-MODEL-163: 2010年モデルのpotential式を論文と照合し採否を整理する
+
+- status: in progress
+- source issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/163`
+- parent issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/10`
+- branch: `feature/phase2-163-2010-potentials`
+- goal: Watari & Larson (2010) のspring、bending、torsion、hook、spring-spring repulsionを式・変数・次元・復元方向で照合し、論文準拠springと過去互換springを再現可能に比較する。
+- accepted decisions:
+  - [x] `fene_fraenkel` は相対変形 `q=(r-L)/L`、相対限界 `s`、分母一乗を用いる。
+  - [x] 現行springは絶対限界 `s*b` と分母二乗を維持する `legacy` とする。selector欠落時も `legacy`。
+  - [x] bending/torsion/hookは論文表示の負号だけで反転せず、現行の平衡角への復元方向を仕様とする。
+  - [x] repulsionの `A_ss=1.0 T`, `alpha_ss=0.2 b`, cutoff `0.2 b` は論文由来。共有端点除外、body-body除外、端点への線形分配は実装仮定。
+  - [x] default採否はmotor-off `0.1 tau` とmotor-on RUN `1 tau` の完走・有限性・全期間strict shape gateで自動判定する。結果取得前は `legacy`。
+- remaining:
+  - [ ] spring selector、validation、力–伸長比較、復元方向・wrap・repulsion testを完了する。
+  - [ ] 比較profileのdry-runと短時間checkを完了する。
+  - [ ] ユーザーが長時間比較を実行し、自動判定artifactを生成する。
+  - [ ] 結果をADRとreview resultへ反映し、defaultを確定する。
+- boundaries:
+  - `sim_swim_2010.yaml` 作成とconfig再編はIssue #164で扱う。
+  - 正式な `tau` duration指定はIssue #165で扱う。本Issueの `0.1 tau` / `1 tau` は現行 `tau_s=1.0` 規約の比較profileに限定する。
+- docs:
+  - `docs/phase2/phase2_163_2010_potential_correspondence.md`
+  - `docs/adr/0009_phase2_2010_potential_formulations.md`
+
 ## Phase 2.9: Tumble状態の段階実装
 
 ### P2-9-010: Tumble状態を段階実装する

--- a/scripts/01_simulate_swimming/01_simulate_swimming.py
+++ b/scripts/01_simulate_swimming/01_simulate_swimming.py
@@ -197,6 +197,12 @@ def main(
         cfg.duration_star,
         cfg.total_steps,
     )
+    logger.info(
+        "[potential ] spring formulation=%s, H/(T/b)=%.6g, s=%.6g",
+        cfg.potentials.spring.formulation,
+        cfg.potentials.spring.H_over_T_over_b,
+        cfg.potentials.spring.s,
+    )
 
     n_layers = cfg.compute_body_n_layers()
     l_over_b = cfg.body.length_total_um / max(cfg.scale.b_um, 1e-12)

--- a/scripts/01_simulate_swimming/analyze_spring_formulations.py
+++ b/scripts/01_simulate_swimming/analyze_spring_formulations.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Generate Issue #163 spring formulation comparison and default decision."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+from sim_swim.analysis.cli_profiles import key_value_args_to_cli_args
+from sim_swim.analysis.spring_formulation_comparison import (
+    write_decision_artifacts,
+    write_force_extension_artifacts,
+)
+from sim_swim.core.run_context import init_run
+
+
+def main(argv: list[str] | None = None) -> Path:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--motor-off-summary", type=Path, required=True)
+    parser.add_argument("--motor-on-summary", type=Path, required=True)
+    parser.add_argument(
+        "--output-base-dir",
+        type=Path,
+        default=Path("outputs/phase2_potential_comparison"),
+    )
+    parser.add_argument("--samples", type=int, default=199)
+    args = parser.parse_args(key_value_args_to_cli_args(raw_argv))
+
+    ctx = init_run(
+        args.output_base_dir,
+        input_info={
+            "motor_off_summary": str(args.motor_off_summary),
+            "motor_on_summary": str(args.motor_on_summary),
+            "samples": args.samples,
+        },
+    )
+    csv_path, png_path = write_force_extension_artifacts(
+        ctx.out.root,
+        samples=args.samples,
+    )
+    json_path, markdown_path, decision = write_decision_artifacts(
+        ctx.out.root,
+        motor_off_summary=args.motor_off_summary,
+        motor_on_summary=args.motor_on_summary,
+    )
+    manifest_path = ctx.out.root / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["kind"] = "spring_formulation_comparison"
+    manifest["outputs"].update(
+        {
+            "force_extension_csv": str(csv_path),
+            "force_extension_png": str(png_path),
+            "default_decision_json": str(json_path),
+            "default_decision_markdown": str(markdown_path),
+        }
+    )
+    manifest["decision"] = {
+        "selected_default": decision["selected_default"],
+        "reason": decision["reason"],
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    ctx.logger.info("Selected default: %s", decision["selected_default"])
+    ctx.logger.info("Wrote comparison artifacts: %s", ctx.out.root)
+    print(ctx.out.root)
+    return ctx.out.root
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,6 +82,8 @@ uv run python scripts/01_simulate_swimming/run_multi_run.py \
 | `conf/phase2_sweeps/shape_stability_grid.yaml` | hook / proximal flagellum を含む shape stability grid |
 | `conf/phase2_sweeps/torque_distribution_grid.yaml` | #97 用 torque distribution 2x2 比較 |
 | `conf/phase2_sweeps/hook_overstretch.yaml` | 旧名互換 profile |
+| `conf/phase2_multi_run/spring_formulation_motor_off.yaml` | Issue #163 motor-off `legacy` / `fene_fraenkel` 比較 |
+| `conf/phase2_multi_run/spring_formulation_motor_on.yaml` | Issue #163 motor-on RUN `legacy` / `fene_fraenkel` 比較 |
 
 新規の user-facing 実行では `shape_stability_grid.yaml` を正本として使います。
 `hook_overstretch.yaml` は historical alias であり，既存メモや過去コマンドの互換用です。
@@ -100,6 +102,38 @@ uv run python scripts/01_simulate_swimming/run_sweep.py \
   config=conf/phase2_sweeps/shape_stability_grid.yaml \
   describe_profile=true
 ```
+
+### 2010 spring formulation比較
+
+`potentials.spring.formulation` は `legacy` と `fene_fraenkel` を受け付けます。selectorを省略した既存configは過去互換の `legacy` として読み込みます。単発で論文準拠式を選ぶ場合:
+
+```bash
+uv run python -m scripts.01_simulate_swimming \
+  config=conf/sim_swim.yaml \
+  potentials.spring.formulation=fene_fraenkel \
+  time.duration_s=0.01 \
+  time.dt_star=1.0e-4
+```
+
+Issue #163 のdefault判定用長時間比較は、motor-offとmotor-on RUNを同じseedで実行します。
+
+```bash
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_off.yaml
+
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/spring_formulation_motor_on.yaml
+```
+
+各コマンドが出力したrun rootの `summary.csv` を解析CLIへ渡します。
+
+```bash
+uv run python scripts/01_simulate_swimming/analyze_spring_formulations.py \
+  motor_off_summary=<motor-off-run-root>/summary.csv \
+  motor_on_summary=<motor-on-run-root>/summary.csv
+```
+
+解析runには `force_extension.csv` / `force_extension.png` と、自動採否の `default_decision.json` / `default_decision.md` が出力されます。採否は両runの完走、有限値、body/nonbody strict shape gateを使い、条件を満たす場合だけ `fene_fraenkel` を選びます。この比較に動画目視は要求しません。
 
 ### Heatmap
 

--- a/src/sim_swim/analysis/spring_formulation_comparison.py
+++ b/src/sim_swim/analysis/spring_formulation_comparison.py
@@ -1,0 +1,319 @@
+"""Issue #163 spring formulation comparison artifacts and default selection."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sim_swim.dynamics.forces import compute_spring_forces
+
+FORMULATIONS = ("legacy", "fene_fraenkel")
+FORMULATION_COLUMN = "axis_formulation_value"
+
+
+def force_extension_rows(
+    *,
+    rest_lengths_over_b: Iterable[float] = (0.58, 1.0),
+    h_over_t_over_b: float = 10.0,
+    s: float = 0.1,
+    samples: int = 199,
+    torque_nm: float = 2.5e-20,
+    b_um: float = 1.0,
+) -> list[dict[str, float | str]]:
+    """Return nondimensional force-extension curves for both formulations.
+
+    Values are produced through the production ``compute_spring_forces`` API.
+    Positive values pull the left bead right under extension; negative values
+    push it left under compression. The sample range stays just inside both
+    singular boundaries.
+    """
+
+    if not math.isfinite(h_over_t_over_b) or h_over_t_over_b <= 0.0:
+        raise ValueError("h_over_t_over_b must be finite and positive")
+    if not math.isfinite(s) or not 0.0 < s < 1.0:
+        raise ValueError("s must satisfy 0 < s < 1")
+    if samples < 3:
+        raise ValueError("samples must be at least 3")
+    if not math.isfinite(torque_nm) or torque_nm <= 0.0:
+        raise ValueError("torque_nm must be finite and positive")
+    if not math.isfinite(b_um) or b_um <= 0.0:
+        raise ValueError("b_um must be finite and positive")
+
+    rest_length_values = [float(value) for value in rest_lengths_over_b]
+    if not rest_length_values:
+        raise ValueError("rest_lengths_over_b must be non-empty")
+
+    rows: list[dict[str, float | str]] = []
+    b_m = b_um * 1.0e-6
+    force_scale = torque_nm / b_m
+    h_const = h_over_t_over_b * force_scale
+    spring_pairs = np.array([[0, 1]], dtype=int)
+    for rest in rest_length_values:
+        if not math.isfinite(rest) or rest <= 0.0:
+            raise ValueError("rest lengths must be finite and positive")
+        relative_extensions = np.linspace(-0.99 * s, 0.99 * s, samples)
+        for formulation in FORMULATIONS:
+            for q in relative_extensions:
+                delta_over_b = float(q) * rest
+                distance_m = (rest + delta_over_b) * b_m
+                forces = compute_spring_forces(
+                    np.array([[0.0, 0.0, 0.0], [distance_m, 0.0, 0.0]]),
+                    spring_pairs,
+                    np.array([rest * b_m]),
+                    h_const=h_const,
+                    s=s,
+                    b_m=b_m,
+                    formulation=formulation,
+                )
+                force = float(forces[0, 0])
+                rows.append(
+                    {
+                        "formulation": formulation,
+                        "rest_length_over_b": rest,
+                        "relative_extension_q": float(q),
+                        "extension_over_b": delta_over_b,
+                        "distance_over_b": rest + delta_over_b,
+                        "force_N": force,
+                        "force_over_t_over_b": force / force_scale,
+                    }
+                )
+    return rows
+
+
+def write_force_extension_artifacts(
+    output_dir: Path,
+    *,
+    rest_lengths_over_b: Iterable[float] = (0.58, 1.0),
+    h_over_t_over_b: float = 10.0,
+    s: float = 0.1,
+    samples: int = 199,
+) -> tuple[Path, Path]:
+    rows = force_extension_rows(
+        rest_lengths_over_b=rest_lengths_over_b,
+        h_over_t_over_b=h_over_t_over_b,
+        s=s,
+        samples=samples,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "force_extension.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    rest_values = list(dict.fromkeys(float(row["rest_length_over_b"]) for row in rows))
+    figure, axes_grid = plt.subplots(
+        1,
+        len(rest_values),
+        figsize=(5 * len(rest_values), 4),
+        sharey=False,
+        squeeze=False,
+    )
+    axes = axes_grid[0]
+    for axis, rest in zip(axes, rest_values, strict=True):
+        for formulation in FORMULATIONS:
+            selected = [
+                row
+                for row in rows
+                if row["formulation"] == formulation
+                and row["rest_length_over_b"] == rest
+            ]
+            axis.plot(
+                [float(row["relative_extension_q"]) for row in selected],
+                [float(row["force_N"]) for row in selected],
+                label=formulation,
+            )
+        axis.axhline(0.0, color="black", linewidth=0.7)
+        axis.axvline(0.0, color="black", linewidth=0.7)
+        axis.set_title(f"L/b = {rest:g}")
+        axis.set_xlabel("relative extension q = (d-L)/L")
+        axis.set_ylabel("production spring force on left bead [N]")
+        axis.grid(alpha=0.25)
+    axes[0].legend()
+    figure.tight_layout()
+    png_path = output_dir / "force_extension.png"
+    figure.savefig(png_path, dpi=160)
+    plt.close(figure)
+    return csv_path, png_path
+
+
+def _read_summary(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows:
+        raise ValueError(f"summary.csv is empty: {path}")
+    return rows
+
+
+def _parse_bool(value: str | None) -> bool | None:
+    text = str(value or "").strip().lower()
+    if text in {"1", "true", "yes", "pass"}:
+        return True
+    if text in {"0", "false", "no", "fail"}:
+        return False
+    return None
+
+
+def _formulation(row: dict[str, str]) -> str:
+    for key in (FORMULATION_COLUMN, "axis_formulation_label", "formulation"):
+        value = str(row.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _evaluate_row(row: dict[str, str] | None) -> dict[str, Any]:
+    reasons: list[str] = []
+    if row is None:
+        return {"pass": False, "reasons": ["summary row is missing"]}
+
+    nonbody = _parse_bool(row.get("final_shape_pass_nonbody"))
+    body = _parse_bool(row.get("body_shape_pass"))
+    if nonbody is not True:
+        reasons.append("final_shape_pass_nonbody is not true")
+    if body is not True:
+        reasons.append("body_shape_pass is not true")
+    if str(row.get("first_fail_t_s", "")).strip():
+        reasons.append("first_fail_t_s is present")
+
+    final_t_s: float | None = None
+    duration_s: float | None = None
+    for field in ("duration_s", "final_t_s"):
+        value = str(row.get(field, "")).strip()
+        if not value:
+            reasons.append(f"{field} is missing")
+            continue
+        try:
+            parsed = float(value)
+        except ValueError:
+            reasons.append(f"{field} is not numeric")
+            continue
+        if not math.isfinite(parsed):
+            reasons.append(f"{field} is non-finite")
+            continue
+        if field == "duration_s":
+            duration_s = parsed
+        else:
+            final_t_s = parsed
+    if (
+        final_t_s is not None
+        and duration_s is not None
+        and final_t_s < duration_s - max(1.0e-12, duration_s * 1.0e-9)
+    ):
+        reasons.append("final_t_s did not reach duration_s")
+
+    finite_metric_fields = {
+        "max_flag_bond_rel_err": ("max_flag_bond_rel_err",),
+        "max_hook_len_rel_err": (
+            "max_hook_len_rel_err",
+            "hook_len_rel_err_max",
+        ),
+    }
+    for field, aliases in finite_metric_fields.items():
+        value = next(
+            (
+                str(row.get(alias, "")).strip()
+                for alias in aliases
+                if str(row.get(alias, "")).strip()
+            ),
+            "",
+        )
+        if value:
+            try:
+                if not math.isfinite(float(value)):
+                    reasons.append(f"{field} is non-finite")
+            except ValueError:
+                reasons.append(f"{field} is not numeric")
+    return {"pass": not reasons, "reasons": reasons}
+
+
+def decide_default(
+    motor_off_summary: Path,
+    motor_on_summary: Path,
+) -> dict[str, Any]:
+    """Apply the accepted #163 default-selection rule to two campaign summaries."""
+
+    evaluations: dict[str, dict[str, Any]] = {name: {} for name in FORMULATIONS}
+    inputs = {
+        "motor_off": motor_off_summary,
+        "motor_on": motor_on_summary,
+    }
+    for run_name, path in inputs.items():
+        rows = _read_summary(path)
+        by_formulation: dict[str, dict[str, str]] = {}
+        for row in rows:
+            formulation = _formulation(row)
+            if formulation in by_formulation:
+                raise ValueError(f"duplicate {formulation} row in {path}")
+            by_formulation[formulation] = row
+        for formulation in FORMULATIONS:
+            evaluations[formulation][run_name] = _evaluate_row(
+                by_formulation.get(formulation)
+            )
+
+    for formulation in FORMULATIONS:
+        evaluations[formulation]["overall_pass"] = all(
+            evaluations[formulation][run_name]["pass"] for run_name in inputs
+        )
+    fene_pass = evaluations["fene_fraenkel"]["overall_pass"]
+    selected = "fene_fraenkel" if fene_pass else "legacy"
+    reason = (
+        "fene_fraenkel passed strict body and non-body gates in both runs"
+        if fene_pass
+        else "fene_fraenkel did not pass both runs; retain legacy compatibility"
+    )
+    return {
+        "decision_rule": "prefer fene_fraenkel only when it passes both runs",
+        "selected_default": selected,
+        "reason": reason,
+        "inputs": {name: str(path) for name, path in inputs.items()},
+        "evaluations": evaluations,
+    }
+
+
+def write_decision_artifacts(
+    output_dir: Path,
+    *,
+    motor_off_summary: Path,
+    motor_on_summary: Path,
+) -> tuple[Path, Path, dict[str, Any]]:
+    decision = decide_default(motor_off_summary, motor_on_summary)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "default_decision.json"
+    json_path.write_text(
+        json.dumps(decision, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    lines = [
+        "# Spring formulation default decision",
+        "",
+        f"- Selected default: `{decision['selected_default']}`",
+        f"- Rule: {decision['decision_rule']}",
+        f"- Reason: {decision['reason']}",
+        "",
+        "| formulation | motor-off | motor-on | overall |",
+        "|---|---:|---:|---:|",
+    ]
+    for formulation in FORMULATIONS:
+        evaluation = decision["evaluations"][formulation]
+        lines.append(
+            f"| `{formulation}` | {evaluation['motor_off']['pass']} | "
+            f"{evaluation['motor_on']['pass']} | {evaluation['overall_pass']} |"
+        )
+        for run_name in ("motor_off", "motor_on"):
+            for reason in evaluation[run_name]["reasons"]:
+                lines.append(f"\n- `{formulation}` / `{run_name}`: {reason}")
+    markdown_path = output_dir / "default_decision.md"
+    markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, markdown_path, decision

--- a/src/sim_swim/analysis/spring_formulation_comparison.py
+++ b/src/sim_swim/analysis/spring_formulation_comparison.py
@@ -295,13 +295,32 @@ def decide_default(
         "motor_on": motor_on_summary,
     }
     for run_name, path in inputs.items():
-        rows = _read_summary(path)
+        try:
+            rows = _read_summary(path)
+        except (OSError, ValueError, csv.Error) as exc:
+            reason = f"summary is unavailable or invalid: {exc}"
+            for formulation in FORMULATIONS:
+                evaluations[formulation][run_name] = {
+                    "pass": False,
+                    "reasons": [reason],
+                }
+            continue
         by_formulation: dict[str, dict[str, str]] = {}
+        duplicate_formulation = ""
         for row in rows:
             formulation = _formulation(row)
             if formulation in by_formulation:
-                raise ValueError(f"duplicate {formulation} row in {path}")
+                duplicate_formulation = formulation
+                break
             by_formulation[formulation] = row
+        if duplicate_formulation:
+            reason = f"duplicate {duplicate_formulation} row in {path}"
+            for formulation in FORMULATIONS:
+                evaluations[formulation][run_name] = {
+                    "pass": False,
+                    "reasons": [reason],
+                }
+            continue
         for formulation in FORMULATIONS:
             evaluations[formulation][run_name] = _evaluate_row(
                 by_formulation.get(formulation)

--- a/src/sim_swim/analysis/spring_formulation_comparison.py
+++ b/src/sim_swim/analysis/spring_formulation_comparison.py
@@ -173,6 +173,45 @@ def _formulation(row: dict[str, str]) -> str:
     return ""
 
 
+def _step_summary_reaches_duration(
+    row: dict[str, str],
+    *,
+    duration_s: float,
+    final_t_s: float,
+) -> tuple[bool, str | None]:
+    output_dir = str(row.get("output_dir", "")).strip()
+    if not output_dir:
+        return False, None
+    step_summary = Path(output_dir) / "step_summary.csv"
+    if not step_summary.is_file():
+        return False, f"step_summary.csv is missing: {step_summary}"
+
+    with step_summary.open("r", encoding="utf-8", newline="") as handle:
+        step_rows = list(csv.DictReader(handle))
+    if len(step_rows) < 2:
+        return False, "step_summary.csv has fewer than two rows"
+
+    try:
+        steps = [int(step_row["step"]) for step_row in step_rows]
+        times = [float(step_row["t_s"]) for step_row in step_rows]
+    except (KeyError, TypeError, ValueError):
+        return False, "step_summary.csv has invalid step or t_s values"
+    if steps != list(range(len(steps))):
+        return False, "step_summary.csv step indices are not contiguous from zero"
+    if not all(math.isfinite(value) for value in times):
+        return False, "step_summary.csv contains non-finite t_s values"
+
+    observed_dt_s = times[-1] - times[-2]
+    tolerance = max(1.0e-12, duration_s * 1.0e-9)
+    if observed_dt_s <= 0.0 or not math.isfinite(observed_dt_s):
+        return False, "step_summary.csv final time interval is invalid"
+    if not math.isclose(times[-1], final_t_s, rel_tol=1.0e-9, abs_tol=tolerance):
+        return False, "summary final_t_s does not match step_summary.csv"
+    if times[-1] + observed_dt_s < duration_s - tolerance:
+        return False, "step_summary.csv did not reach duration_s"
+    return True, None
+
+
 def _evaluate_row(row: dict[str, str] | None) -> dict[str, Any]:
     reasons: list[str] = []
     if row is None:
@@ -206,12 +245,18 @@ def _evaluate_row(row: dict[str, str] | None) -> dict[str, Any]:
             duration_s = parsed
         else:
             final_t_s = parsed
-    if (
-        final_t_s is not None
-        and duration_s is not None
-        and final_t_s < duration_s - max(1.0e-12, duration_s * 1.0e-9)
-    ):
-        reasons.append("final_t_s did not reach duration_s")
+    if final_t_s is not None and duration_s is not None:
+        tolerance = max(1.0e-12, duration_s * 1.0e-9)
+        if final_t_s < duration_s - tolerance:
+            completed, completion_reason = _step_summary_reaches_duration(
+                row,
+                duration_s=duration_s,
+                final_t_s=final_t_s,
+            )
+            if not completed:
+                reasons.append(
+                    completion_reason or "final_t_s did not reach duration_s"
+                )
 
     finite_metric_fields = {
         "max_flag_bond_rel_err": ("max_flag_bond_rel_err",),

--- a/src/sim_swim/dynamics/engine.py
+++ b/src/sim_swim/dynamics/engine.py
@@ -124,7 +124,9 @@ class DynamicsEngine:
         torque = max(cfg.torque_for_forces_Nm, 1e-30)
         b_m = cfg.b_m
         self.spring_h = cfg.potentials.spring.H_over_T_over_b * torque / max(b_m, 1e-30)
-        self.spring_s_m = cfg.potentials.spring.s * b_m
+        self.spring_s = cfg.potentials.spring.s
+        self.spring_formulation = cfg.potentials.spring.formulation
+        self.b_m = b_m
         self.k_bend = cfg.potentials.bend.kb_over_T * torque
         self.k_torsion = cfg.potentials.torsion.kt_over_T * torque
         self.torsion_fd_eps_m = max(cfg.potentials.torsion.fd_eps_over_b * b_m, 1e-12)
@@ -759,7 +761,9 @@ class DynamicsEngine:
                     self.body_spring_rows
                 ],
                 h_const=self.spring_h * self.body_stiffness_scale,
-                s_limit_m=self.spring_s_m,
+                s=self.spring_s,
+                b_m=self.b_m,
+                formulation=self.spring_formulation,
                 clamp_eps=1e-3,
             )
         if self.hook_spring_rows.size > 0:
@@ -772,7 +776,9 @@ class DynamicsEngine:
                     self.hook_spring_rows
                 ],
                 h_const=self.spring_h * (hook_spring_scale if motor_on else 1.0),
-                s_limit_m=self.spring_s_m,
+                s=self.spring_s,
+                b_m=self.b_m,
+                formulation=self.spring_formulation,
                 clamp_eps=1e-3,
             )
         if self.flag_local_spring_rows.size > 0:
@@ -787,7 +793,9 @@ class DynamicsEngine:
                 h_const=self.spring_h
                 * self.flag_spring_stiffness_scale
                 * (first_second_spring_scale if motor_on else 1.0),
-                s_limit_m=self.spring_s_m,
+                s=self.spring_s,
+                b_m=self.b_m,
+                formulation=self.spring_formulation,
                 clamp_eps=1e-3,
             )
         if self.flag_proximal_spring_rows.size > 0:
@@ -800,7 +808,9 @@ class DynamicsEngine:
                 h_const=self.spring_h
                 * self.flag_spring_stiffness_scale
                 * self.proximal_flag_spring_stiffness_scale,
-                s_limit_m=self.spring_s_m,
+                s=self.spring_s,
+                b_m=self.b_m,
+                formulation=self.spring_formulation,
                 clamp_eps=1e-3,
             )
         if self.flag_nonlocal_spring_rows.size > 0:
@@ -811,7 +821,9 @@ class DynamicsEngine:
                     self.flag_nonlocal_spring_rows
                 ],
                 h_const=self.spring_h * self.flag_spring_stiffness_scale,
-                s_limit_m=self.spring_s_m,
+                s=self.spring_s,
+                b_m=self.b_m,
+                formulation=self.spring_formulation,
                 clamp_eps=1e-3,
             )
         bend_forces = np.zeros_like(pos)

--- a/src/sim_swim/dynamics/forces.py
+++ b/src/sim_swim/dynamics/forces.py
@@ -57,16 +57,18 @@ def compute_spring_forces(
     spring_pairs: np.ndarray,
     spring_rest_lengths_m: np.ndarray,
     h_const: float,
-    s_limit_m: float,
+    s: float,
+    b_m: float,
+    formulation: str = "legacy",
     clamp_eps: float = 1e-6,
 ) -> np.ndarray:
-    """Fraenkel型spring力を計算する。"""
+    """Compute legacy or Watari-Larson FENE-Fraenkel spring forces."""
 
     forces = np.zeros_like(positions_m)
     if spring_pairs.size == 0:
         return forces
 
-    s = max(s_limit_m, 1e-15)
+    s_value = max(float(s), 1e-15)
     h = float(h_const)
 
     for idx, (i, j) in enumerate(spring_pairs):
@@ -74,11 +76,35 @@ def compute_spring_forces(
         rj = positions_m[int(j)]
         dvec = ri - rj
         d = _safe_norm(dvec)
-        x = d - float(spring_rest_lengths_m[idx])
-        x = float(np.clip(x, -(1.0 - clamp_eps) * s, (1.0 - clamp_eps) * s))
-        denom = 1.0 - (x * x) / (s * s)
-        dU_dd = h * x / (denom * denom)
-        fij = -dU_dd * (dvec / d)
+        rest = max(float(spring_rest_lengths_m[idx]), 1e-30)
+        x = d - rest
+        if formulation == "legacy":
+            limit_m = max(s_value * float(b_m), 1e-15)
+            x = float(
+                np.clip(
+                    x,
+                    -(1.0 - clamp_eps) * limit_m,
+                    (1.0 - clamp_eps) * limit_m,
+                )
+            )
+            denom = 1.0 - (x * x) / (limit_m * limit_m)
+            force_magnitude = h * x / (denom * denom)
+        elif formulation == "fene_fraenkel":
+            relative_extension = x / rest
+            relative_extension = float(
+                np.clip(
+                    relative_extension,
+                    -(1.0 - clamp_eps) * s_value,
+                    (1.0 - clamp_eps) * s_value,
+                )
+            )
+            denom = 1.0 - (relative_extension * relative_extension) / (
+                s_value * s_value
+            )
+            force_magnitude = h * relative_extension / denom
+        else:
+            raise ValueError(f"Unsupported spring formulation: {formulation!r}")
+        fij = -force_magnitude * (dvec / d)
         forces[int(i)] += fij
         forces[int(j)] -= fij
 

--- a/src/sim_swim/sim/core.py
+++ b/src/sim_swim/sim/core.py
@@ -254,6 +254,13 @@ class Simulator:
         pitch_target_over_b = float(self.config.flagella.helix_init.pitch_over_b)
 
         summary: dict[str, Any] = {
+            "potentials": {
+                "spring_formulation": str(self.config.potentials.spring.formulation),
+                "spring_H_over_T_over_b": float(
+                    self.config.potentials.spring.H_over_T_over_b
+                ),
+                "spring_s": float(self.config.potentials.spring.s),
+            },
             "flagella": {
                 "init_mode": str(self.config.flagella.init_mode),
                 "placement_mode": str(self.config.flagella.placement_mode),

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -41,6 +41,8 @@ MOTOR_TORQUE_DISTRIBUTION_PROFILE_ALIASES = {
 }
 MOTOR_ATTACH_FRAME_TANGENT_MODE_DEFAULT = "vector"
 MOTOR_ATTACH_FRAME_TANGENT_MODES = frozenset({"vector", "basal_bearing"})
+SPRING_FORMULATION_DEFAULT = "legacy"
+SPRING_FORMULATIONS = frozenset({"legacy", "fene_fraenkel"})
 MOTOR_LOCAL_SCALE_KEYS = (
     "local_hook_scale",
     "local_spring_scale",
@@ -135,6 +137,19 @@ def normalize_motor_attach_frame_tangent_mode(value: Any) -> str:
             f"{mode!r}. Use one of: {supported}."
         )
     return mode
+
+
+def normalize_spring_formulation(value: Any) -> str:
+    """Validate the spring force formulation selector."""
+
+    formulation = str(value)
+    if formulation not in SPRING_FORMULATIONS:
+        supported = ", ".join(sorted(SPRING_FORMULATIONS))
+        raise ValueError(
+            "Unsupported potentials.spring.formulation: "
+            f"{formulation!r}. Use one of: {supported}."
+        )
+    return formulation
 
 
 class DynamicsMode(Enum):
@@ -322,6 +337,7 @@ class MotorParams:
 class SpringPotentialParams:
     """springポテンシャル設定。"""
 
+    formulation: str = SPRING_FORMULATION_DEFAULT
     H_over_T_over_b: float = 10.0
     s: float = 0.1
 
@@ -657,6 +673,11 @@ class SimulationConfig:
         add("flagella.n_flagella", self.flagella.n_flagella, 3)
         add("scale.bead_radius_a_over_b", self.scale.bead_radius_a_over_b, 0.1)
         add(
+            "potentials.spring.formulation",
+            self.potentials.spring.formulation,
+            "fene_fraenkel",
+        )
+        add(
             "potentials.spring.H_over_T_over_b",
             self.potentials.spring.H_over_T_over_b,
             10.0,
@@ -903,15 +924,29 @@ class SimulationConfig:
         b_m = max(scale.b_um, 1e-9) * 1e-6
 
         spring_raw = (raw.get("potentials", {}) or {}).get("spring", {}) or {}
+        spring_formulation = normalize_spring_formulation(
+            _get(spring_raw, "formulation", SPRING_FORMULATION_DEFAULT)
+        )
         h_over = spring_raw.get("H_over_T_over_b")
         if h_over is None and "H" in spring_raw:
             h_over = float(spring_raw["H"]) * b_m / max(thermal, 1e-30)
         s_val = spring_raw.get("s")
         if s_val is None and "s_um" in spring_raw:
             s_val = float(spring_raw["s_um"]) / max(scale.b_um, 1e-12)
+        h_over_value = float(h_over if h_over is not None else 10.0)
+        s_value = float(s_val if s_val is not None else 0.1)
+        if not math.isfinite(h_over_value) or h_over_value <= 0.0:
+            raise ValueError("potentials.spring.H_over_T_over_b must be positive.")
+        if not math.isfinite(s_value) or s_value <= 0.0:
+            raise ValueError("potentials.spring.s must be positive.")
+        if spring_formulation == "fene_fraenkel" and s_value >= 1.0:
+            raise ValueError(
+                "potentials.spring.s must be smaller than 1 for fene_fraenkel."
+            )
         spring = SpringPotentialParams(
-            H_over_T_over_b=float(h_over if h_over is not None else 10.0),
-            s=float(s_val if s_val is not None else 0.1),
+            formulation=spring_formulation,
+            H_over_T_over_b=h_over_value,
+            s=s_value,
         )
 
         bend_raw = (raw.get("potentials", {}) or {}).get("bend", {}) or {}

--- a/tests/test_phase2_163_spring_formulation_comparison.py
+++ b/tests/test_phase2_163_spring_formulation_comparison.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from sim_swim.analysis.multi_run_campaign import (
+    build_campaign_conditions,
+    load_yaml,
+    normalize_campaign_config,
+)
+from sim_swim.analysis.spring_formulation_comparison import (
+    decide_default,
+    force_extension_rows,
+    write_force_extension_artifacts,
+)
+from sim_swim.sim.params import SimulationConfig
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_summary(
+    path: Path,
+    *,
+    fene_pass: bool,
+    legacy_pass: bool = True,
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "axis_formulation_value",
+                "duration_s",
+                "final_t_s",
+                "final_shape_pass_nonbody",
+                "body_shape_pass",
+                "first_fail_t_s",
+                "max_flag_bond_rel_err",
+                "max_hook_len_rel_err",
+            ],
+        )
+        writer.writeheader()
+        for formulation, passed in (
+            ("legacy", legacy_pass),
+            ("fene_fraenkel", fene_pass),
+        ):
+            writer.writerow(
+                {
+                    "axis_formulation_value": formulation,
+                    "duration_s": "1.0",
+                    "final_t_s": "1.0",
+                    "final_shape_pass_nonbody": str(passed),
+                    "body_shape_pass": str(passed),
+                    "first_fail_t_s": "" if passed else "0.25",
+                    "max_flag_bond_rel_err": "0.01",
+                    "max_hook_len_rel_err": "0.02",
+                }
+            )
+
+
+@pytest.mark.light
+@pytest.mark.parametrize(
+    ("profile_name", "duration_s", "torque_nm"),
+    [
+        ("spring_formulation_motor_off.yaml", 0.1, 0.0),
+        ("spring_formulation_motor_on.yaml", 1.0, 2.5e-20),
+    ],
+)
+def test_spring_formulation_profiles_expand_two_conditions(
+    profile_name: str,
+    duration_s: float,
+    torque_nm: float,
+) -> None:
+    profile = normalize_campaign_config(
+        load_yaml(ROOT / "conf/phase2_multi_run" / profile_name)
+    )
+    conditions = build_campaign_conditions(profile)
+
+    assert [condition["condition_id"] for condition in conditions] == [
+        "legacy",
+        "fene_fraenkel",
+    ]
+    assert profile["base_overrides"]["time"]["duration_s"] == duration_s
+    assert profile["base_overrides"]["time"]["dt_star"] == 1.0e-4
+    assert profile["base_overrides"]["motor"]["torque_Nm"] == torque_nm
+    assert profile["base_overrides"]["motor"]["enable_switching"] is False
+    assert (
+        conditions[1]["config_overrides"]["potentials"]["spring"]["formulation"]
+        == "fene_fraenkel"
+    )
+    base_config = load_yaml(ROOT / str(profile["base_config"]))
+    effective_configs = [
+        SimulationConfig.from_dict(base_config).with_overrides(
+            condition["config_overrides"]
+        )
+        for condition in conditions
+    ]
+    assert [cfg.potentials.spring.formulation for cfg in effective_configs] == [
+        "legacy",
+        "fene_fraenkel",
+    ]
+
+
+@pytest.mark.light
+def test_force_extension_uses_expected_equilibrium_and_relative_fene_curve() -> None:
+    rows = force_extension_rows(samples=199)
+
+    equilibrium = [
+        row for row in rows if abs(float(row["relative_extension_q"])) < 1.0e-12
+    ]
+    assert len(equilibrium) == 4
+    assert all(abs(float(row["force_N"])) < 1.0e-30 for row in equilibrium)
+
+    fene_at_q = [
+        row
+        for row in rows
+        if row["formulation"] == "fene_fraenkel"
+        and abs(float(row["relative_extension_q"]) - 0.05) < 1.0e-12
+    ]
+    assert len(fene_at_q) == 2
+    assert float(fene_at_q[0]["force_N"]) == pytest.approx(
+        float(fene_at_q[1]["force_N"])
+    )
+
+
+@pytest.mark.light
+def test_default_decision_prefers_fene_only_when_both_runs_pass(
+    tmp_path: Path,
+) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+
+    assert decide_default(motor_off, motor_on)["selected_default"] == ("fene_fraenkel")
+
+    _write_summary(motor_on, fene_pass=False)
+    decision = decide_default(motor_off, motor_on)
+    assert decision["selected_default"] == "legacy"
+    assert decision["evaluations"]["fene_fraenkel"]["overall_pass"] is False
+
+
+@pytest.mark.light
+def test_missing_formulation_row_retains_legacy(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+    rows = list(csv.DictReader(motor_on.open(encoding="utf-8", newline="")))
+    with motor_on.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerow(rows[0])
+
+    decision = decide_default(motor_off, motor_on)
+    assert decision["selected_default"] == "legacy"
+    assert decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"] == [
+        "summary row is missing"
+    ]
+
+
+@pytest.mark.light
+def test_incomplete_run_retains_legacy(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+    rows = list(csv.DictReader(motor_on.open(encoding="utf-8", newline="")))
+    rows[1]["final_t_s"] = "0.5"
+    with motor_on.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    decision = decide_default(motor_off, motor_on)
+    assert decision["selected_default"] == "legacy"
+    assert (
+        "final_t_s did not reach duration_s"
+        in decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"]
+    )
+
+
+@pytest.mark.light
+def test_non_finite_summary_metric_retains_legacy(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+    rows = list(csv.DictReader(motor_on.open(encoding="utf-8", newline="")))
+    rows[1]["max_hook_len_rel_err"] = "nan"
+    with motor_on.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    decision = decide_default(motor_off, motor_on)
+
+    assert decision["selected_default"] == "legacy"
+    assert (
+        "max_hook_len_rel_err is non-finite"
+        in decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"]
+    )
+
+
+@pytest.mark.light
+def test_comparison_cli_writes_run_contract(tmp_path: Path, monkeypatch) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+
+    script_path = ROOT / "scripts/01_simulate_swimming/analyze_spring_formulations.py"
+    spec = importlib.util.spec_from_file_location(
+        "analyze_spring_formulations", script_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr("sim_swim.core.run_context._require_clean_git", lambda: None)
+
+    output_root = module.main(
+        [
+            f"motor_off_summary={motor_off}",
+            f"motor_on_summary={motor_on}",
+            f"output_base_dir={tmp_path / 'output'}",
+            "samples=9",
+        ]
+    )
+
+    assert (output_root / "run.log").is_file()
+    assert (output_root / "force_extension.csv").is_file()
+    assert (output_root / "force_extension.png").is_file()
+    assert (output_root / "default_decision.json").is_file()
+    assert (output_root / "default_decision.md").is_file()
+    manifest = json.loads((output_root / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["kind"] == "spring_formulation_comparison"
+    assert manifest["run_time"]["timezone"] == "Asia/Tokyo"
+    assert manifest["decision"]["selected_default"] == "fene_fraenkel"
+
+
+@pytest.mark.light
+def test_force_extension_writer_creates_csv_and_png(tmp_path: Path) -> None:
+    csv_path, png_path = write_force_extension_artifacts(tmp_path, samples=9)
+    assert csv_path.is_file()
+    assert png_path.is_file()

--- a/tests/test_phase2_163_spring_formulation_comparison.py
+++ b/tests/test_phase2_163_spring_formulation_comparison.py
@@ -184,6 +184,73 @@ def test_incomplete_run_retains_legacy(tmp_path: Path) -> None:
 
 
 @pytest.mark.light
+def test_final_step_start_time_is_accepted_as_complete(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+
+    rows = list(csv.DictReader(motor_on.open(encoding="utf-8", newline="")))
+    for row in rows:
+        condition_dir = tmp_path / row["axis_formulation_value"]
+        condition_dir.mkdir()
+        row["output_dir"] = str(condition_dir)
+        row["final_t_s"] = "0.9"
+        with (condition_dir / "step_summary.csv").open(
+            "w", encoding="utf-8", newline=""
+        ) as handle:
+            writer = csv.DictWriter(handle, fieldnames=["step", "t_s"])
+            writer.writeheader()
+            writer.writerows([{"step": step, "t_s": step * 0.1} for step in range(10)])
+    with motor_on.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    decision = decide_default(motor_off, motor_on)
+
+    assert decision["selected_default"] == "fene_fraenkel"
+
+
+@pytest.mark.light
+def test_non_contiguous_step_summary_retains_legacy(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    _write_summary(motor_on, fene_pass=True)
+
+    rows = list(csv.DictReader(motor_on.open(encoding="utf-8", newline="")))
+    condition_dir = tmp_path / "fene_fraenkel"
+    condition_dir.mkdir()
+    rows[0]["output_dir"] = ""
+    rows[1]["output_dir"] = str(condition_dir)
+    rows[1]["final_t_s"] = "0.9"
+    with (condition_dir / "step_summary.csv").open(
+        "w", encoding="utf-8", newline=""
+    ) as handle:
+        writer = csv.DictWriter(handle, fieldnames=["step", "t_s"])
+        writer.writeheader()
+        writer.writerows(
+            [
+                {"step": 0, "t_s": 0.0},
+                {"step": 2, "t_s": 0.9},
+            ]
+        )
+    with motor_on.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    decision = decide_default(motor_off, motor_on)
+
+    assert decision["selected_default"] == "legacy"
+    assert (
+        "step_summary.csv step indices are not contiguous from zero"
+        in decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"]
+    )
+
+
+@pytest.mark.light
 def test_non_finite_summary_metric_retains_legacy(tmp_path: Path) -> None:
     motor_off = tmp_path / "motor_off.csv"
     motor_on = tmp_path / "motor_on.csv"

--- a/tests/test_phase2_163_spring_formulation_comparison.py
+++ b/tests/test_phase2_163_spring_formulation_comparison.py
@@ -15,6 +15,7 @@ from sim_swim.analysis.multi_run_campaign import (
 from sim_swim.analysis.spring_formulation_comparison import (
     decide_default,
     force_extension_rows,
+    write_decision_artifacts,
     write_force_extension_artifacts,
 )
 from sim_swim.sim.params import SimulationConfig
@@ -167,6 +168,44 @@ def test_missing_formulation_row_retains_legacy(tmp_path: Path) -> None:
     assert decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"] == [
         "summary row is missing"
     ]
+
+
+@pytest.mark.light
+def test_missing_summary_retains_legacy_and_records_failure(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "missing_motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+
+    json_path, markdown_path, decision = write_decision_artifacts(
+        tmp_path / "decision",
+        motor_off_summary=motor_off,
+        motor_on_summary=motor_on,
+    )
+
+    assert decision["selected_default"] == "legacy"
+    assert json_path.is_file()
+    assert markdown_path.is_file()
+    for formulation in ("legacy", "fene_fraenkel"):
+        evaluation = decision["evaluations"][formulation]["motor_on"]
+        assert evaluation["pass"] is False
+        assert "summary is unavailable or invalid" in evaluation["reasons"][0]
+        assert str(motor_on) in evaluation["reasons"][0]
+
+
+@pytest.mark.light
+def test_empty_summary_retains_legacy_and_records_failure(tmp_path: Path) -> None:
+    motor_off = tmp_path / "motor_off.csv"
+    motor_on = tmp_path / "empty_motor_on.csv"
+    _write_summary(motor_off, fene_pass=True)
+    motor_on.write_text("axis_formulation_value\n", encoding="utf-8")
+
+    decision = decide_default(motor_off, motor_on)
+
+    assert decision["selected_default"] == "legacy"
+    assert (
+        "summary.csv is empty"
+        in decision["evaluations"]["fene_fraenkel"]["motor_on"]["reasons"][0]
+    )
 
 
 @pytest.mark.light

--- a/tests/test_phase2_163_spring_formulation_comparison.py
+++ b/tests/test_phase2_163_spring_formulation_comparison.py
@@ -22,6 +22,13 @@ from sim_swim.sim.params import SimulationConfig
 ROOT = Path(__file__).resolve().parents[1]
 
 
+@pytest.mark.light
+def test_repository_default_uses_selected_fene_fraenkel() -> None:
+    cfg = SimulationConfig.from_dict(load_yaml(ROOT / "conf/sim_swim.yaml"))
+
+    assert cfg.potentials.spring.formulation == "fene_fraenkel"
+
+
 def _write_summary(
     path: Path,
     *,

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from sim_swim.dynamics.forces import (
+    compute_bending_forces,
+    compute_hook_forces,
+    compute_segment_repulsion_forces,
+    compute_spring_forces,
+    compute_torsion_forces,
+)
+from sim_swim.dynamics.engine import DynamicsEngine
+from sim_swim.model.builder import ModelBuilder, _segment_pairs_without_neighbors
+from sim_swim.sim.params import SimulationConfig
+
+pytestmark = pytest.mark.light
+
+
+def _spring_force(
+    distance: float,
+    *,
+    rest_length: float = 0.58,
+    h_const: float = 2.0,
+    s_limit: float = 0.1,
+    formulation: str,
+) -> np.ndarray:
+    return compute_spring_forces(
+        positions_m=np.array([[0.0, 0.0, 0.0], [distance, 0.0, 0.0]]),
+        spring_pairs=np.array([[0, 1]], dtype=int),
+        spring_rest_lengths_m=np.array([rest_length]),
+        h_const=h_const,
+        s=s_limit,
+        b_m=1.0,
+        formulation=formulation,
+    )
+
+
+@pytest.mark.parametrize("formulation", ["legacy", "fene_fraenkel"])
+def test_spring_force_is_zero_at_rest_length(formulation: str) -> None:
+    forces = _spring_force(0.58, formulation=formulation)
+
+    assert np.allclose(forces, 0.0, atol=1.0e-14)
+
+
+@pytest.mark.parametrize(
+    ("distance", "expected_force_on_left"),
+    [
+        (0.55, -2.0 * 0.03 / (1.0 - (0.03 / 0.1) ** 2) ** 2),
+        (0.61, 2.0 * 0.03 / (1.0 - (0.03 / 0.1) ** 2) ** 2),
+    ],
+)
+def test_legacy_spring_matches_existing_analytic_force(
+    distance: float, expected_force_on_left: float
+) -> None:
+    forces = _spring_force(distance, formulation="legacy")
+
+    assert forces[0, 0] == pytest.approx(expected_force_on_left)
+    assert forces[1, 0] == pytest.approx(-expected_force_on_left)
+
+
+@pytest.mark.parametrize("relative_extension", [-0.03, 0.03])
+def test_fene_fraenkel_matches_relative_extension_analytic_force(
+    relative_extension: float,
+) -> None:
+    rest_length = 0.58
+    h_const = 2.0
+    s_limit = 0.1
+    distance = rest_length * (1.0 + relative_extension)
+    expected = (
+        h_const * relative_extension / (1.0 - (relative_extension / s_limit) ** 2)
+    )
+
+    forces = _spring_force(
+        distance,
+        rest_length=rest_length,
+        h_const=h_const,
+        s_limit=s_limit,
+        formulation="fene_fraenkel",
+    )
+
+    assert forces[0, 0] == pytest.approx(expected)
+    assert forces[1, 0] == pytest.approx(-expected)
+
+
+def test_fene_fraenkel_limit_scales_with_each_bond_rest_length() -> None:
+    relative_extension = 0.05
+    short = _spring_force(
+        0.4 * (1.0 + relative_extension),
+        rest_length=0.4,
+        formulation="fene_fraenkel",
+    )
+    long = _spring_force(
+        0.8 * (1.0 + relative_extension),
+        rest_length=0.8,
+        formulation="fene_fraenkel",
+    )
+
+    assert short[0, 0] == pytest.approx(long[0, 0])
+
+
+def _angle_triplet(theta: float) -> np.ndarray:
+    return np.array(
+        [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [math.cos(theta), math.sin(theta), 0.0]]
+    )
+
+
+@pytest.mark.parametrize("offset", [-0.15, 0.15])
+def test_bending_force_restores_both_sides_of_equilibrium(offset: float) -> None:
+    theta0 = 1.4
+    displaced = _angle_triplet(theta0 + offset)
+    equilibrium = _angle_triplet(theta0)
+
+    forces = compute_bending_forces(
+        positions_m=displaced,
+        triplets=np.array([[0, 1, 2]], dtype=int),
+        theta0_rad=np.array([theta0]),
+        kb=3.0,
+    )
+
+    assert float(np.sum(forces * (equilibrium - displaced))) > 0.0
+    assert np.allclose(forces.sum(axis=0), 0.0, atol=1.0e-12)
+
+
+def _dihedral_quad(phi: float) -> np.ndarray:
+    return np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, math.cos(phi), math.sin(phi)],
+        ]
+    )
+
+
+@pytest.mark.parametrize("offset", [-0.15, 0.15])
+def test_torsion_force_restores_both_sides_of_equilibrium(offset: float) -> None:
+    phi0 = 0.7
+    displaced = _dihedral_quad(phi0 + offset)
+    equilibrium = _dihedral_quad(phi0)
+
+    forces = compute_torsion_forces(
+        positions_m=displaced,
+        quads=np.array([[0, 1, 2, 3]], dtype=int),
+        phi0_rad=np.array([phi0]),
+        kt=2.0,
+        fd_eps_m=1.0e-5,
+    )
+
+    assert float(np.sum(forces * (equilibrium - displaced))) > 0.0
+    assert np.allclose(forces.sum(axis=0), 0.0, atol=1.0e-8)
+
+
+def test_torsion_uses_shortest_error_across_pi_wrap() -> None:
+    phi0 = -math.pi + 0.02
+    displaced = _dihedral_quad(math.pi - 0.02)
+    equilibrium = _dihedral_quad(phi0)
+
+    forces = compute_torsion_forces(
+        positions_m=displaced,
+        quads=np.array([[0, 1, 2, 3]], dtype=int),
+        phi0_rad=np.array([phi0]),
+        kt=2.0,
+        fd_eps_m=1.0e-5,
+    )
+
+    assert float(np.sum(forces * (equilibrium - displaced))) > 0.0
+
+
+def test_hook_is_active_at_or_below_threshold_only() -> None:
+    triplets = np.array([[0, 1, 2]], dtype=int)
+    below = compute_hook_forces(_angle_triplet(math.radians(80.0)), triplets, 2.0, 90.0)
+    boundary = compute_hook_forces(
+        _angle_triplet(math.radians(90.0)), triplets, 2.0, 90.0
+    )
+    above = compute_hook_forces(
+        _angle_triplet(math.radians(100.0)), triplets, 2.0, 90.0
+    )
+
+    assert np.linalg.norm(below) > 0.0
+    assert np.allclose(boundary, 0.0, atol=1.0e-12)
+    assert np.allclose(above, 0.0, atol=1.0e-12)
+
+
+def test_segment_repulsion_balances_force_and_distributes_at_midpoints() -> None:
+    positions = np.array(
+        [
+            [-1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.1, -1.0],
+            [0.0, 0.1, 1.0],
+        ]
+    )
+    forces = compute_segment_repulsion_forces(
+        positions_m=positions,
+        spring_pairs=np.array([[0, 1], [2, 3]], dtype=int),
+        segment_pair_indices=np.array([[0, 1]], dtype=int),
+        a_ss=2.0,
+        cutoff=0.2,
+        a_length=0.5,
+    )
+    expected_magnitude = 2.0 / 0.5 * math.exp(-0.1 / 0.5)
+
+    assert np.allclose(forces.sum(axis=0), 0.0, atol=1.0e-12)
+    assert forces[0, 1] == pytest.approx(-0.5 * expected_magnitude)
+    assert forces[1] == pytest.approx(forces[0])
+    assert forces[2, 1] == pytest.approx(0.5 * expected_magnitude)
+    assert forces[3] == pytest.approx(forces[2])
+
+
+def test_segment_repulsion_is_zero_at_cutoff() -> None:
+    positions = np.array(
+        [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.2, -1.0], [0.0, 0.2, 1.0]]
+    )
+    forces = compute_segment_repulsion_forces(
+        positions_m=positions,
+        spring_pairs=np.array([[0, 1], [2, 3]], dtype=int),
+        segment_pair_indices=np.array([[0, 1]], dtype=int),
+        a_ss=2.0,
+        cutoff=0.2,
+        a_length=0.5,
+    )
+
+    assert np.allclose(forces, 0.0)
+
+
+def test_repulsion_candidates_exclude_segments_with_shared_endpoint() -> None:
+    spring_pairs = np.array([[0, 1], [1, 2], [3, 4]], dtype=int)
+
+    candidates = _segment_pairs_without_neighbors(spring_pairs)
+
+    assert candidates.tolist() == [[0, 2], [1, 2]]
+
+
+def test_repulsion_excludes_body_body_and_keeps_other_segment_pairs() -> None:
+    cfg = SimulationConfig.from_dict(_minimal_config_with_spring(None))
+    engine = DynamicsEngine(ModelBuilder(cfg).build(), cfg)
+    candidates = engine.segment_pair_indices_for_repulsion
+    first_is_body = engine.body_spring_mask[candidates[:, 0]]
+    second_is_body = engine.body_spring_mask[candidates[:, 1]]
+
+    assert not np.any(first_is_body & second_is_body)
+    assert np.any(first_is_body ^ second_is_body)
+    assert np.any(~first_is_body & ~second_is_body)
+
+
+def _minimal_config_with_spring(spring: dict[str, object] | None) -> dict[str, object]:
+    config: dict[str, object] = {
+        "scale": {"b_um": 1.0, "bead_radius_a_over_b": 0.1},
+        "body": {
+            "prism": {
+                "n_prism": 3,
+                "dz_over_b": 0.5,
+                "radius_over_b": 0.5,
+                "axis": "x",
+            },
+            "length_total_um": 2.0,
+        },
+        "fluid": {"viscosity_Pa_s": 1.0e-3},
+        "motor": {"torque_Nm": 0.0, "reverse_n_flagella": 0},
+        "time": {"duration_s": 0.1, "dt_s": 1.0e-3},
+    }
+    if spring is not None:
+        config["potentials"] = {"spring": spring}
+    return config
+
+
+def test_missing_spring_formulation_falls_back_to_legacy() -> None:
+    cfg = SimulationConfig.from_dict(
+        _minimal_config_with_spring({"H_over_T_over_b": 10.0, "s": 0.1})
+    )
+
+    assert cfg.potentials.spring.formulation == "legacy"
+
+
+def test_spring_formulation_accepts_fene_fraenkel() -> None:
+    cfg = SimulationConfig.from_dict(
+        _minimal_config_with_spring(
+            {"formulation": "fene_fraenkel", "H_over_T_over_b": 10.0, "s": 0.1}
+        )
+    )
+
+    assert cfg.potentials.spring.formulation == "fene_fraenkel"
+
+
+@pytest.mark.parametrize(
+    "spring",
+    [
+        {"formulation": "unknown", "H_over_T_over_b": 10.0, "s": 0.1},
+        {"formulation": "legacy", "H_over_T_over_b": 0.0, "s": 0.1},
+        {"formulation": "legacy", "H_over_T_over_b": 10.0, "s": 0.0},
+        {"formulation": "fene_fraenkel", "H_over_T_over_b": 10.0, "s": 1.0},
+    ],
+)
+def test_invalid_spring_parameters_are_rejected(spring: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        SimulationConfig.from_dict(_minimal_config_with_spring(spring))


### PR DESCRIPTION
## Summary

- Watari & Larson (2010) のspring / bending / torsion / hook / spring-spring repulsionを式・次元・復元方向で照合
- `potentials.spring.formulation=legacy|fene_fraenkel` を追加し、selector欠落時はlegacy互換を維持
- force-extension比較、potential単体テスト、motor-off/on比較profile、自動default判定を追加
- user-run比較で両formulationが全gateを通過し、誤差低減と論文一致からdefaultを`fene_fraenkel`へ変更

## Comparison

- motor-off: FENEはlegacy比でmax flag bond誤差49.2%減、body spring最大伸長84.4%減
- motor-on: FENEはlegacy比でmax flag bond誤差84.2%減、body spring最大伸長81.0%減
- 両run・両formulationとも完走、body/nonbody strict shape gate PASS、first failなし
- corrected decision: `outputs/phase2_potential_comparison/2026-08-02/154149/default_decision.json`

## Verification

- `uv run pytest -q tests/test_potentials.py tests/test_phase2_163_spring_formulation_comparison.py`: 35 passed
- `uv run pytest -q -m light`: 228 passed, 240 deselected
- `uv run pytest -q`: 468 passed
- `uv run ruff format --check . && uv run ruff check .`: PASS
- `git diff --check`: PASS
- local `review_result.json`: PASS
- visual review: not required

Closes #163