### PR TITLE
Phase 2 time schema normalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ There is no `prompts/` source of truth in the current repository. Do not recreat
 
 * Do not work directly on `main` or `master`.
 * Check current branch and `git status` before making changes.
+* After a PR is merged, sync the default branch and delete that task branch locally and remotely. Do not delete unmerged branches or branches retained for active follow-up work without an explicit decision.
 * Keep changes within the requested task scope.
 * Do not make broad refactors unless required by the task.
 * Do not add dependencies without explaining why they are necessary.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Phase 2のmodel profileは次の4つです。`2015` profileはgeometry・paper�
 | `conf/sim_swim_2010_paper.yaml` | Watari & Larson (2010) paper参照条件 |
 | `conf/sim_swim_2015.yaml` | 2015 refined modelのproject採用候補 |
 | `conf/sim_swim_2015_paper.yaml` | Kong et al. (2015) paper参照条件 |
+
+Phase 2 の時間指定は `time.duration.value` / `time.duration.unit` と
+`time.integration.dt_star` が正本です。`duration.unit` は `s` または `tau`
+を受け付けます。`time.duration_s`、`time.dt_star`、`time.dt_s` は既存互換の
+deprecated key です。`time.dt_s` は出力・記録間隔であり、内部積分刻みは
+`time.integration.dt_star` から決まります。
+
+内部step数は `total_steps = ceil(duration_tau / dt_star)` です。
+`step_summary.csv` は各stepの開始時刻を `total_steps` 行記録し、state列は
+初期状態を含む `total_steps + 1` 件になります。そのため `ceil` により最終
+state時刻が指定durationをわずかに超える場合があります。
 - `scripts/`: ユーザー向け CLI entrypoints。詳細は `scripts/README.md` を参照してください。
 - `src/`: 再利用可能な実装本体。Phase 2 simulation は `src/sim_swim/` が中心です。
 - `docs/phase2/`: Phase 2 の現在地、task status、設計・検証記録。

--- a/conf/sim_swim_2010.yaml
+++ b/conf/sim_swim_2010.yaml
@@ -43,7 +43,9 @@ fluid:
   viscosity_Pa_s: 0.001        # [Pa*s] 水相当
 
 motor:
+  enabled: true
   torque_Nm: 2.5e-20      # [N*m] Phase 2代表条件のモータートルク(Torque, T)．-1のときはτ=1になるよう「η * b^3」と定義する．
+  reference_torque_Nm: 2.5e-20 # [N*m] 時間換算・無次元係数の参照トルク。2010 projectではtau_s=1固定のためprovenance用
   # motor torque をbead forceへ変換する方式。
   # - root_torque_segment_couples: 既定値。root起点のねじりをsegmentごとのlocal force coupleとして分配し、形状安定性を優先する。
   # - root_torque_axis_projection: flagellum軸まわりの接線方向へzero-net-forceで分配し、軸中心回転の参照比較に使う。
@@ -110,9 +112,12 @@ run_tumble:
   curly1_tau: 400.0            # [tau] tumble 後半（curly1）
 
 time:
-  duration_s: 0.1              # [s] 物理時間（デバッグ固定）
-  dt_s: 1.0e-3                 # [s] 出力・記録間隔。dt_star=null時は内部積分刻みとしても使う
-  dt_star: 1.0e-4              # [-] Phase 2標準の内部積分刻み。null時はdt_s/tau_sを使用
+  duration:
+    value: 0.1                 # [s] 物理時間（デバッグ固定）
+    unit: s                    # s / tau
+  dt_s: 1.0e-3                 # [s] deprecated: 出力・記録間隔。内部積分刻みではない
+  integration:
+    dt_star: 1.0e-4            # [-] Phase 2標準の内部積分刻み
 
 output_sampling:
   out_all_steps_3d: false      # false: 3D は fps_out_3d で間引く。全内部step描画は明示override時のみ

--- a/conf/sim_swim_2010_paper.yaml
+++ b/conf/sim_swim_2010_paper.yaml
@@ -42,8 +42,9 @@ fluid:
   viscosity_Pa_s: 0.001
 
 motor:
+  enabled: true
   # -1 sentinelは現行legacyでT=eta*b^3、tau_s=1 sとするnondimensional paper reference。
-  # 正式なreference torque/time contractへの移行は#165で扱う。
+  # #165以降は2010 paper profile由来のdeprecated compatibilityとしてのみ受け付ける。
   torque_Nm: -1.0
   # tripletはroot局所のforce coupleで、現行実装中のclosest approximation。
   # 論文の駆動条件を厳密に再現する実装は#167の範囲。
@@ -105,9 +106,12 @@ run_tumble:
   curly1_tau: 400.0
 
 time:
-  duration_s: 0.1
-  dt_s: 1.0e-3
-  dt_star: 1.0e-4              # tau duration・実時間換算の正式化は#165で扱う
+  duration:
+    value: 0.1
+    unit: tau
+  dt_s: 1.0e-3                 # [s] deprecated: 出力・記録間隔。内部積分刻みではない
+  integration:
+    dt_star: 1.0e-4
 
 output_sampling:
   out_all_steps_3d: false

--- a/conf/sim_swim_2015.yaml
+++ b/conf/sim_swim_2015.yaml
@@ -44,7 +44,9 @@ fluid:
   viscosity_Pa_s: 0.001
 
 motor:
+  enabled: true
   torque_Nm: 1.2e-18
+  reference_torque_Nm: 1.2e-18
   force_distribution: "triplet" # #167実装前のpaper profile同値
   torque_distribution_profile: "diffusive"
   reverse_n_flagella: 1
@@ -103,9 +105,12 @@ run_tumble:
   curly1_tau: 400.0
 
 time:
-  duration_s: 0.1              # 暫定legacyキー。tau duration契約は#165で扱う
-  dt_s: 1.0e-3
-  dt_star: 1.0e-5
+  duration:
+    value: 1.0
+    unit: tau
+  dt_s: 1.0e-3                 # [s] deprecated: 出力・記録間隔。内部積分刻みではない
+  integration:
+    dt_star: 1.0e-5
 
 output_sampling:
   out_all_steps_3d: false

--- a/conf/sim_swim_2015_paper.yaml
+++ b/conf/sim_swim_2015_paper.yaml
@@ -44,7 +44,9 @@ fluid:
   viscosity_Pa_s: 0.001
 
 motor:
+  enabled: true
   torque_Nm: 1.2e-18           # [N m] 1200 pN nm reference torque
+  reference_torque_Nm: 1.2e-18 # [N m] tau = eta b^3 / T の参照トルク
   # 現行tripletは暫定表現。2015 paperの駆動・反作用条件は#167で実装する。
   force_distribution: "triplet"
   torque_distribution_profile: "diffusive"
@@ -104,9 +106,12 @@ run_tumble:
   curly1_tau: 400.0
 
 time:
-  duration_s: 0.1              # 暫定legacyキー。tau duration契約は#165で扱う
-  dt_s: 1.0e-3
-  dt_star: 1.0e-5              # [-] Kong et al. (2015)の積分刻み
+  duration:
+    value: 1.0
+    unit: tau
+  dt_s: 1.0e-3                 # [s] deprecated: 出力・記録間隔。内部積分刻みではない
+  integration:
+    dt_star: 1.0e-5            # [-] Kong et al. (2015)の積分刻み
 
 output_sampling:
   out_all_steps_3d: false

--- a/docs/adr/0012_phase2_time_schema_profiles.md
+++ b/docs/adr/0012_phase2_time_schema_profiles.md
@@ -1,0 +1,103 @@
+# ADR 0012: Phase 2 time schema と profile別時間スケール
+
+- status: accepted
+- date: 2026-08-02
+- scope: Phase 2 / Issue #165
+
+## Context
+
+従来の Phase 2 config は `time.duration_s` と `time.dt_star` を直接持ち、`tau_s` は実装上 `1.0 s` 固定だった。これは 2010 project profile の過去run互換には必要だが、2015 refined model では論文の `dt_star=1e-5` と `tau = eta b^3 / T` に基づく実時間換算を分離して扱う必要がある。
+
+また `time.dt_s` は名前上は内部積分刻みに見えるが、現行運用では出力・記録間隔として使われる。今回のPRでは互換性を優先し、意味を変えず deprecated key として残す。
+
+## Decision
+
+正式な時間schemaは次とする。
+
+```yaml
+time:
+  duration:
+    value: 1.0
+    unit: tau  # tau / s
+  integration:
+    dt_star: 1.0e-5
+```
+
+`time.duration_s`、`time.dt_star`、`time.dt_s`、CLI shorthand `--duration-s` は deprecated compatibility として受け付ける。新schemaとlegacy flat keyが同時に指定され、同じ意味の値が矛盾する場合は警告ではなく `ValueError` で拒否する。同値なら `time_schema_source=mixed_equivalent` として受理する。
+
+profile別の時間スケールは次のように固定する。
+
+| profile | `tau_s` policy |
+| --- | --- |
+| `conf/sim_swim_2010.yaml` | legacy fixed `tau_s=1.0` |
+| `conf/sim_swim_2010_paper.yaml` | `eta * b_m^3 / abs(reference_torque_Nm)` |
+| `conf/sim_swim_2015.yaml` | `eta * b_m^3 / abs(reference_torque_Nm)` |
+| `conf/sim_swim_2015_paper.yaml` | `eta * b_m^3 / abs(reference_torque_Nm)` |
+
+`motor.enabled` は実駆動ON/OFF、`motor.torque_Nm` は実際に加える符号付きtorque、`motor.reference_torque_Nm` は時間換算と無次元係数の参照torqueを表す。motor-offでも `reference_torque_Nm` は保持する。
+
+`motor.torque_Nm=-1` sentinel は 2010 paper profile由来の legacy compatibility としてだけ `reference_torque_Nm = eta b^3`, `motor_torque_Nm = eta b^3`, `motor_enabled = true` に正規化する。profileなしの古いfixtureは parser互換のため維持するが、canonical 2010 project / 2015 profileでは拒否する。
+
+## Step 時刻契約
+
+内部step数は次で決める。
+
+```text
+total_steps = ceil(duration_tau / dt_star)
+```
+
+出力契約は次のとおり。
+
+```text
+initial state:
+  t = 0
+
+number of states:
+  total_steps + 1
+
+step_summary.csv rows:
+  total_steps
+
+final step_summary time:
+  (total_steps - 1) * dt_star * tau_s
+
+final state time:
+  total_steps * dt_star * tau_s
+```
+
+`step_summary.csv` は各stepの開始時刻を記録する。`ceil` により final state時刻は指定durationをわずかに超える場合がある。この超過は内部積分契約の結果であり、manifestに `final_state_t_s` と `final_step_summary_t_s` を保存して追跡する。
+
+## Manifest
+
+single-run manifest と generic multi-run `run_manifest.json` には、正規化済み時間量として次を保存する。
+
+```text
+duration_value
+duration_unit
+duration_tau
+duration_s
+dt_star
+tau_s
+dt_internal_s
+total_steps
+final_state_t_s
+final_step_summary_t_s
+time_scale_policy
+reference_torque_Nm
+motor_enabled
+motor_torque_Nm
+time_schema_source
+legacy_time_keys_used
+```
+
+`time_schema_source` は `canonical`, `legacy_duration_s`, `legacy_dt_star`, `cli_shorthand`, `mixed_equivalent` のいずれかとする。`legacy_time_keys_used` は旧campaignやreplayがどの互換経路を通ったかを追跡するために保存する。
+
+## Boundaries
+
+2015 profilesは引き続き `implementation_status: pending` とし、parse・正規化・manifest出力の対象に留める。30-bead geometry、2015 paper motor dynamics、stability評価はそれぞれ Issue #166 / #167 / #168 で扱う。
+
+`time.dt_s` から `output.interval_s` または `time.output_interval_s` への名称移行は後続Issueで扱う。今回のPRでは既存互換を優先し、`time.dt_s` の意味を変更しない。
+
+## Verification status
+
+parser unit test、canonical profile test、CLI manifest test、generic multi-run manifest test、invalid schema test、simulation loop契約の既存testで確認する。長時間simulationとvisual review動画生成はIssue #165の完了条件に含めない。

--- a/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
+++ b/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
@@ -9,7 +9,8 @@
     "Separated motor.enabled, motor.torque_Nm, and motor.reference_torque_Nm responsibilities.",
     "Recorded normalized time quantities and compatibility source paths in single-run and campaign manifests.",
     "Documented the ceil(duration_tau / dt_star) step-time contract and kept 2015 geometry/dynamics/stability out of scope.",
-    "Addressed Codex Cloud feedback by making motor.enabled=false override the 2010 paper torque_Nm=-1 sentinel for actual motor drive while preserving reference_torque_Nm."
+    "Addressed Codex Cloud feedback by making motor.enabled=false override the 2010 paper torque_Nm=-1 sentinel for actual motor drive while preserving reference_torque_Nm.",
+    "Addressed Codex Cloud feedback by preserving canonical duration units across partial time overrides and allowing negative signed torque values other than the -1 sentinel."
   ],
   "scope_boundaries": [
     "2015 profiles remain implementation_status=pending and are not made executable.",
@@ -85,6 +86,34 @@
     {
       "command": "uv run pytest -q",
       "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run pytest tests/test_params.py -q",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run ruff check src/sim_swim/sim/params.py tests/test_params.py",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run ruff format --check src/sim_swim/sim/params.py tests/test_params.py",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run pytest -q -m light",
+      "result": "PASS after second Codex Cloud feedback batch"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS after second Codex Cloud feedback batch"
     }
   ],
   "user_visual_review_required": false,

--- a/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
+++ b/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
@@ -8,7 +8,8 @@
     "Preserved 2010 project tau_s=1.0 while deriving tau_s from eta*b^3/reference_torque_Nm for 2010 paper and 2015 profiles.",
     "Separated motor.enabled, motor.torque_Nm, and motor.reference_torque_Nm responsibilities.",
     "Recorded normalized time quantities and compatibility source paths in single-run and campaign manifests.",
-    "Documented the ceil(duration_tau / dt_star) step-time contract and kept 2015 geometry/dynamics/stability out of scope."
+    "Documented the ceil(duration_tau / dt_star) step-time contract and kept 2015 geometry/dynamics/stability out of scope.",
+    "Addressed Codex Cloud feedback by making motor.enabled=false override the 2010 paper torque_Nm=-1 sentinel for actual motor drive while preserving reference_torque_Nm."
   ],
   "scope_boundaries": [
     "2015 profiles remain implementation_status=pending and are not made executable.",
@@ -56,6 +57,34 @@
     {
       "command": "uv run pytest -q",
       "result": "PASS"
+    },
+    {
+      "command": "uv run pytest tests/test_params.py -q",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run ruff check src/sim_swim/sim/params.py tests/test_params.py",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run ruff format --check src/sim_swim/sim/params.py tests/test_params.py",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run pytest -q -m light",
+      "result": "PASS after Codex Cloud feedback"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS after Codex Cloud feedback"
     }
   ],
   "user_visual_review_required": false,

--- a/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
+++ b/docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json
@@ -1,0 +1,65 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #165 time schema and profile-aware duration scaling",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/165",
+  "branch": "feature/phase2-165-time-schema",
+  "summary": [
+    "Added canonical time.duration.{value,unit} and time.integration.dt_star parsing with legacy flat-key compatibility.",
+    "Preserved 2010 project tau_s=1.0 while deriving tau_s from eta*b^3/reference_torque_Nm for 2010 paper and 2015 profiles.",
+    "Separated motor.enabled, motor.torque_Nm, and motor.reference_torque_Nm responsibilities.",
+    "Recorded normalized time quantities and compatibility source paths in single-run and campaign manifests.",
+    "Documented the ceil(duration_tau / dt_star) step-time contract and kept 2015 geometry/dynamics/stability out of scope."
+  ],
+  "scope_boundaries": [
+    "2015 profiles remain implementation_status=pending and are not made executable.",
+    "Issue #166 refined geometry, Issue #167 2015 dynamics, and Issue #168 stability evaluation were not implemented.",
+    "time.dt_s remains a deprecated output/recording interval key; no output.interval_s migration was implemented.",
+    "Long Phase 2 simulations and visual review videos were not run."
+  ],
+  "checks": [
+    {
+      "command": "uv run pytest tests/test_params.py tests/test_model_profiles.py tests/test_e2e_cli.py tests/test_phase2_generic_multi_run.py -q",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest tests/test_simulation.py tests/test_run_state_fixed.py tests/test_render_state_and_projection.py -q",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check src/sim_swim/sim/params.py src/sim_swim/sim/core.py src/sim_swim/analysis/sweeps/generic_multi_run.py src/sim_swim/analysis/sweeps/shape_stability_grid.py src/sim_swim/analysis/sweeps/single_flagellum_torque.py scripts/01_simulate_swimming/01_simulate_swimming.py tests/test_params.py tests/test_e2e_cli.py tests/test_phase2_generic_multi_run.py tests/test_model_profiles.py",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest tests/test_phase2_sweep_profiles.py tests/test_phase2_6_torque_model_evaluation.py tests/test_phase2_82_hook_overstretch_sweep.py -q",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run python -c \"import yaml; from pathlib import Path; from sim_swim.sim.params import SimulationConfig; [SimulationConfig.from_dict(yaml.safe_load(Path('conf', name).read_text(encoding='utf-8'))).time_manifest() for name in ('sim_swim_2010.yaml','sim_swim_2010_paper.yaml','sim_swim_2015.yaml','sim_swim_2015_paper.yaml')]; print('profiles ok')\"",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest -q -m light",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check .",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff format --check .",
+      "result": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS"
+    }
+  ],
+  "user_visual_review_required": false,
+  "long_simulation_required": false,
+  "adr": "docs/adr/0012_phase2_time_schema_profiles.md",
+  "created_at": "2026-08-02T19:25:00+09:00"
+}

--- a/docs/codex/codex_workflow.md
+++ b/docs/codex/codex_workflow.md
@@ -129,6 +129,8 @@ Examples:
 Rules:
 
 * Do not commit directly on `main` or `master`.
+* After merge, sync the default branch, delete the merged task branch locally and remotely, and prune stale remote-tracking refs. Preserve unmerged branches and branches explicitly retained for active follow-up work.
+* Start the next task from the updated default branch on a new task-specific branch.
 * Commit useful FAIL progress only when it is clearly diagnostic or WIP and does not claim completion.
 * Push the feature branch when remote access is available.
 * Send the final user report only after the final task state has been committed and pushed when remote access is available.

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -29,12 +29,13 @@ Phase 2 は，3D物理シミュレーションと2D擬似顕微鏡動画生成�
 * Phase 2.6: `root_torque_segment_couples` により，単一べん毛の螺旋形状維持と net 回転を両立する代表条件を確認済み。Issue #53 / #54 は完了。旧名 `material_twist_local_couple` は deprecated alias として受け付ける。
 * Phase 2.7: 複数べん毛の束化検証は，近接束ではなく螺旋中心軸の安定整列を成功定義として完了。代表条件は `hook_wrapped_axis_aligned`。
 * 3D出力の間引き用 `output_sampling.fps_out_3d` は導入済み。
-* Phase 2 CLI の新規コマンド例は `config=...`，`time.duration_s=...`，`time.dt_star=...` などの `KEY=VALUE` 形式を第一表記にする。`--config` / `--duration-s` / `--fps-out` などの option 形式は legacy compatibility としてのみ残す。
+* Phase 2 CLI の新規コマンド例は `config=...`，`time.duration.value=...`，`time.duration.unit=s|tau`，`time.integration.dt_star=...` などの `KEY=VALUE` 形式を第一表記にする。`time.duration_s` / `time.dt_star` / `time.dt_s` / `--config` / `--duration-s` / `--fps-out` は legacy compatibility としてのみ残す。
 
 現在の主対象:
 
 * Phase 2 / Issue #163: Watari & Larson (2010) potential式照合を完了した。論文準拠 `fene_fraenkel` と過去互換 `legacy` を `potentials.spring.formulation` で選択でき、selector欠落時は `legacy`。motor-off `0.1 tau` / motor-on RUN `1 tau` の両runでFENEが完走・strict shape gateを通過し、defaultは `fene_fraenkel` とした。bending/torsion/hookの復元方向とspring-spring repulsionの実装仮定はADR 0009に記録した。
 * Phase 2 / Issue #164: simulation configを2010/2015 x project/paperの4 profileへ再編した。defaultは旧条件を維持する `conf/sim_swim_2010.yaml`。`model_profile` はyear、variant、resolution、implementation status、nominal bead構成を持ち、manifestには `model_profile` と `source_config_path` を保存する。2010 project/paperは `supported`、2015 project/paperは `pending` とし、pending profileの実simulationはoutput作成前に拒否する。正式な時間schemaは #165、2015 geometryは #166、2015 paper dynamicsは #167へ分離した。設計判断はADR 0010に記録した。
+* Phase 2 / Issue #165: `time.duration.{value,unit}` と `time.integration.dt_star` を正式schemaとし、`tau` / `s` durationを正規化する。2010 project profileは過去run互換のため `tau_s=1.0` 固定を維持し、2010 paper / 2015 profilesは `tau_s = viscosity_Pa_s * b_m^3 / abs(motor.reference_torque_Nm)` を使う。2015 profilesは引き続き `pending` で、parse・正規化・manifest出力の対象だが実simulationは拒否する。`total_steps = ceil(duration_tau / dt_star)`、`step_summary.csv` はstep開始時刻を `total_steps` 行、state列は初期状態を含め `total_steps+1` 件とする。`ceil` によりfinal state時刻が指定durationをわずかに超える場合がある。設計判断はADR 0012に記録する。
 * Phase 2 / Issue #171: `conf/sim_swim_2010.yaml` の初期べん毛螺旋軸を菌体後方へ揃える `flagella.initial_helix_axis_from_rear_deg=0` をproject defaultとした。user実行0.5 s runは5,000/5,000 stepでfinite・通常/strict non-body shape gateを通過し、bundle rearward projectionは全期間 `>=0.9668`、最終bundle軸は後方から `14.62 deg`だった。user定性評価も問題なし。paper profileと2つの2015 pending profileは `null` を維持し、時間schemaは #165、2015 projectの後方default評価は #166/#167/#168 完了後の別件とする。採用判断はADR 0011に記録した。
 * Phase 2.8 / Issue #65: 親Issue #71 のRUN固定べん毛数差分析に向けて，特徴量カテゴリとdataset出力方針を定義済み。
 * Phase 2.8 / Issue #72 / #112: 親Issue #71 のRUN固定べん毛数差分析に向けて，raw output は `scripts/01_simulate_swimming/run_multi_run.py` で作り，dataset builder は generic multi-run の `run_manifest.json` から `summary.csv` / `timeseries/<sample_id>.csv` を生成する。

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -1377,6 +1377,37 @@
 - docs:
   - `docs/adr/0010_phase2_model_config_profiles.md`
 
+### P2-MODEL-165: 時間スケールとduration指定をprofile対応する
+
+- status: completed
+- source issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/165`
+- parent issue: `https://github.com/Kenta-morimori/prj-flagella-estimation/issues/154`
+- branch: `feature/phase2-165-time-schema`
+- goal: 2010 projectのlegacy時間解釈を維持しつつ、2010 paper / 2015 profilesでは参照トルクから `tau_s` を導出し、`tau` / `s` durationを同じ契約で扱う。
+- accepted decisions:
+  - [x] 正式schemaを `time.duration.value` / `time.duration.unit` / `time.integration.dt_star` とする。
+  - [x] `time.duration_s` / `time.dt_star` / `time.dt_s` / `--duration-s` は deprecated compatibility として受け付ける。
+  - [x] 新旧time keyが同時指定され同じ意味の値が矛盾する場合は `ValueError` で拒否する。同値なら `mixed_equivalent` として受理する。
+  - [x] 2010 project profileは `tau_s=1.0` 固定を維持する。
+  - [x] 2010 paper / 2015 profilesは `tau_s = viscosity_Pa_s * b_m^3 / abs(motor.reference_torque_Nm)` を使う。
+  - [x] `motor.enabled` は実駆動ON/OFF、`motor.torque_Nm` は実駆動torque、`motor.reference_torque_Nm` は時間換算・無次元係数の参照torqueとして分離する。
+  - [x] `motor.torque_Nm=-1` sentinelは profileなしlegacy fixtureと2010 paper profile由来のみ deprecated compatibility として受け付ける。canonical 2010 project / 2015 profileでは拒否する。
+  - [x] `total_steps = ceil(duration_tau / dt_star)`、state数は `total_steps + 1`、`step_summary.csv` はstep開始時刻を `total_steps` 行記録する契約に固定する。
+  - [x] manifestへ `duration_value`, `duration_unit`, `duration_tau`, `duration_s`, `dt_star`, `tau_s`, `dt_internal_s`, `total_steps`, `final_state_t_s`, `final_step_summary_t_s`, `time_scale_policy`, `reference_torque_Nm`, `motor_enabled`, `motor_torque_Nm`, `time_schema_source`, `legacy_time_keys_used` を保存する。
+- boundaries:
+  - 2015 profilesは引き続き `implementation_status: pending` とし、geometry実装、2015 paper motor dynamics、安定性評価には踏み込まない。
+  - `time.dt_s` は今回意味を変えず、deprecatedな出力・記録間隔として維持する。明示的な `output.interval_s` または `time.output_interval_s` への移行は後続で扱う。
+  - 長時間simulationやvisual review用動画生成は実行しない。
+- verification:
+  - [x] parser / canonical profiles / CLI manifest / generic multi-run manifest のfocused pytestを完了した。
+  - [x] simulation loop契約に関係する既存pytestを完了した。
+- docs:
+  - `README.md`
+  - `scripts/README.md`
+  - `docs/phase2/phase2_current.md`
+  - `docs/adr/0012_phase2_time_schema_profiles.md`
+  - `docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json`
+
 ### P2-MODEL-163: 2010年モデルのpotential式を論文と照合し採否を整理する
 
 - status: completed

--- a/scripts/01_simulate_swimming/01_simulate_swimming.py
+++ b/scripts/01_simulate_swimming/01_simulate_swimming.py
@@ -102,6 +102,7 @@ def main(
     override_dict = _to_nested_overrides(overrides)
     if duration_s is not None:
         override_dict.setdefault("time", {})["duration_s"] = duration_s
+        override_dict.setdefault("time", {})["_schema_source"] = "cli_shorthand"
         shorthand_overrides.append(f"time.duration_s={duration_s}")
     if fps_out is not None:
         override_dict.setdefault("output_sampling", {})["fps_out_2d"] = fps_out
@@ -136,7 +137,7 @@ def main(
     logger.info("Loaded simulation config (effective): %s", cfg)
     logger.info("Overrides: %s", override_dict if override_dict else "None")
     cfg.validate_time_scaling()
-    logger.info("[time-scale] τ is fixed to 1.0 in stable integration mode")
+    logger.info("[time-scale] normalized=%s", cfg.time_manifest())
 
     if cfg.use_eta_b3_torque:
         logger.info(
@@ -155,7 +156,7 @@ def main(
             cfg.tau_s,
         )
     elif cfg.is_motor_off_torque:
-        logger.info("[time-scale] input motor.torque_Nm=0; motor OFF mode (tau=1)")
+        logger.info("[time-scale] motor disabled or torque_Nm=0; motor OFF mode")
         logger.info(
             (
                 "[time-scale] b=%.6e um, b_m=%.6e m, η=%.6e Pa·s, "
@@ -286,6 +287,7 @@ def main(
     except Exception:
         manifest = {}
     outputs = manifest.get("outputs", {})
+    manifest["time"] = cfg.time_manifest()
     body_diag_csv = ctx.out.sim_dir / "body_constraint_diagnostics.csv"
     body_local_diag_csv = ctx.out.sim_dir / "body_constraint_local_diagnostics.csv"
     init_geom_json = ctx.out.sim_dir / "initial_geometry_summary.json"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,12 +17,21 @@ uv run python -m scripts.01_simulate_swimming
 ```bash
 uv run python -m scripts.01_simulate_swimming \
   config=conf/sim_swim_2010.yaml \
-  time.duration_s=0.05 \
+  time.duration.value=0.05 \
+  time.duration.unit=s \
   motor.torque_Nm=2.0e-20 \
-  time.dt_star=1.0e-4
+  time.integration.dt_star=1.0e-4
 ```
 
-`--config`、`--duration-s`、`--fps-out` は既存互換用に残しています。新規コマンド例では `config=...`、`time.duration_s=...`、`output_sampling.fps_out_2d=...` を使います。
+`--config`、`--duration-s`、`--fps-out`、`time.duration_s`、`time.dt_star` は既存互換用に残しています。新規コマンド例では `config=...`、`time.duration.value=...`、`time.duration.unit=...`、`time.integration.dt_star=...`、`output_sampling.fps_out_2d=...` を使います。
+
+時間正規化の契約:
+
+- `time.duration.unit` は `s` または `tau`。
+- 2010 project profile は legacy 互換のため `tau_s=1.0` 固定。
+- 2010 paper / 2015 profiles は `tau_s = viscosity_Pa_s * b_m^3 / abs(motor.reference_torque_Nm)`。
+- `time.dt_s` は deprecated な出力・記録間隔で、内部積分刻みではありません。
+- `total_steps = ceil(duration_tau / dt_star)`。`step_summary.csv` はstep開始時刻を記録するため最終state時刻は指定durationをわずかに超える場合があります。
 
 主な出力は `outputs/YYYY-MM-DD/HHMMSS/` 配下に作成され、`manifest.json` と `run.log` に実行条件が記録されます。
 
@@ -43,7 +52,8 @@ uv run python scripts/01_simulate_swimming/run_sweep.py \
 uv run python scripts/01_simulate_swimming/run_sweep.py \
   config=conf/phase2_sweeps/shape_stability_grid.yaml \
   mode=first-second-grid \
-  time.duration_s=0.001 \
+  time.duration.value=0.001 \
+  time.duration.unit=s \
   motor.torque_Nm=0 \
   first_second_spring_scales=1 \
   output_dir=/private/tmp/phase2_smoke \
@@ -66,7 +76,8 @@ uv run python scripts/01_simulate_swimming/run_multi_run.py \
 uv run python scripts/01_simulate_swimming/run_multi_run.py \
   config=conf/phase2_multi_run/latest_model_torque_shape_stability.yaml \
   sweep.axes.torque.values=[1.5e-20,2.0e-20,2.5e-20] \
-  time.duration_s=1.0 \
+  time.duration.value=1.0 \
+  time.duration.unit=s \
   overwrite=true
 ```
 
@@ -111,8 +122,9 @@ uv run python scripts/01_simulate_swimming/run_sweep.py \
 uv run python -m scripts.01_simulate_swimming \
   config=conf/sim_swim_2010.yaml \
   potentials.spring.formulation=fene_fraenkel \
-  time.duration_s=0.01 \
-  time.dt_star=1.0e-4
+  time.duration.value=0.01 \
+  time.duration.unit=s \
+  time.integration.dt_star=1.0e-4
 ```
 
 Issue #163 のdefault判定用長時間比較は、motor-offとmotor-on RUNを同じseedで実行します。

--- a/src/sim_swim/analysis/phase2_158_diagnostics.py
+++ b/src/sim_swim/analysis/phase2_158_diagnostics.py
@@ -349,8 +349,9 @@ def _condition_config(
 ) -> SimulationConfig:
     base_config_path = Path(str(campaign["base_config"]))
     raw = load_yaml(base_config_path)
-    effective = _merge_nested(raw, condition.get("config_overrides", {}) or {})
-    return SimulationConfig.from_dict(effective)
+    return SimulationConfig.from_dict(raw).with_overrides(
+        condition.get("config_overrides", {}) or {}
+    )
 
 
 def _flag_local_bead_lookup(cfg: SimulationConfig) -> dict[int, int]:

--- a/src/sim_swim/analysis/sweeps/generic_multi_run.py
+++ b/src/sim_swim/analysis/sweeps/generic_multi_run.py
@@ -112,8 +112,13 @@ def _condition_row(
     return row
 
 
-def _manifest_condition_record(root: Path, condition: dict[str, Any]) -> dict[str, Any]:
-    return {
+def _manifest_condition_record(
+    root: Path,
+    condition: dict[str, Any],
+    *,
+    time_manifest: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    record = {
         "condition_id": condition["condition_id"],
         "condition_index": condition["condition_index"],
         "condition_label": condition["condition_label"],
@@ -132,6 +137,9 @@ def _manifest_condition_record(root: Path, condition: dict[str, Any]) -> dict[st
             "col_label": condition.get("grid_col_label"),
         },
     }
+    if time_manifest is not None:
+        record["time"] = time_manifest
+    return record
 
 
 def _summary_fieldnames(rows: list[dict[str, Any]]) -> list[str]:
@@ -199,6 +207,7 @@ def run_campaign(argv: list[str] | None = None) -> Path:
     logger.info("Campaign conditions=%d", len(conditions))
 
     rows: list[dict[str, Any]] = []
+    condition_time_manifests: dict[str, dict[str, Any]] = {}
     total = len(conditions)
     for index, condition in enumerate(conditions, start=1):
         logger.info(
@@ -209,6 +218,7 @@ def run_campaign(argv: list[str] | None = None) -> Path:
         cfg = SimulationConfig.from_dict(base_cfg).with_overrides(
             condition["config_overrides"]
         )
+        condition_time_manifests[condition["condition_id"]] = cfg.time_manifest()
         simulator = Simulator(cfg)
         states = simulator.run(
             cfg.time.duration_s,
@@ -236,6 +246,7 @@ def run_campaign(argv: list[str] | None = None) -> Path:
         "base_config": str(base_config_path),
         "source_config_path": str(base_config_path),
         "model_profile": base_simulation_cfg.model_profile_manifest(),
+        "time": base_simulation_cfg.time_manifest(),
         "summary_csv": str(summary_path),
         "git": {
             "commit": ctx.git.commit,
@@ -250,7 +261,11 @@ def run_campaign(argv: list[str] | None = None) -> Path:
         "axes": campaign_axes_metadata(campaign),
         "condition_order": [condition["condition_id"] for condition in conditions],
         "conditions": [
-            _manifest_condition_record(ctx.out.root, condition)
+            _manifest_condition_record(
+                ctx.out.root,
+                condition,
+                time_manifest=condition_time_manifests.get(condition["condition_id"]),
+            )
             for condition in conditions
         ],
     }
@@ -268,6 +283,7 @@ def run_campaign(argv: list[str] | None = None) -> Path:
             "replay": manifest["replay"],
             "plot": manifest["plot"],
         }
+        existing["time"] = base_simulation_cfg.time_manifest()
         existing["outputs"]["summary_csv"] = str(summary_path)
         existing["outputs"]["run_manifest_json"] = str(run_manifest_path)
         manifest_path.write_text(

--- a/src/sim_swim/analysis/sweeps/shape_stability_grid.py
+++ b/src/sim_swim/analysis/sweeps/shape_stability_grid.py
@@ -1189,9 +1189,10 @@ def _manifest_record(
     condition: Condition,
     *,
     condition_index: int,
+    time_manifest: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     metadata = _campaign_condition_metadata(args, condition, condition_index)
-    return {
+    record = {
         "condition_id": condition.condition_id,
         "condition_index": condition_index,
         "condition_label": metadata["condition_label"],
@@ -1213,6 +1214,9 @@ def _manifest_record(
             "col_label": metadata.get("grid_col_label"),
         },
     }
+    if time_manifest is not None:
+        record["time"] = time_manifest
+    return record
 
 
 def _summary_fieldnames(rows: list[dict[str, str | float]]) -> list[str]:
@@ -1352,12 +1356,16 @@ def main(argv: list[str] | None = None) -> None:
     profile_cfg.validate_execution_supported()
     args.output_dir.mkdir(parents=True, exist_ok=args.overwrite)
     rows = []
+    condition_time_manifests: dict[str, dict[str, Any]] = {}
     total = len(conditions)
     for index, condition in enumerate(conditions, start=1):
         print(
             f"[{index}/{total}] shape_stability_grid {condition.condition_id}",
             flush=True,
         )
+        overrides = _overrides_for_condition(args, condition)
+        cfg = SimulationConfig.from_dict(base_cfg).with_overrides(overrides)
+        condition_time_manifests[condition.condition_id] = cfg.time_manifest()
         rows.append(
             _run_condition(
                 base_cfg,
@@ -1378,6 +1386,7 @@ def main(argv: list[str] | None = None) -> None:
         "config": str(args.config),
         "source_config_path": str(args.config),
         "model_profile": profile_cfg.model_profile_manifest(),
+        "time": profile_cfg.time_manifest(),
         "args": {
             "mode": args.mode,
             "output_dir": str(args.output_dir),
@@ -1396,7 +1405,12 @@ def main(argv: list[str] | None = None) -> None:
         "axes": _campaign_axes(args),
         "condition_order": [condition.condition_id for condition in conditions],
         "conditions": [
-            _manifest_record(args, condition, condition_index=index)
+            _manifest_record(
+                args,
+                condition,
+                condition_index=index,
+                time_manifest=condition_time_manifests.get(condition.condition_id),
+            )
             for index, condition in enumerate(conditions)
         ],
     }

--- a/src/sim_swim/analysis/sweeps/single_flagellum_torque.py
+++ b/src/sim_swim/analysis/sweeps/single_flagellum_torque.py
@@ -397,6 +397,9 @@ def _write_manifest(
         "config": str(args.config),
         "source_config_path": str(args.config),
         "model_profile": base_cfg.model_profile_manifest(),
+        "time": base_cfg.with_overrides(
+            {"time": {"duration_s": args.duration, "dt_star": args.dt_star}}
+        ).time_manifest(),
         "torques_Nm": args.torques,
         "scale_values": args.scale_values,
         "scale_torques": args.scale_torques,

--- a/src/sim_swim/sim/core.py
+++ b/src/sim_swim/sim/core.py
@@ -156,6 +156,15 @@ def _wrap_deg(deg: float) -> float:
     return float((deg + 180.0) % 360.0 - 180.0)
 
 
+def _duration_matches_config(duration_s: float, config_duration_s: float) -> bool:
+    return math.isclose(
+        float(duration_s),
+        float(config_duration_s),
+        rel_tol=1.0e-12,
+        abs_tol=1.0e-15,
+    )
+
+
 def _estimate_helix_radius_pitch_over_b(
     points_m: np.ndarray,
     b_m: float,
@@ -559,7 +568,10 @@ class Simulator:
         tau_s = self.config.tau_s
         dt_star = max(self.config.dt_star, 1e-12)
         duration_star = max(float(duration_s), 0.0) / max(tau_s, 1e-30)
-        total_steps = max(1, int(math.ceil(duration_star / dt_star)))
+        if _duration_matches_config(duration_s, self.config.time.duration_s):
+            total_steps = self.config.total_steps
+        else:
+            total_steps = max(0, int(math.ceil(duration_star / dt_star)))
         flush_interval_steps = max(1, int(flush_interval_steps))
 
         states: List[SimulationState] = []

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -869,10 +869,10 @@ class SimulationConfig:
     @property
     def motor_torque_Nm(self) -> float:
         """モータ力計算で使う符号付きトルク。"""
-        if self.use_eta_b3_torque:
-            return self.torque_eta_b3_Nm
         if self.is_motor_off_torque:
             return 0.0
+        if self.use_eta_b3_torque:
+            return self.torque_eta_b3_Nm
         return self.input_torque_Nm
 
     @property

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -930,7 +930,10 @@ class SimulationConfig:
             or abs(self.reference_torque_Nm) <= 0.0
         ):
             raise ValueError("motor.reference_torque_Nm must be finite and non-zero.")
-        if self.input_torque_Nm < 0.0 and not self.use_eta_b3_torque:
+        if (
+            math.isclose(self.input_torque_Nm, -1.0, rel_tol=0.0, abs_tol=1.0e-12)
+            and not self.use_eta_b3_torque
+        ):
             raise ValueError(
                 "motor.torque_Nm=-1 is a deprecated 2010 paper profile sentinel "
                 "and cannot be used for this profile."
@@ -1527,17 +1530,27 @@ class SimulationConfig:
             overrides.get("time", {}) if isinstance(overrides, dict) else {}
         )
         merged_time = merged.get("time")
-        if isinstance(merged_time, dict) and "time" not in overrides:
+        if isinstance(merged_time, dict):
             if self.time.schema_source == "canonical":
-                merged_time["duration"] = {
-                    "value": self.time.duration_value,
-                    "unit": self.time.duration_unit,
-                }
-                merged_time["integration"] = {"dt_star": self.time.integration_dt_star}
-                merged_time.pop("duration_s", None)
-                merged_time.pop("dt_star", None)
-                merged_time.pop("legacy_duration_s", None)
-                merged_time.pop("legacy_dt_star", None)
+                override_has_duration = isinstance(time_overrides, dict) and (
+                    "duration" in time_overrides or "duration_s" in time_overrides
+                )
+                override_has_integration = isinstance(time_overrides, dict) and (
+                    "integration" in time_overrides or "dt_star" in time_overrides
+                )
+                if not override_has_duration:
+                    merged_time["duration"] = {
+                        "value": self.time.duration_value,
+                        "unit": self.time.duration_unit,
+                    }
+                    merged_time.pop("duration_s", None)
+                    merged_time.pop("legacy_duration_s", None)
+                if not override_has_integration:
+                    merged_time["integration"] = {
+                        "dt_star": self.time.integration_dt_star
+                    }
+                    merged_time.pop("dt_star", None)
+                    merged_time.pop("legacy_dt_star", None)
             for derived_key in (
                 "duration_value",
                 "duration_unit",
@@ -1551,10 +1564,15 @@ class SimulationConfig:
                 if "duration" in time_overrides:
                     merged_time.pop("duration_s", None)
                     merged_time.pop("legacy_duration_s", None)
+                if "duration_s" in time_overrides:
+                    merged_time.pop("duration", None)
                 if "integration" in time_overrides:
                     merged_time.pop("dt_star", None)
                     merged_time.pop("integration_dt_star", None)
                     merged_time.pop("legacy_dt_star", None)
+                if "dt_star" in time_overrides:
+                    merged_time.pop("integration", None)
+                    merged_time.pop("integration_dt_star", None)
                 for derived_key in (
                     "duration_value",
                     "duration_unit",

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -47,6 +47,18 @@ MODEL_PROFILE_YEARS = frozenset({2010, 2015})
 MODEL_PROFILE_VARIANTS = frozenset({"project", "paper"})
 MODEL_PROFILE_RESOLUTIONS = frozenset({"legacy_project", "coarse", "refined"})
 MODEL_PROFILE_IMPLEMENTATION_STATUSES = frozenset({"supported", "pending"})
+TIME_DURATION_UNITS = frozenset({"s", "tau"})
+TIME_SCHEMA_SOURCES = frozenset(
+    {
+        "canonical",
+        "legacy_duration_s",
+        "legacy_dt_star",
+        "cli_shorthand",
+        "mixed_equivalent",
+    }
+)
+TIME_SCALE_POLICY_LEGACY_FIXED_TAU = "legacy_fixed_tau_s_1"
+TIME_SCALE_POLICY_REFERENCE_TORQUE = "reference_torque"
 MOTOR_LOCAL_SCALE_KEYS = (
     "local_hook_scale",
     "local_spring_scale",
@@ -380,7 +392,9 @@ class FluidParams:
 class MotorParams:
     """モータ設定。"""
 
+    enabled: bool = True
     torque_Nm: float = 4.0e-18
+    reference_torque_Nm: float | None = None
     force_distribution: str = MOTOR_FORCE_DISTRIBUTION_DEFAULT
     torque_distribution_profile: str = MOTOR_TORQUE_DISTRIBUTION_PROFILE_DEFAULT
     reverse_n_flagella: int = 1
@@ -501,6 +515,13 @@ class TimeParams:
     duration_s: float = 0.1
     dt_s: float = 1.0e-3
     dt_star: float | None = None
+    duration_value: float = 0.1
+    duration_unit: str = "s"
+    integration_dt_star: float | None = None
+    schema_source: str = "legacy_duration_s"
+    legacy_keys_used: tuple[str, ...] = ()
+    legacy_duration_s: float | None = None
+    legacy_dt_star: float | None = None
 
 
 @dataclass(frozen=True)
@@ -563,6 +584,158 @@ class StiffnessScaleParams:
     flag_torsion: float = 1.0
 
 
+def _is_2010_project_profile(profile: ModelProfileParams | None) -> bool:
+    return profile is None or (
+        profile.year == 2010
+        and profile.variant == "project"
+        and profile.resolution == "legacy_project"
+    )
+
+
+def _is_2010_paper_profile(profile: ModelProfileParams | None) -> bool:
+    return (
+        profile is not None
+        and profile.year == 2010
+        and profile.variant == "paper"
+        and profile.resolution == "coarse"
+    )
+
+
+def _time_scale_policy(profile: ModelProfileParams | None) -> str:
+    if _is_2010_project_profile(profile):
+        return TIME_SCALE_POLICY_LEGACY_FIXED_TAU
+    return TIME_SCALE_POLICY_REFERENCE_TORQUE
+
+
+def _equivalent_time_seconds(a: float, b: float) -> bool:
+    return math.isclose(float(a), float(b), rel_tol=1.0e-12, abs_tol=1.0e-15)
+
+
+def _normalize_duration_unit(value: Any) -> str:
+    unit = str(value).strip()
+    if unit not in TIME_DURATION_UNITS:
+        supported = ", ".join(sorted(TIME_DURATION_UNITS))
+        raise ValueError(
+            f"Unsupported time.duration.unit: {unit!r}. Use one of: {supported}."
+        )
+    return unit
+
+
+def _parse_time_params(raw: dict[str, Any]) -> TimeParams:
+    time_raw = raw.get("time", {}) or {}
+    if "dt_over_tau" in time_raw:
+        raise ValueError(
+            "time.dt_over_tau は入力キーとして廃止。time.dt_s を使用してください。"
+        )
+
+    legacy_keys_used: list[str] = []
+    duration_raw = time_raw.get("duration")
+    has_canonical_duration = duration_raw not in (None, "")
+    if has_canonical_duration and not isinstance(duration_raw, dict):
+        raise ValueError("time.duration must be a mapping with value and unit")
+
+    legacy_duration_present = time_raw.get("duration_s") not in (None, "")
+    if legacy_duration_present:
+        legacy_keys_used.append("time.duration_s")
+
+    if has_canonical_duration:
+        duration_value = float(_get(duration_raw, "value", 0.1))
+        duration_unit = _normalize_duration_unit(_get(duration_raw, "unit", "s"))
+    elif legacy_duration_present:
+        duration_value = float(time_raw["duration_s"])
+        duration_unit = "s"
+    else:
+        duration_value = 0.1
+        duration_unit = "s"
+
+    dt_s = time_raw.get("dt_s")
+    if dt_s is None:
+        raise ValueError("time.dt_s は必須です。出力・記録間隔として設定してください。")
+    legacy_keys_used.append("time.dt_s")
+
+    integration_raw = time_raw.get("integration")
+    has_canonical_integration = integration_raw not in (None, "")
+    if has_canonical_integration and not isinstance(integration_raw, dict):
+        raise ValueError("time.integration must be a mapping with dt_star")
+
+    legacy_dt_star_present = time_raw.get("dt_star") not in (None, "")
+    if legacy_dt_star_present:
+        legacy_keys_used.append("time.dt_star")
+
+    if has_canonical_integration:
+        canonical_dt = integration_raw.get("dt_star")
+        integration_dt_star = (
+            float(canonical_dt) if canonical_dt not in (None, "") else None
+        )
+    elif legacy_dt_star_present:
+        integration_dt_star = float(time_raw["dt_star"])
+    else:
+        integration_dt_star = None
+
+    if (
+        has_canonical_integration
+        and legacy_dt_star_present
+        and integration_dt_star is not None
+        and not math.isclose(
+            float(integration_dt_star),
+            float(time_raw["dt_star"]),
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-15,
+        )
+    ):
+        raise ValueError(
+            "Conflicting time integration settings: "
+            "time.integration.dt_star and legacy time.dt_star differ."
+        )
+
+    if has_canonical_duration and legacy_duration_present:
+        canonical_duration_s = duration_value if duration_unit == "s" else None
+        if canonical_duration_s is not None and not _equivalent_time_seconds(
+            canonical_duration_s,
+            float(time_raw["duration_s"]),
+        ):
+            raise ValueError(
+                "Conflicting time duration settings: "
+                "time.duration and legacy time.duration_s differ."
+            )
+
+    if has_canonical_duration or has_canonical_integration:
+        schema_source = (
+            "mixed_equivalent"
+            if legacy_duration_present or legacy_dt_star_present
+            else "canonical"
+        )
+    elif legacy_duration_present:
+        schema_source = "legacy_duration_s"
+    elif legacy_dt_star_present:
+        schema_source = "legacy_dt_star"
+    else:
+        schema_source = "legacy_duration_s"
+
+    explicit_schema_source = time_raw.get("_schema_source")
+    if explicit_schema_source not in (None, ""):
+        schema_source = str(explicit_schema_source)
+
+    if schema_source not in TIME_SCHEMA_SOURCES:
+        raise ValueError(f"Unsupported time schema source: {schema_source}")
+
+    legacy_keys = tuple(dict.fromkeys(legacy_keys_used))
+    return TimeParams(
+        duration_s=float(duration_value),
+        dt_s=float(dt_s),
+        dt_star=integration_dt_star,
+        duration_value=float(duration_value),
+        duration_unit=duration_unit,
+        integration_dt_star=integration_dt_star,
+        schema_source=schema_source,
+        legacy_keys_used=legacy_keys,
+        legacy_duration_s=(
+            float(time_raw["duration_s"]) if legacy_duration_present else None
+        ),
+        legacy_dt_star=(float(time_raw["dt_star"]) if legacy_dt_star_present else None),
+    )
+
+
 @dataclass(frozen=True)
 class SimulationConfig:
     """Phase2シミュレーション設定。"""
@@ -584,6 +757,36 @@ class SimulationConfig:
     output: OutputParams
     stiffness_scales: StiffnessScaleParams
     model_profile: ModelProfileParams | None = None
+
+    def __post_init__(self) -> None:
+        tau_s = self._compute_tau_s()
+        duration_s = (
+            float(self.time.duration_value) * tau_s
+            if self.time.duration_unit == "tau"
+            else float(self.time.duration_value)
+        )
+        if self.time.legacy_duration_s is not None and not _equivalent_time_seconds(
+            duration_s,
+            self.time.legacy_duration_s,
+        ):
+            raise ValueError(
+                "Conflicting time duration settings: "
+                "time.duration and legacy time.duration_s differ after tau_s "
+                "normalization."
+            )
+        resolved_time = TimeParams(
+            duration_s=duration_s,
+            dt_s=self.time.dt_s,
+            dt_star=self.time.integration_dt_star,
+            duration_value=self.time.duration_value,
+            duration_unit=self.time.duration_unit,
+            integration_dt_star=self.time.integration_dt_star,
+            schema_source=self.time.schema_source,
+            legacy_keys_used=self.time.legacy_keys_used,
+            legacy_duration_s=self.time.legacy_duration_s,
+            legacy_dt_star=self.time.legacy_dt_star,
+        )
+        object.__setattr__(self, "time", resolved_time)
 
     def validate_execution_supported(self) -> None:
         """Reject profiles that intentionally describe future implementations."""
@@ -617,11 +820,15 @@ class SimulationConfig:
 
     @property
     def use_eta_b3_torque(self) -> bool:
-        return math.isclose(self.input_torque_Nm, -1.0, rel_tol=0.0, abs_tol=1e-12)
+        return (
+            self.model_profile is None or _is_2010_paper_profile(self.model_profile)
+        ) and math.isclose(self.input_torque_Nm, -1.0, rel_tol=0.0, abs_tol=1e-12)
 
     @property
     def is_motor_off_torque(self) -> bool:
-        return math.isclose(self.input_torque_Nm, 0.0, rel_tol=0.0, abs_tol=1e-30)
+        return (not bool(self.motor.enabled)) or math.isclose(
+            self.input_torque_Nm, 0.0, rel_tol=0.0, abs_tol=1e-30
+        )
 
     @property
     def torque_eta_b3_Nm(self) -> float:
@@ -630,18 +837,34 @@ class SimulationConfig:
     @property
     def torque_scale_Nm(self) -> float:
         """τ計算に使うスケールトルク絶対値。"""
-        if self.use_eta_b3_torque or self.is_motor_off_torque:
-            return self.torque_eta_b3_Nm
-        return abs(self.input_torque_Nm)
+        return abs(self.reference_torque_Nm)
 
     @property
     def torque_for_forces_Nm(self) -> float:
         """力学パラメータ（剛性/反発）のスケーリングに使うトルク絶対値。"""
         if float(self.motor.torque_for_forces_override_Nm) > 0.0:
             return float(self.motor.torque_for_forces_override_Nm)
-        if self.use_eta_b3_torque or self.is_motor_off_torque:
+        return abs(self.reference_torque_Nm)
+
+    @property
+    def motor_enabled(self) -> bool:
+        return not self.is_motor_off_torque
+
+    @property
+    def time_scale_policy(self) -> str:
+        return _time_scale_policy(self.model_profile)
+
+    @property
+    def reference_torque_Nm(self) -> float:
+        if self.use_eta_b3_torque:
             return self.torque_eta_b3_Nm
-        return abs(self.motor_torque_Nm)
+        if self.motor.reference_torque_Nm is not None:
+            return float(self.motor.reference_torque_Nm)
+        if self.time_scale_policy == TIME_SCALE_POLICY_REFERENCE_TORQUE:
+            return abs(self.input_torque_Nm)
+        if self.is_motor_off_torque:
+            return self.torque_eta_b3_Nm
+        return abs(self.input_torque_Nm)
 
     @property
     def motor_torque_Nm(self) -> float:
@@ -663,8 +886,14 @@ class SimulationConfig:
 
     @property
     def tau_s(self) -> float:
-        """内部計算で使う時間スケールτ[s]。Phase2では常に1固定。"""
-        return 1.0
+        """内部計算で使う時間スケールτ[s]。"""
+        return self._compute_tau_s()
+
+    def _compute_tau_s(self) -> float:
+        if self.time_scale_policy == TIME_SCALE_POLICY_LEGACY_FIXED_TAU:
+            return 1.0
+        reference = abs(float(self.reference_torque_Nm))
+        return self.viscosity_Pa_s * (self.b_m**3) / max(reference, 1e-300)
 
     @property
     def output_dt_s(self) -> float:
@@ -689,19 +918,61 @@ class SimulationConfig:
 
     @property
     def total_steps(self) -> int:
-        return max(1, int(math.ceil(self.duration_star / max(self.dt_star, 1e-30))))
+        return max(0, int(math.ceil(self.duration_star / max(self.dt_star, 1e-30))))
 
     def validate_time_scaling(
         self,
     ) -> None:
         """内部計算刻みが有効な値かを検証する。"""
 
+        if (
+            not math.isfinite(self.reference_torque_Nm)
+            or abs(self.reference_torque_Nm) <= 0.0
+        ):
+            raise ValueError("motor.reference_torque_Nm must be finite and non-zero.")
+        if self.input_torque_Nm < 0.0 and not self.use_eta_b3_torque:
+            raise ValueError(
+                "motor.torque_Nm=-1 is a deprecated 2010 paper profile sentinel "
+                "and cannot be used for this profile."
+            )
         if not math.isfinite(self.dt_star) or self.dt_star <= 0.0:
             raise ValueError(
                 "内部時間刻みが不正です。"
                 f" dt_s={self.dt_s:.12e}, tau_s={self.tau_s:.12e},"
                 f" dt_star={self.dt_star:.12e}"
             )
+        if not math.isfinite(self.time.duration_s) or self.time.duration_s < 0.0:
+            raise ValueError("time.duration must resolve to a non-negative duration.")
+
+    @property
+    def final_state_t_s(self) -> float:
+        return self.total_steps * self.dt_star * self.tau_s
+
+    @property
+    def final_step_summary_t_s(self) -> float:
+        if self.total_steps <= 0:
+            return 0.0
+        return (self.total_steps - 1) * self.dt_star * self.tau_s
+
+    def time_manifest(self) -> dict[str, Any]:
+        return {
+            "duration_value": float(self.time.duration_value),
+            "duration_unit": str(self.time.duration_unit),
+            "duration_tau": float(self.duration_star),
+            "duration_s": float(self.time.duration_s),
+            "dt_star": float(self.dt_star),
+            "tau_s": float(self.tau_s),
+            "dt_internal_s": float(self.dt_s),
+            "total_steps": int(self.total_steps),
+            "final_state_t_s": float(self.final_state_t_s),
+            "final_step_summary_t_s": float(self.final_step_summary_t_s),
+            "time_scale_policy": str(self.time_scale_policy),
+            "reference_torque_Nm": float(self.reference_torque_Nm),
+            "motor_enabled": bool(self.motor_enabled),
+            "motor_torque_Nm": float(self.motor_torque_Nm),
+            "time_schema_source": str(self.time.schema_source),
+            "legacy_time_keys_used": list(self.time.legacy_keys_used),
+        }
 
     def motor_local_scale_deviations(self) -> dict[str, float]:
         """Return motor local scales that differ from the paper-aligned default."""
@@ -961,7 +1232,13 @@ class SimulationConfig:
                 stacklevel=2,
             )
         motor = MotorParams(
+            enabled=bool(_get(motor_raw, "enabled", True)),
             torque_Nm=float(_get(motor_raw, "torque_Nm", 2.5e-20)),
+            reference_torque_Nm=(
+                float(motor_raw["reference_torque_Nm"])
+                if motor_raw.get("reference_torque_Nm") not in (None, "")
+                else None
+            ),
             force_distribution=normalize_motor_force_distribution(
                 _get(
                     motor_raw,
@@ -1151,27 +1428,7 @@ class SimulationConfig:
             curly1_tau=float(_get(rt_raw, "curly1_tau", 400.0)),
         )
 
-        time_raw = raw.get("time", {}) or {}
-        if "dt_over_tau" in time_raw:
-            raise ValueError(
-                "time.dt_over_tau は入力キーとして廃止。time.dt_s を使用してください。"
-            )
-
-        dt_s = time_raw.get("dt_s")
-        if dt_s is None:
-            raise ValueError(
-                "time.dt_s は必須です。出力間隔として設定してください（内部計算のΔtは1e-3固定）。"
-            )
-
-        time = TimeParams(
-            duration_s=float(_get(time_raw, "duration_s", 0.1)),
-            dt_s=float(dt_s),
-            dt_star=(
-                float(time_raw["dt_star"])
-                if time_raw.get("dt_star") not in (None, "")
-                else None
-            ),
-        )
+        time = _parse_time_params(raw)
 
         out_sample_raw = raw.get("output_sampling", {}) or {}
         old_fps = (raw.get("time", {}) or {}).get("fps_out")
@@ -1266,6 +1523,46 @@ class SimulationConfig:
             )
 
         merged = asdict(self)
+        time_overrides = (
+            overrides.get("time", {}) if isinstance(overrides, dict) else {}
+        )
+        merged_time = merged.get("time")
+        if isinstance(merged_time, dict) and "time" not in overrides:
+            if self.time.schema_source == "canonical":
+                merged_time["duration"] = {
+                    "value": self.time.duration_value,
+                    "unit": self.time.duration_unit,
+                }
+                merged_time["integration"] = {"dt_star": self.time.integration_dt_star}
+                merged_time.pop("duration_s", None)
+                merged_time.pop("dt_star", None)
+                merged_time.pop("legacy_duration_s", None)
+                merged_time.pop("legacy_dt_star", None)
+            for derived_key in (
+                "duration_value",
+                "duration_unit",
+                "integration_dt_star",
+                "schema_source",
+                "legacy_keys_used",
+            ):
+                merged_time.pop(derived_key, None)
+        if isinstance(time_overrides, dict):
+            if isinstance(merged_time, dict):
+                if "duration" in time_overrides:
+                    merged_time.pop("duration_s", None)
+                    merged_time.pop("legacy_duration_s", None)
+                if "integration" in time_overrides:
+                    merged_time.pop("dt_star", None)
+                    merged_time.pop("integration_dt_star", None)
+                    merged_time.pop("legacy_dt_star", None)
+                for derived_key in (
+                    "duration_value",
+                    "duration_unit",
+                    "integration_dt_star",
+                    "schema_source",
+                    "legacy_keys_used",
+                ):
+                    merged_time.pop(derived_key, None)
 
         def _merge(dst: dict[str, Any], src: dict[str, Any]) -> None:
             for key, value in src.items():

--- a/tests/test_e2e_cli.py
+++ b/tests/test_e2e_cli.py
@@ -54,7 +54,7 @@ def test_script_generates_outputs(tmp_path: Path, monkeypatch) -> None:
             "helix_init": {"radius_over_b": 0.25, "pitch_over_b": 2.5},
         },
         "fluid": {"viscosity_Pa_s": 0.001},
-        "motor": {"torque_Nm": -1.0, "reverse_n_flagella": 1},
+        "motor": {"torque_Nm": 2.5e-20, "reverse_n_flagella": 1},
         "potentials": {
             "spring": {"H_over_T_over_b": 10.0, "s": 0.1},
             "bend": {
@@ -149,6 +149,13 @@ def test_script_generates_outputs(tmp_path: Path, monkeypatch) -> None:
         "render.render_flagella=True",
     ]
     assert manifest["input"]["effective_overrides"]["time"]["duration_s"] == 5.0e-5
+    assert manifest["time"]["duration_s"] == 5.0e-5
+    assert manifest["time"]["duration_unit"] == "s"
+    assert manifest["time"]["dt_star"] == 1.0e-3
+    assert manifest["time"]["time_schema_source"] == "cli_shorthand"
+    assert manifest["time"]["total_steps"] == 1
+    assert manifest["time"]["final_state_t_s"] == 1.0e-3
+    assert manifest["time"]["final_step_summary_t_s"] == 0.0
     assert (
         manifest["input"]["effective_overrides"]["output_sampling"]["fps_out_2d"]
         == 25.0

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -528,6 +528,21 @@ def test_torque_minus_one_is_allowed_for_2010_paper_profile() -> None:
     assert sim_cfg.motor_torque_Nm == pytest.approx(sim_cfg.torque_eta_b3_Nm)
 
 
+def test_motor_disabled_overrides_2010_paper_minus_one_sentinel_drive() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _paper_model_profile(year=2010)
+    cfg["motor"]["enabled"] = False
+    cfg["motor"]["torque_Nm"] = -1.0
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    sim_cfg.validate_time_scaling()
+    assert sim_cfg.use_eta_b3_torque
+    assert sim_cfg.reference_torque_Nm == pytest.approx(sim_cfg.torque_eta_b3_Nm)
+    assert sim_cfg.motor_enabled is False
+    assert sim_cfg.motor_torque_Nm == pytest.approx(0.0)
+
+
 def test_torque_minus_one_is_rejected_for_2010_project_profile() -> None:
     cfg = _base_cfg()
     cfg["model_profile"] = _model_profile()

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -195,6 +195,25 @@ def test_legacy_project_profile_keeps_tau_s_fixed_at_one() -> None:
     assert sim_cfg.time_scale_policy == "legacy_fixed_tau_s_1"
 
 
+def test_partial_time_override_preserves_canonical_duration_unit() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _paper_model_profile(year=2010)
+    cfg["motor"] = {"torque_Nm": 2.0e-20, "reference_torque_Nm": 2.0e-20}
+    cfg["time"] = {
+        "duration": {"value": 0.1, "unit": "tau"},
+        "dt_s": 1.0e-3,
+        "integration": {"dt_star": 1.0e-4},
+    }
+    base = SimulationConfig.from_dict(cfg)
+
+    overridden = base.with_overrides({"time": {"integration": {"dt_star": 2.0e-4}}})
+
+    assert overridden.time.duration_unit == "tau"
+    assert overridden.tau_s == pytest.approx(base.tau_s)
+    assert overridden.time.duration_s == pytest.approx(0.1 * base.tau_s)
+    assert overridden.dt_star == pytest.approx(2.0e-4)
+
+
 def test_equivalent_new_and_legacy_time_keys_are_accepted() -> None:
     cfg = _base_cfg()
     cfg["time"] = {
@@ -552,6 +571,18 @@ def test_torque_minus_one_is_rejected_for_2010_project_profile() -> None:
 
     with pytest.raises(ValueError, match="deprecated 2010 paper profile sentinel"):
         sim_cfg.validate_time_scaling()
+
+
+def test_negative_signed_torque_other_than_minus_one_is_allowed() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _model_profile()
+    cfg["motor"]["torque_Nm"] = -2.5e-20
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    sim_cfg.validate_time_scaling()
+    assert sim_cfg.motor_torque_Nm == pytest.approx(-2.5e-20)
+    assert sim_cfg.reference_torque_Nm == pytest.approx(2.5e-20)
 
 
 def test_zero_reference_torque_is_rejected() -> None:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -40,6 +40,30 @@ def _model_profile(*, status: str = "supported") -> dict:
     }
 
 
+def _paper_model_profile(*, year: int = 2010, status: str = "supported") -> dict:
+    if year == 2010:
+        return {
+            "year": 2010,
+            "variant": "paper",
+            "resolution": "coarse",
+            "implementation_status": status,
+            "body_beads": 15,
+            "flagellum_beads_per_filament": 15,
+            "nominal_flagella_count": 3,
+            "nominal_total_beads": 60,
+        }
+    return {
+        "year": 2015,
+        "variant": "paper",
+        "resolution": "refined",
+        "implementation_status": status,
+        "body_beads": 30,
+        "flagellum_beads_per_filament": 30,
+        "nominal_flagella_count": 3,
+        "nominal_total_beads": 120,
+    }
+
+
 def test_model_profile_is_optional_for_legacy_configs() -> None:
     cfg = _base_cfg()
     cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
@@ -131,6 +155,99 @@ def test_dt_over_tau_input_is_rejected() -> None:
     cfg["time"] = {"duration_s": 0.1, "dt_over_tau": 0.001}
 
     with pytest.raises(ValueError, match="time.dt_over_tau"):
+        SimulationConfig.from_dict(cfg)
+
+
+def test_canonical_time_schema_resolves_tau_duration_from_reference_torque() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _paper_model_profile(year=2015, status="pending")
+    cfg["motor"] = {"torque_Nm": 1.2e-18, "reference_torque_Nm": 1.2e-18}
+    cfg["time"] = {
+        "duration": {"value": 1.0, "unit": "tau"},
+        "dt_s": 1.0e-3,
+        "integration": {"dt_star": 1.0e-5},
+    }
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    expected_tau_s = sim_cfg.viscosity_Pa_s * (sim_cfg.b_m**3) / 1.2e-18
+    assert sim_cfg.tau_s == pytest.approx(expected_tau_s)
+    assert sim_cfg.time.duration_s == pytest.approx(expected_tau_s)
+    assert sim_cfg.dt_s == pytest.approx(1.0e-5 * expected_tau_s)
+    assert sim_cfg.time_manifest()["time_schema_source"] == "canonical"
+
+
+def test_legacy_project_profile_keeps_tau_s_fixed_at_one() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _model_profile()
+    cfg["motor"]["torque_Nm"] = 2.0e-20
+    cfg["motor"]["reference_torque_Nm"] = 1.2e-18
+    cfg["time"] = {
+        "duration": {"value": 0.2, "unit": "tau"},
+        "dt_s": 1.0e-3,
+        "integration": {"dt_star": 1.0e-4},
+    }
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.tau_s == pytest.approx(1.0)
+    assert sim_cfg.time.duration_s == pytest.approx(0.2)
+    assert sim_cfg.time_scale_policy == "legacy_fixed_tau_s_1"
+
+
+def test_equivalent_new_and_legacy_time_keys_are_accepted() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {
+        "duration": {"value": 0.1, "unit": "s"},
+        "duration_s": 0.1,
+        "dt_s": 1.0e-3,
+        "integration": {"dt_star": 1.0e-4},
+        "dt_star": 1.0e-4,
+    }
+
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    assert sim_cfg.time.schema_source == "mixed_equivalent"
+    assert set(sim_cfg.time_manifest()["legacy_time_keys_used"]) == {
+        "time.duration_s",
+        "time.dt_s",
+        "time.dt_star",
+    }
+
+
+def test_conflicting_new_and_legacy_duration_is_rejected() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {
+        "duration": {"value": 0.2, "unit": "s"},
+        "duration_s": 0.1,
+        "dt_s": 1.0e-3,
+    }
+
+    with pytest.raises(ValueError, match="Conflicting time duration"):
+        SimulationConfig.from_dict(cfg)
+
+
+def test_conflicting_new_and_legacy_dt_star_is_rejected() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {
+        "duration_s": 0.1,
+        "dt_s": 1.0e-3,
+        "integration": {"dt_star": 1.0e-4},
+        "dt_star": 2.0e-4,
+    }
+
+    with pytest.raises(ValueError, match="Conflicting time integration"):
+        SimulationConfig.from_dict(cfg)
+
+
+def test_invalid_time_duration_unit_is_rejected() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {
+        "duration": {"value": 0.1, "unit": "frame"},
+        "dt_s": 1.0e-3,
+    }
+
+    with pytest.raises(ValueError, match="Unsupported time.duration.unit"):
         SimulationConfig.from_dict(cfg)
 
 
@@ -395,6 +512,54 @@ def test_torque_minus_one_uses_eta_b3_and_tau_is_one() -> None:
     )
     assert sim_cfg.torque_Nm == pytest.approx(sim_cfg.motor_torque_Nm)
     assert sim_cfg.tau_s == pytest.approx(1.0)
+
+
+def test_torque_minus_one_is_allowed_for_2010_paper_profile() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _paper_model_profile(year=2010)
+    cfg["fluid"]["viscosity_Pa_s"] = 2.0e-3
+    cfg["motor"]["torque_Nm"] = -1.0
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    sim_cfg.validate_time_scaling()
+    assert sim_cfg.use_eta_b3_torque
+    assert sim_cfg.reference_torque_Nm == pytest.approx(sim_cfg.torque_eta_b3_Nm)
+    assert sim_cfg.motor_torque_Nm == pytest.approx(sim_cfg.torque_eta_b3_Nm)
+
+
+def test_torque_minus_one_is_rejected_for_2010_project_profile() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _model_profile()
+    cfg["motor"]["torque_Nm"] = -1.0
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    with pytest.raises(ValueError, match="deprecated 2010 paper profile sentinel"):
+        sim_cfg.validate_time_scaling()
+
+
+def test_zero_reference_torque_is_rejected() -> None:
+    cfg = _base_cfg()
+    cfg["model_profile"] = _paper_model_profile(year=2015, status="pending")
+    cfg["motor"] = {
+        "torque_Nm": 1.2e-18,
+        "reference_torque_Nm": 0.0,
+    }
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    with pytest.raises(ValueError, match="reference_torque_Nm"):
+        sim_cfg.validate_time_scaling()
+
+
+def test_non_positive_dt_star_is_rejected() -> None:
+    cfg = _base_cfg()
+    cfg["time"] = {"duration_s": 0.1, "dt_s": 1.0e-3, "dt_star": 0.0}
+    sim_cfg = SimulationConfig.from_dict(cfg)
+
+    with pytest.raises(ValueError, match="内部時間刻み"):
+        sim_cfg.validate_time_scaling()
 
 
 def test_torque_non_minus_one_uses_input_value() -> None:

--- a/tests/test_phase2_generic_multi_run.py
+++ b/tests/test_phase2_generic_multi_run.py
@@ -307,6 +307,13 @@ def test_generic_multi_run_manifests_record_model_profile(
             "nominal_flagella_count": 3,
             "nominal_total_beads": 48,
         }
+        assert manifest["time"]["duration_s"] == pytest.approx(0.1)
+        assert manifest["time"]["dt_star"] == pytest.approx(1.0e-4)
+        assert manifest["time"]["time_schema_source"] == "canonical"
+    assert run_manifest["conditions"][0]["time"]["duration_s"] == pytest.approx(0.0001)
+    assert run_manifest["conditions"][0]["time"]["time_schema_source"] == (
+        "legacy_duration_s"
+    )
 
 
 def test_issue113_seed_fixed_profile_builds_three_boundary_conditions() -> None:

--- a/tests/test_phase2_generic_multi_run.py
+++ b/tests/test_phase2_generic_multi_run.py
@@ -312,7 +312,7 @@ def test_generic_multi_run_manifests_record_model_profile(
         assert manifest["time"]["time_schema_source"] == "canonical"
     assert run_manifest["conditions"][0]["time"]["duration_s"] == pytest.approx(0.0001)
     assert run_manifest["conditions"][0]["time"]["time_schema_source"] == (
-        "legacy_duration_s"
+        "mixed_equivalent"
     )
 
 


### PR DESCRIPTION
## Summary

Closes #165.

- Add canonical Phase 2 time schema with time.duration.{value,unit} and time.integration.dt_star.
- Preserve legacy time.duration_s / time.dt_star / time.dt_s compatibility with fail-fast conflict detection.
- Keep 2010 project tau_s=1.0 while deriving tau_s from eta*b^3/reference_torque_Nm for 2010 paper and 2015 profiles.
- Separate motor.enabled, motor.torque_Nm, and motor.reference_torque_Nm responsibilities.
- Record normalized time quantities and compatibility source in single-run and campaign manifests.
- Include the inherited AGENTS.md and docs/codex/codex_workflow.md branch cleanup workflow updates.

## Out of scope

- Issue #166 refined 2015 geometry.
- Issue #167 2015 paper motor dynamics.
- Issue #168 stability evaluation.
- Long Phase 2 simulation runs and visual review videos.

## Checks

- uv run pytest tests/test_params.py tests/test_model_profiles.py tests/test_e2e_cli.py tests/test_phase2_generic_multi_run.py -q
- uv run pytest tests/test_simulation.py tests/test_run_state_fixed.py tests/test_render_state_and_projection.py -q
- uv run pytest tests/test_phase2_sweep_profiles.py tests/test_phase2_6_torque_model_evaluation.py tests/test_phase2_82_hook_overstretch_sweep.py -q
- uv run pytest -q -m light
- uv run ruff check .
- uv run ruff format --check .
- git diff --check
- uv run pytest -q

## Review result

- docs/codex-runs/20260802_192500_phase2_165_time_schema/review_result.json: PASS

## User visual review

Not required for this schema/parser/manifest change. No long simulation was run.