### PR TITLE
[Phase2] 軽量 run_summary.json を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Read only what is needed for the task, in this order:
 
 Use `rg -n` before opening long Markdown files, logs, CSVs, or generated outputs.
 For prior Codex runs, read `review_result.json` before `work_log.md`.
-Do not read large files under `outputs/` unless compact summaries and manifests are insufficient.
+Do not read large files under `outputs/` unless compact summaries and manifests are insufficient. For Phase 2 diagnostics, read `run_summary.json` before using the bounded `inspect_step_summary.py` CLI; never load `step_summary.csv` in full for routine analysis.
 
 ## Language
 

--- a/docs/codex-runs/20260808_214922_phase2_181_run_summary/review_result.json
+++ b/docs/codex-runs/20260808_214922_phase2_181_run_summary/review_result.json
@@ -1,0 +1,42 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #181 compact run_summary.json",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/181",
+  "branch": "feature/issue-181-run-summary",
+  "summary": [
+    "Added a versioned, bounded Phase 2 run_summary.json generated automatically for every Simulator run.",
+    "Added compatibility CLI generation for existing outputs and bounded raw-diagnostic inspection by time window or summary episode.",
+    "Preserved step_summary.csv and existing gate meanings; absent body diagnostics are explicitly unavailable and incomplete legacy runs are explicitly unknown or partial."
+  ],
+  "scope_boundaries": [
+    "No physical model, threshold, dataset-adoption policy, step_summary.csv schema, or sampling policy was changed.",
+    "Long simulations, sweeps, training, rendering, and user visual review were not required or run."
+  ],
+  "checks": [
+    {
+      "command": "uv run pytest tests/test_phase2_run_summary.py tests/test_simulation.py tests/test_phase2_generic_multi_run.py tests/test_phase2_sweep_profiles.py -q",
+      "result": "PASS: 133 passed"
+    },
+    {
+      "command": "uv run pytest -q",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run ruff check . && uv run ruff format --check . && git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "pre-commit hook: uv run pytest -q -m light",
+      "result": "PASS: 286 passed, 249 deselected"
+    }
+  ],
+  "user_visual_review_required": false,
+  "long_simulation_required": false,
+  "adr_required": false,
+  "adr_reason": "既存診断の軽量集約と安全な参照導線の追加であり、物理モデル・dataset policy・phase boundaryの決定を変更しないため。",
+  "commit_type": "complete",
+  "commit_hash": "5b4156a04ce6fc786564b21a3873d65049772fcd",
+  "push_status": "not_pushed",
+  "pull_request_url": null,
+  "next_actions": []
+}

--- a/docs/codex-runs/20260808_214922_phase2_181_run_summary/review_result.json
+++ b/docs/codex-runs/20260808_214922_phase2_181_run_summary/review_result.json
@@ -28,15 +28,23 @@
     {
       "command": "pre-commit hook: uv run pytest -q -m light",
       "result": "PASS: 286 passed, 249 deselected"
+    },
+    {
+      "command": "Copilot review follow-up: uv run pytest tests/test_phase2_run_summary.py tests/test_simulation.py tests/test_phase2_generic_multi_run.py tests/test_phase2_sweep_profiles.py -q",
+      "result": "PASS: 133 passed"
     }
+  ],
+  "review_follow_up": [
+    "Copilot thread on schemas/phase2_run_summary.schema.json: added typed input, execution, sampling, extrema, gate, and episode fields.",
+    "Copilot thread on src/sim_swim/analysis/run_summary.py: end_t_s now identifies the last observed fail sample; next_observed_pass_t_s records recovery separately."
   ],
   "user_visual_review_required": false,
   "long_simulation_required": false,
   "adr_required": false,
   "adr_reason": "既存診断の軽量集約と安全な参照導線の追加であり、物理モデル・dataset policy・phase boundaryの決定を変更しないため。",
   "commit_type": "complete",
-  "commit_hash": "5b4156a04ce6fc786564b21a3873d65049772fcd",
-  "push_status": "not_pushed",
-  "pull_request_url": null,
+  "commit_hash": "f1b9425",
+  "push_status": "pushed",
+  "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/182",
   "next_actions": []
 }

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -76,6 +76,7 @@
 - n=3 diagnostics: `docs/phase2/phase2_158_v1_r1_nf3_proximal_diagnostics.md`
 - Phase 3 handoff: `docs/phase2/phase2_8_phase2_to_phase3_handoff.md`
 - Dataset registry: `docs/phase2/phase2_8_dataset_version_registry.md`
+- Run summary contract: `docs/phase2/phase2_run_summary_contract.md`
 - Axis / feature contracts: `phase2_7_flag_helix_axis_diagnostics.md`, `phase2_8_flagella_count_feature_definitions.md`
 - Model correspondence: `phase2_163_2010_potential_correspondence.md`, `phase2_167_2015_paper_conditions.md`
 - ADRs: `docs/adr/`

--- a/docs/phase2/phase2_run_summary_contract.md
+++ b/docs/phase2/phase2_run_summary_contract.md
@@ -1,0 +1,45 @@
+# Phase 2 `run_summary.json` contract
+
+## Purpose
+
+`run_summary.json` is the compact, formal first-read artifact for one Phase 2 simulation or campaign condition. It aggregates existing diagnostics and does not change the physical model, gate definitions, thresholds, or `step_summary.csv`.
+
+## Location and reading order
+
+- Single simulation: `<run>/sim/run_summary.json`
+- Sweep / multi-run: `<campaign>/<condition>/run_summary.json`
+
+Read `manifest.json` and `run_summary.json` first. Inspect raw diagnostics only through the bounded CLI below; do not load a complete `step_summary.csv` into Codex context during routine analysis.
+
+```bash
+uv run python scripts/02_phase2_analysis/inspect_step_summary.py \
+  --input-dir outputs/.../condition_001 \
+  --gate shape_nonbody --episode 1 \
+  --columns t_s,shape_pass_nonbody,first_fail_category_nonbody,hook_len_rel_err_max
+```
+
+The CLI requires a time window or a `gate`/`episode`, requires 1--12 columns, and returns at most 1,000 rows (100 by default).
+
+## Schema version 1.0
+
+Machine-readable top-level validation contract: `schemas/phase2_run_summary.schema.json`.
+
+- `execution`: `completed`, `partial`, or `unknown`. `unknown` means an older output lacks enough manifest time metadata; it does not mean pass or fail.
+- `sampling`: observed temporal spacing and the episode policy. Durations are physical seconds but are bounded by observed samples; they do not claim an unobserved threshold-crossing time.
+- `gates.finite` and `gates.shape_nonbody`: existing per-step gate values, without reinterpretation.
+- `gates.shape_body`: `available` only when body diagnostics exist. Missing diagnostics are `unavailable`, never treated as a body failure or pass.
+- `episodes`: maximal consecutive observed fail samples. `persistent_observed` means at least three consecutive observations, not a new physical acceptance threshold.
+- `extrema`: selected existing diagnostic maxima and their observed times.
+
+Each gate stores at most 32 episodes. When that limit is exceeded, it retains early, late, and long episodes and records the omitted count. No per-step time series is copied into JSON. The generated file is capped at 64 KiB; generation fails rather than silently emitting an unbounded artifact.
+
+## Generation and compatibility
+
+New simulations generate the file automatically after their diagnostics are written. Existing outputs can be summarized without re-simulation:
+
+```bash
+uv run python scripts/02_phase2_analysis/build_run_summary.py \
+  --input-dir outputs/.../condition_001
+```
+
+The command does not modify source diagnostics. Replacing an existing summary requires `--overwrite`.

--- a/docs/phase2/phase2_run_summary_contract.md
+++ b/docs/phase2/phase2_run_summary_contract.md
@@ -28,7 +28,7 @@ Machine-readable top-level validation contract: `schemas/phase2_run_summary.sche
 - `sampling`: observed temporal spacing and the episode policy. Durations are physical seconds but are bounded by observed samples; they do not claim an unobserved threshold-crossing time.
 - `gates.finite` and `gates.shape_nonbody`: existing per-step gate values, without reinterpretation.
 - `gates.shape_body`: `available` only when body diagnostics exist. Missing diagnostics are `unavailable`, never treated as a body failure or pass.
-- `episodes`: maximal consecutive observed fail samples. `persistent_observed` means at least three consecutive observations, not a new physical acceptance threshold.
+- `episodes`: maximal consecutive observed fail samples. `start_t_s` / `end_t_s` are the first / last observed fail times; `next_observed_pass_t_s` records recovery when observed. `observed_duration_s` is therefore a sampled span, not an unobserved threshold-crossing duration. `persistent_observed` means at least three consecutive observations, not a new physical acceptance threshold.
 - `extrema`: selected existing diagnostic maxima and their observed times.
 
 Each gate stores at most 32 episodes. When that limit is exceeded, it retains early, late, and long episodes and records the omitted count. No per-step time series is copied into JSON. The generated file is capped at 64 KiB; generation fails rather than silently emitting an unbounded artifact.

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -147,7 +147,7 @@ Issue単位の進捗台帳，branch一覧，acceptance criteria一覧，実行co
 - **Status:** adopted
 - **Background:** `dt_star=1.0e-4`では内部step数が多く，全stepを画像化すると実行時間とファイル数が大きくなる一方，保存時にstateを間引くと後続解析・再描画ができなくなる．
 - **Change:** user-facingな複数条件実行を`run_multi_run.py`，診断gridを`run_sweep.py`，定量plotを`plot_heatmap.py`，保存済みstateの再描画をreplay CLIへ分離した．
-- **Result:** `summary.csv`, `trajectory.csv`, `state_archive.npz`, `run_manifest.json`をreplayable output contractとして固定した．raw sampleは全step情報を保持し，軽量化はrender側のfps samplingで行う方針となった．保存段階のstrideは廃止し，canonical sweep名を`shape_stability_grid`，sweep summary名を`summary.csv`とした．
+- **Result:** `summary.csv`, `trajectory.csv`, `state_archive.npz`, `run_manifest.json`をreplayable output contractとして固定した．raw sampleは全step情報を保持し，軽量化はrender側のfps samplingで行う方針となった．保存段階のstrideは廃止し，canonical sweep名を`shape_stability_grid`，sweep summary名を`summary.csv`とした．通常診断は軽量な`run_summary.json`を先に読み，raw `step_summary.csv` は限定抽出時のみ使う．
 - **Interpretation:** simulation情報を保存段階で不可逆に削減せず，描画・レビュー時にsamplingする方が，再現性と実行効率を両立できる．
 - **Decision:** raw outputを解析・replay可能な形で保持し，通常renderでは全内部stepを描画しない．full-step renderは診断時のみ明示指定し，Issue番号付き使い捨てscriptをcanonical entrypointにしない．
 - **Evidence:** Tasks P2-9-009，P2-8-078，P2-8-081，P2-8-084，P2-8-100，P2-8-DTSTAR，P2-SCRIPT-096，`conf/phase2_multi_run/README.md`，`scripts/README.md`．

--- a/schemas/phase2_run_summary.schema.json
+++ b/schemas/phase2_run_summary.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "phase2_run_summary.schema.json",
+  "title": "Phase 2 run summary",
+  "type": "object",
+  "required": ["schema_version", "kind", "input", "execution", "sampling", "gates", "extrema"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "kind": {"const": "phase2_run_summary"},
+    "execution": {
+      "type": "object",
+      "required": ["status", "row_count"],
+      "properties": {"status": {"enum": ["completed", "partial", "unknown"]}}
+    },
+    "gates": {
+      "type": "object",
+      "required": ["finite", "shape_nonbody", "shape_body"],
+      "additionalProperties": {"$ref": "#/$defs/gate"}
+    }
+  },
+  "$defs": {
+    "gate": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"enum": ["available", "unavailable"]},
+        "episodes": {"type": "array", "maxItems": 32}
+      }
+    }
+  }
+}

--- a/schemas/phase2_run_summary.schema.json
+++ b/schemas/phase2_run_summary.schema.json
@@ -7,24 +7,103 @@
   "properties": {
     "schema_version": {"const": "1.0"},
     "kind": {"const": "phase2_run_summary"},
+    "input": {
+      "type": "object",
+      "required": ["run_dir", "step_summary_csv", "body_constraint_diagnostics_csv"],
+      "properties": {
+        "run_dir": {"type": "string"},
+        "step_summary_csv": {"type": "string"},
+        "body_constraint_diagnostics_csv": {"type": ["string", "null"]}
+      }
+    },
     "execution": {
       "type": "object",
-      "required": ["status", "row_count"],
-      "properties": {"status": {"enum": ["completed", "partial", "unknown"]}}
+      "required": ["status", "row_count", "step_indices_contiguous_from_zero"],
+      "properties": {
+        "status": {"enum": ["completed", "partial", "unknown"]},
+        "row_count": {"type": "integer", "minimum": 0},
+        "step_indices_contiguous_from_zero": {"type": "boolean"},
+        "observed_first_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "observed_final_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "expected_total_steps": {"type": ["integer", "null"], "minimum": 0},
+        "expected_final_step_summary_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "reason": {"type": "string"}
+      }
+    },
+    "sampling": {
+      "type": "object",
+      "required": ["step_summary_row_count", "time_spacing_s", "episode_definition", "persistent_observed_min_consecutive_fail_samples", "episode_storage_limit_per_gate"],
+      "properties": {
+        "step_summary_row_count": {"type": "integer", "minimum": 0},
+        "time_spacing_s": {
+          "type": "object",
+          "required": ["min_s", "median_s", "max_s"],
+          "properties": {
+            "min_s": {"$ref": "#/$defs/nullableNumber"},
+            "median_s": {"$ref": "#/$defs/nullableNumber"},
+            "max_s": {"$ref": "#/$defs/nullableNumber"}
+          }
+        },
+        "episode_definition": {"type": "string"},
+        "persistent_observed_min_consecutive_fail_samples": {"type": "integer", "minimum": 1},
+        "episode_storage_limit_per_gate": {"type": "integer", "minimum": 1}
+      }
     },
     "gates": {
       "type": "object",
       "required": ["finite", "shape_nonbody", "shape_body"],
-      "additionalProperties": {"$ref": "#/$defs/gate"}
+      "properties": {
+        "finite": {"$ref": "#/$defs/gate"},
+        "shape_nonbody": {"$ref": "#/$defs/gate"},
+        "shape_body": {"$ref": "#/$defs/gate"}
+      }
+    },
+    "extrema": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/extremum"}
     }
   },
   "$defs": {
+    "nullableNumber": {"type": ["number", "null"]},
+    "extremum": {
+      "type": "object",
+      "required": ["value", "t_s"],
+      "properties": {
+        "value": {"$ref": "#/$defs/nullableNumber"},
+        "t_s": {"$ref": "#/$defs/nullableNumber"}
+      }
+    },
+    "episode": {
+      "type": "object",
+      "required": ["start_step", "last_observed_fail_step", "start_t_s", "end_t_s", "next_observed_pass_t_s", "observed_fail_sample_count", "observed_duration_s", "persistent_observed", "category_counts"],
+      "properties": {
+        "start_step": {"type": "integer", "minimum": 0},
+        "last_observed_fail_step": {"type": "integer", "minimum": 0},
+        "start_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "end_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "next_observed_pass_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "observed_fail_sample_count": {"type": "integer", "minimum": 1},
+        "observed_duration_s": {"$ref": "#/$defs/nullableNumber"},
+        "persistent_observed": {"type": "boolean"},
+        "category_counts": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 1}}
+      }
+    },
     "gate": {
       "type": "object",
       "required": ["status"],
       "properties": {
         "status": {"enum": ["available", "unavailable"]},
-        "episodes": {"type": "array", "maxItems": 32}
+        "reason": {"type": "string"},
+        "final_pass": {"type": ["boolean", "null"]},
+        "any_fail": {"type": "boolean"},
+        "first_observed_fail_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "last_observed_fail_t_s": {"$ref": "#/$defs/nullableNumber"},
+        "observed_fail_sample_count": {"type": "integer", "minimum": 0},
+        "episode_count": {"type": "integer", "minimum": 0},
+        "stored_episode_count": {"type": "integer", "minimum": 0, "maximum": 32},
+        "omitted_episode_count": {"type": "integer", "minimum": 0},
+        "recovered_after_fail": {"type": "boolean"},
+        "episodes": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/episode"}}
       }
     }
   }

--- a/scripts/01_simulate_swimming/01_simulate_swimming.py
+++ b/scripts/01_simulate_swimming/01_simulate_swimming.py
@@ -296,6 +296,7 @@ def main(
         {
             "trajectory_csv": str(traj_path),
             "step_summary_csv": str(ctx.out.sim_dir / "step_summary.csv"),
+            "run_summary_json": str(ctx.out.sim_dir / "run_summary.json"),
             "render3d": str(ctx.out.render_dir),
             "render2d": str(ctx.out.render2d_dir),
         }

--- a/scripts/02_phase2_analysis/build_run_summary.py
+++ b/scripts/02_phase2_analysis/build_run_summary.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""既存 Phase 2 diagnostics から軽量な run_summary.json を生成する。"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from sim_swim.analysis.run_summary import write_run_summary
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args(argv)
+    print(write_run_summary(args.input_dir, overwrite=args.overwrite))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/02_phase2_analysis/inspect_step_summary.py
+++ b/scripts/02_phase2_analysis/inspect_step_summary.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""run_summary.json を入口に、step_summary.csv の限定区間だけを表示する。"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from sim_swim.analysis.run_summary import resolve_run_dir
+
+
+def _episode_window(run_dir: Path, gate: str, episode: int) -> tuple[float, float]:
+    summary_path = run_dir / "run_summary.json"
+    if not summary_path.is_file():
+        raise FileNotFoundError("run_summary.json is required for --gate/--episode")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    episodes = summary.get("gates", {}).get(gate, {}).get("episodes", [])
+    if episode < 1 or episode > len(episodes):
+        raise ValueError(
+            f"episode must be between 1 and {len(episodes)} for gate={gate}"
+        )
+    selected = episodes[episode - 1]
+    start, end = selected.get("start_t_s"), selected.get("end_t_s")
+    if start is None or end is None:
+        raise ValueError("selected episode has no finite time bounds")
+    return float(start), float(end)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument(
+        "--columns", required=True, help="Comma-separated columns; max 12."
+    )
+    parser.add_argument("--gate")
+    parser.add_argument("--episode", type=int)
+    parser.add_argument("--start-t-s", type=float)
+    parser.add_argument("--end-t-s", type=float)
+    parser.add_argument("--max-rows", type=int, default=100)
+    args = parser.parse_args(argv)
+    if (args.gate is None) != (args.episode is None):
+        parser.error("--gate and --episode must be used together")
+    if args.gate is not None:
+        start, end = _episode_window(
+            resolve_run_dir(args.input_dir), args.gate, args.episode
+        )
+    elif args.start_t_s is not None and args.end_t_s is not None:
+        start, end = args.start_t_s, args.end_t_s
+    else:
+        parser.error("provide --gate/--episode or both --start-t-s and --end-t-s")
+    if end < start or not 1 <= args.max_rows <= 1000:
+        parser.error("time window must be ordered and --max-rows must be 1..1000")
+    columns = [value.strip() for value in args.columns.split(",") if value.strip()]
+    if not columns or len(columns) > 12:
+        parser.error("--columns must contain 1..12 columns")
+    run_dir = resolve_run_dir(args.input_dir)
+    selected: list[dict[str, str]] = []
+    match_count = 0
+    with (run_dir / "step_summary.csv").open(
+        "r", encoding="utf-8", newline=""
+    ) as handle:
+        reader = csv.DictReader(handle)
+        available = set(reader.fieldnames or [])
+        missing = [column for column in columns if column not in available]
+        if missing:
+            parser.error(f"unknown columns: {', '.join(missing)}")
+        for row in reader:
+            try:
+                t_s = float(row["t_s"])
+            except (KeyError, ValueError):
+                continue
+            if start <= t_s <= end:
+                match_count += 1
+                if len(selected) < args.max_rows:
+                    selected.append({column: row[column] for column in columns})
+    print(
+        json.dumps(
+            {
+                "run_dir": str(run_dir),
+                "time_window_s": [start, end],
+                "columns": columns,
+                "matching_row_count": match_count,
+                "returned_row_count": len(selected),
+                "truncated": match_count > len(selected),
+                "rows": selected,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sim_swim/analysis/run_summary.py
+++ b/src/sim_swim/analysis/run_summary.py
@@ -154,7 +154,7 @@ def _episodes(
     episodes: list[dict[str, Any]] = []
     for begin, end in spans:
         begin_t = times[begin]
-        end_t = times[end] if end < len(times) else times[end - 1]
+        end_t = times[end - 1]
         categories = Counter(
             str(row.get(category_column, "unspecified"))[:128]
             for row in rows[begin:end]
@@ -163,11 +163,14 @@ def _episodes(
         episodes.append(
             {
                 "start_step": int(_float(rows[begin].get("step"))),
-                "end_step_exclusive": (
-                    int(_float(rows[end].get("step"))) if end < len(rows) else None
-                ),
+                "last_observed_fail_step": int(_float(rows[end - 1].get("step"))),
                 "start_t_s": begin_t if math.isfinite(begin_t) else None,
                 "end_t_s": end_t if math.isfinite(end_t) else None,
+                "next_observed_pass_t_s": (
+                    times[end]
+                    if end < len(times) and math.isfinite(times[end])
+                    else None
+                ),
                 "observed_fail_sample_count": end - begin,
                 "observed_duration_s": (
                     max(0.0, end_t - begin_t)

--- a/src/sim_swim/analysis/run_summary.py
+++ b/src/sim_swim/analysis/run_summary.py
@@ -1,0 +1,389 @@
+"""Phase 2 run diagnostics を軽量な run_summary.json へ集約する。"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from zoneinfo import ZoneInfo
+
+from sim_swim.sim.body_shape_gate import (
+    BODY_BEND_ERR_MAX_DEG_LIMIT,
+    BODY_CENTERLINE_DEV_UM_MAX_LIMIT,
+    BODY_SPRING_STRETCH_RATIO_MAX_LIMIT,
+    BODY_TRIANGLE_AREA_RATIO_MIN_LIMIT,
+)
+
+SCHEMA_VERSION = "1.0"
+EPISODE_STORAGE_LIMIT = 32
+PERSISTENT_MIN_CONSECUTIVE_FAIL_SAMPLES = 3
+MAX_RUN_SUMMARY_BYTES = 64 * 1024
+
+
+def _float(value: object) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _bool(value: object) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def resolve_run_dir(input_dir: Path) -> Path:
+    """``step_summary.csv`` を含む run directory を解決する。"""
+    input_dir = Path(input_dir)
+    if (input_dir / "step_summary.csv").is_file():
+        return input_dir
+    if (input_dir / "sim" / "step_summary.csv").is_file():
+        return input_dir / "sim"
+    raise FileNotFoundError(f"step_summary.csv is missing below: {input_dir}")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _manifest_time(run_dir: Path) -> dict[str, Any] | None:
+    for candidate in (run_dir / "manifest.json", run_dir.parent / "manifest.json"):
+        manifest = _read_json(candidate)
+        if isinstance(manifest, dict) and isinstance(manifest.get("time"), dict):
+            return dict(manifest["time"])
+    campaign = _read_json(run_dir.parent / "run_manifest.json")
+    if not isinstance(campaign, dict):
+        return None
+    for condition in campaign.get("conditions", []):
+        if (
+            isinstance(condition, dict)
+            and Path(str(condition.get("output_dir", ""))).name == run_dir.name
+        ):
+            if isinstance(condition.get("time"), dict):
+                return dict(condition["time"])
+    return dict(campaign["time"]) if isinstance(campaign.get("time"), dict) else None
+
+
+def _execution(
+    rows: Sequence[Mapping[str, str]], time: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    steps = [_float(row.get("step")) for row in rows]
+    times = [_float(row.get("t_s")) for row in rows]
+    contiguous = bool(rows) and all(
+        math.isfinite(step) and int(step) == index for index, step in enumerate(steps)
+    )
+    result: dict[str, Any] = {
+        "status": "unknown",
+        "row_count": len(rows),
+        "step_indices_contiguous_from_zero": contiguous,
+        "observed_first_t_s": times[0] if times and math.isfinite(times[0]) else None,
+        "observed_final_t_s": times[-1] if times and math.isfinite(times[-1]) else None,
+    }
+    if not time:
+        result["reason"] = "time manifest is unavailable"
+        return result
+    expected_steps = _float(time.get("total_steps"))
+    expected_final = _float(time.get("final_step_summary_t_s"))
+    result["expected_total_steps"] = (
+        int(expected_steps) if math.isfinite(expected_steps) else None
+    )
+    result["expected_final_step_summary_t_s"] = (
+        expected_final if math.isfinite(expected_final) else None
+    )
+    if not math.isfinite(expected_steps) or not math.isfinite(expected_final):
+        result["reason"] = "time manifest lacks total_steps or final_step_summary_t_s"
+        return result
+    completed = (
+        contiguous
+        and len(rows) == int(expected_steps)
+        and bool(times)
+        and math.isfinite(times[-1])
+        and math.isclose(times[-1], expected_final, rel_tol=1e-9, abs_tol=1e-12)
+    )
+    result["status"] = "completed" if completed else "partial"
+    result["reason"] = (
+        "matched time manifest"
+        if completed
+        else "observed rows do not match time manifest"
+    )
+    return result
+
+
+def _sample_spacing(times: Sequence[float]) -> dict[str, float | None]:
+    gaps = sorted(
+        later - earlier for earlier, later in zip(times, times[1:]) if later > earlier
+    )
+    if not gaps:
+        return {"min_s": None, "median_s": None, "max_s": None}
+    midpoint = len(gaps) // 2
+    median = (
+        gaps[midpoint] if len(gaps) % 2 else (gaps[midpoint - 1] + gaps[midpoint]) / 2
+    )
+    return {"min_s": gaps[0], "median_s": median, "max_s": gaps[-1]}
+
+
+def _episodes(
+    rows: Sequence[Mapping[str, str]],
+    passed: Sequence[bool],
+    *,
+    category_column: str | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    times = [_float(row.get("t_s")) for row in rows]
+    spans: list[tuple[int, int]] = []
+    start: int | None = None
+    for index, is_pass in enumerate(passed):
+        if not is_pass and start is None:
+            start = index
+        elif is_pass and start is not None:
+            spans.append((start, index))
+            start = None
+    if start is not None:
+        spans.append((start, len(rows)))
+    episodes: list[dict[str, Any]] = []
+    for begin, end in spans:
+        begin_t = times[begin]
+        end_t = times[end] if end < len(times) else times[end - 1]
+        categories = Counter(
+            str(row.get(category_column, "unspecified"))[:128]
+            for row in rows[begin:end]
+            if category_column and str(row.get(category_column, ""))
+        )
+        episodes.append(
+            {
+                "start_step": int(_float(rows[begin].get("step"))),
+                "end_step_exclusive": (
+                    int(_float(rows[end].get("step"))) if end < len(rows) else None
+                ),
+                "start_t_s": begin_t if math.isfinite(begin_t) else None,
+                "end_t_s": end_t if math.isfinite(end_t) else None,
+                "observed_fail_sample_count": end - begin,
+                "observed_duration_s": (
+                    max(0.0, end_t - begin_t)
+                    if math.isfinite(begin_t) and math.isfinite(end_t)
+                    else None
+                ),
+                "persistent_observed": (end - begin)
+                >= PERSISTENT_MIN_CONSECUTIVE_FAIL_SAMPLES,
+                "category_counts": dict(sorted(categories.items())),
+            }
+        )
+    if len(episodes) <= EPISODE_STORAGE_LIMIT:
+        return episodes, 0
+    ranked = sorted(
+        range(len(episodes)),
+        key=lambda index: (
+            -float(episodes[index]["observed_duration_s"] or 0.0),
+            index,
+        ),
+    )
+    kept = set(range(8)) | set(range(len(episodes) - 8, len(episodes)))
+    for index in ranked:
+        if len(kept) >= EPISODE_STORAGE_LIMIT:
+            break
+        kept.add(index)
+    selected = [episode for index, episode in enumerate(episodes) if index in kept]
+    return selected, len(episodes) - len(selected)
+
+
+def _gate_summary(
+    rows: Sequence[Mapping[str, str]],
+    passed: Sequence[bool] | None,
+    *,
+    category_column: str | None = None,
+    unavailable_reason: str | None = None,
+) -> dict[str, Any]:
+    if passed is None:
+        return {"status": "unavailable", "reason": unavailable_reason}
+    episodes, omitted = _episodes(rows, passed, category_column=category_column)
+    failed = [index for index, value in enumerate(passed) if not value]
+    return {
+        "status": "available",
+        "final_pass": bool(passed[-1]) if passed else None,
+        "any_fail": bool(failed),
+        "first_observed_fail_t_s": (
+            _float(rows[failed[0]].get("t_s")) if failed else None
+        ),
+        "last_observed_fail_t_s": (
+            _float(rows[failed[-1]].get("t_s")) if failed else None
+        ),
+        "observed_fail_sample_count": len(failed),
+        "episode_count": len(episodes) + omitted,
+        "stored_episode_count": len(episodes),
+        "omitted_episode_count": omitted,
+        "recovered_after_fail": bool(failed) and bool(passed[-1]),
+        "episodes": episodes,
+    }
+
+
+def _step_gate(
+    rows: Sequence[Mapping[str, str]],
+    column: str,
+    *,
+    category_column: str | None = None,
+) -> dict[str, Any]:
+    if not rows:
+        return _gate_summary(rows, None, unavailable_reason="step_summary.csv is empty")
+    if any(column not in row for row in rows):
+        return _gate_summary(
+            rows,
+            None,
+            unavailable_reason=f"step_summary.csv lacks required column: {column}",
+        )
+    return _gate_summary(
+        rows,
+        [_bool(row.get(column)) for row in rows],
+        category_column=category_column,
+    )
+
+
+def _body_gate(rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
+    if not rows:
+        return _gate_summary(
+            rows,
+            None,
+            unavailable_reason="body_constraint_diagnostics.csv is missing or empty",
+        )
+    initial_area = _float(rows[0].get("body_triangle_area_min"))
+    passed: list[bool] = []
+    normalized: list[dict[str, str]] = []
+    for row in rows:
+        stretch = _float(row.get("body_spring_max_stretch_ratio"))
+        bend = _float(row.get("body_bend_max_error_deg"))
+        centerline = _float(row.get("body_centerline_max_deviation_um"))
+        area = _float(row.get("body_triangle_area_min"))
+        if (
+            not all(
+                math.isfinite(value)
+                for value in (stretch, bend, centerline, area, initial_area)
+            )
+            or initial_area <= 0.0
+        ):
+            category = "body_nonfinite"
+        elif stretch > BODY_SPRING_STRETCH_RATIO_MAX_LIMIT:
+            category = "body_spring"
+        elif bend > BODY_BEND_ERR_MAX_DEG_LIMIT:
+            category = "body_bend"
+        elif centerline > BODY_CENTERLINE_DEV_UM_MAX_LIMIT:
+            category = "body_centerline"
+        elif area / max(initial_area, 1e-30) < BODY_TRIANGLE_AREA_RATIO_MIN_LIMIT:
+            category = "body_area"
+        else:
+            category = "none"
+        copy = dict(row)
+        copy["body_fail_category"] = category
+        normalized.append(copy)
+        passed.append(category == "none")
+    return _gate_summary(normalized, passed, category_column="body_fail_category")
+
+
+def _extrema(rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for metric in (
+        "hook_len_rel_err_max",
+        "flag_bond_rel_err_max",
+        "flag_bend_err_max_deg",
+        "flag_torsion_err_max_deg",
+    ):
+        candidates = [
+            (index, _float(row.get(metric))) for index, row in enumerate(rows)
+        ]
+        finite = [(index, value) for index, value in candidates if math.isfinite(value)]
+        if not finite:
+            result[metric] = {"value": None, "t_s": None}
+            continue
+        index, value = max(finite, key=lambda item: item[1])
+        result[metric] = {"value": value, "t_s": _float(rows[index].get("t_s"))}
+    return result
+
+
+def build_run_summary(
+    input_dir: Path, *, time_manifest: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    """既存 diagnostics から、時系列を複製しない run summary を構築する。"""
+    run_dir = resolve_run_dir(input_dir)
+    step_path = run_dir / "step_summary.csv"
+    step_rows = _rows(step_path)
+    body_path = run_dir / "body_constraint_diagnostics.csv"
+    body_rows = _rows(body_path) if body_path.is_file() else []
+    effective_time = (
+        dict(time_manifest) if time_manifest is not None else _manifest_time(run_dir)
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "phase2_run_summary",
+        "created_at": datetime.now(ZoneInfo("Asia/Tokyo")).isoformat(),
+        "input": {
+            "run_dir": str(run_dir),
+            "step_summary_csv": str(step_path),
+            "body_constraint_diagnostics_csv": (
+                str(body_path) if body_path.is_file() else None
+            ),
+        },
+        "execution": _execution(step_rows, effective_time),
+        "sampling": {
+            "step_summary_row_count": len(step_rows),
+            "time_spacing_s": _sample_spacing(
+                [_float(row.get("t_s")) for row in step_rows]
+            ),
+            "episode_definition": "maximal consecutive observed fail samples",
+            "persistent_observed_min_consecutive_fail_samples": PERSISTENT_MIN_CONSECUTIVE_FAIL_SAMPLES,
+            "episode_storage_limit_per_gate": EPISODE_STORAGE_LIMIT,
+        },
+        "gates": {
+            "finite": _step_gate(step_rows, "finite_pass"),
+            "shape_nonbody": _step_gate(
+                step_rows,
+                "shape_pass_nonbody",
+                category_column="first_fail_category_nonbody",
+            ),
+            "shape_body": _body_gate(body_rows),
+        },
+        "extrema": _extrema(step_rows),
+        "source_file_size_bytes": {
+            "step_summary_csv": step_path.stat().st_size,
+            "body_constraint_diagnostics_csv": (
+                body_path.stat().st_size if body_path.is_file() else None
+            ),
+        },
+    }
+
+
+def write_run_summary(
+    input_dir: Path,
+    *,
+    time_manifest: Mapping[str, Any] | None = None,
+    overwrite: bool = False,
+) -> Path:
+    run_dir = resolve_run_dir(input_dir)
+    output = run_dir / "run_summary.json"
+    if output.exists() and not overwrite:
+        raise FileExistsError(
+            f"run_summary.json already exists: {output}; use --overwrite"
+        )
+    text = (
+        json.dumps(
+            build_run_summary(run_dir, time_manifest=time_manifest),
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n"
+    )
+    encoded = text.encode("utf-8")
+    if len(encoded) > MAX_RUN_SUMMARY_BYTES:
+        raise ValueError(
+            f"run_summary.json would exceed {MAX_RUN_SUMMARY_BYTES} bytes: {output}"
+        )
+    output.write_bytes(encoded)
+    return output

--- a/src/sim_swim/analysis/sweeps/generic_multi_run.py
+++ b/src/sim_swim/analysis/sweeps/generic_multi_run.py
@@ -124,6 +124,7 @@ def _manifest_condition_record(
         "condition_index": condition["condition_index"],
         "condition_label": condition["condition_label"],
         "output_dir": str(root / condition["condition_id"]),
+        "run_summary_json": str(root / condition["condition_id"] / "run_summary.json"),
         "config_overrides": condition["config_overrides"],
         "axis_values": condition["axis_values"],
         "axis_labels": condition["axis_labels"],

--- a/src/sim_swim/analysis/sweeps/shape_stability_grid.py
+++ b/src/sim_swim/analysis/sweeps/shape_stability_grid.py
@@ -1206,6 +1206,9 @@ def _manifest_record(
         "description": condition.description,
         "scales": dict(condition.scales),
         "output_dir": str(args.output_dir / condition.condition_id),
+        "run_summary_json": str(
+            args.output_dir / condition.condition_id / "run_summary.json"
+        ),
         "config_overrides": _overrides_for_condition(args, condition),
         "axis_values": metadata["axis_values"],
         "axis_labels": metadata["axis_labels"],

--- a/src/sim_swim/sim/core.py
+++ b/src/sim_swim/sim/core.py
@@ -12,6 +12,7 @@ from typing import Any, List, Tuple
 
 import numpy as np
 
+from sim_swim.analysis.run_summary import write_run_summary
 from sim_swim.dynamics.engine import DynamicsEngine
 from sim_swim.model.builder import ModelBuilder
 from sim_swim.sim.debug_summary import (
@@ -775,5 +776,13 @@ class Simulator:
             body_local_csv = body_local_diag_recorder.write_csv()
             if logger is not None:
                 logger.info("Saved body local diagnostics to %s", body_local_csv)
+        if step_summary_dir is not None:
+            run_summary = write_run_summary(
+                step_summary_dir,
+                time_manifest=self.config.time_manifest(),
+                overwrite=True,
+            )
+            if logger is not None:
+                logger.info("Saved run summary to %s", run_summary)
 
         return states

--- a/tests/test_phase2_run_summary.py
+++ b/tests/test_phase2_run_summary.py
@@ -64,6 +64,8 @@ def test_run_summary_distinguishes_short_fail_recovery_and_missing_body(
     assert gate["recovered_after_fail"] is True
     assert gate["episode_count"] == 2
     assert gate["episodes"][0]["persistent_observed"] is False
+    assert gate["episodes"][0]["end_t_s"] == pytest.approx(0.1)
+    assert gate["episodes"][0]["next_observed_pass_t_s"] == pytest.approx(0.2)
     assert gate["episodes"][1]["persistent_observed"] is True
     assert summary["gates"]["shape_body"] == {
         "status": "unavailable",

--- a/tests/test_phase2_run_summary.py
+++ b/tests/test_phase2_run_summary.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from sim_swim.analysis.run_summary import (
+    MAX_RUN_SUMMARY_BYTES,
+    build_run_summary,
+    write_run_summary,
+)
+
+
+def _write_csv(
+    path: Path, fieldnames: list[str], rows: list[dict[str, object]]
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _step_rows(passes: list[bool]) -> list[dict[str, object]]:
+    return [
+        {
+            "step": index,
+            "t_s": index * 0.1,
+            "finite_pass": True,
+            "shape_pass_nonbody": value,
+            "first_fail_category_nonbody": "none" if value else "hook",
+            "hook_len_rel_err_max": index / 10,
+            "flag_bond_rel_err_max": index / 100,
+            "flag_bend_err_max_deg": index,
+            "flag_torsion_err_max_deg": index * 2,
+        }
+        for index, value in enumerate(passes)
+    ]
+
+
+def _run_dir(tmp_path: Path, passes: list[bool]) -> Path:
+    run_dir = tmp_path / "condition_001"
+    run_dir.mkdir()
+    rows = _step_rows(passes)
+    _write_csv(run_dir / "step_summary.csv", list(rows[0]), rows)
+    return run_dir
+
+
+def test_run_summary_distinguishes_short_fail_recovery_and_missing_body(
+    tmp_path: Path,
+) -> None:
+    run_dir = _run_dir(tmp_path, [True, False, True, False, False, False, True])
+
+    summary = build_run_summary(
+        run_dir,
+        time_manifest={"total_steps": 7, "final_step_summary_t_s": 0.6},
+    )
+
+    assert summary["execution"]["status"] == "completed"
+    gate = summary["gates"]["shape_nonbody"]
+    assert gate["final_pass"] is True
+    assert gate["recovered_after_fail"] is True
+    assert gate["episode_count"] == 2
+    assert gate["episodes"][0]["persistent_observed"] is False
+    assert gate["episodes"][1]["persistent_observed"] is True
+    assert summary["gates"]["shape_body"] == {
+        "status": "unavailable",
+        "reason": "body_constraint_diagnostics.csv is missing or empty",
+    }
+
+
+def test_run_summary_marks_partial_and_handles_body_gate(tmp_path: Path) -> None:
+    run_dir = _run_dir(tmp_path, [True, True])
+    body_rows = [
+        {
+            "step": 0,
+            "t_s": 0.0,
+            "body_spring_max_stretch_ratio": 0.9,
+            "body_bend_max_error_deg": 10.0,
+            "body_centerline_max_deviation_um": 0.1,
+            "body_triangle_area_min": 2.0,
+        },
+        {
+            "step": 1,
+            "t_s": 0.1,
+            "body_spring_max_stretch_ratio": 1.1,
+            "body_bend_max_error_deg": 10.0,
+            "body_centerline_max_deviation_um": 0.1,
+            "body_triangle_area_min": 2.0,
+        },
+    ]
+    _write_csv(
+        run_dir / "body_constraint_diagnostics.csv", list(body_rows[0]), body_rows
+    )
+
+    summary = build_run_summary(
+        run_dir,
+        time_manifest={"total_steps": 3, "final_step_summary_t_s": 0.2},
+    )
+
+    assert summary["execution"]["status"] == "partial"
+    body = summary["gates"]["shape_body"]
+    assert body["final_pass"] is False
+    assert body["episodes"][0]["category_counts"] == {"body_spring": 1}
+
+
+def test_run_summary_caps_episode_storage_and_preserves_file(tmp_path: Path) -> None:
+    passes = [value for _ in range(40) for value in (True, False)]
+    run_dir = _run_dir(tmp_path, passes)
+    source = (run_dir / "step_summary.csv").read_bytes()
+
+    output = write_run_summary(run_dir)
+    summary = json.loads(output.read_text(encoding="utf-8"))
+
+    gate = summary["gates"]["shape_nonbody"]
+    assert gate["episode_count"] == 40
+    assert gate["stored_episode_count"] == 32
+    assert gate["omitted_episode_count"] == 8
+    assert (run_dir / "step_summary.csv").read_bytes() == source
+    assert output.stat().st_size <= MAX_RUN_SUMMARY_BYTES
+    with pytest.raises(FileExistsError):
+        write_run_summary(run_dir)
+
+
+def _load_inspector() -> object:
+    path = Path("scripts/02_phase2_analysis/inspect_step_summary.py")
+    spec = importlib.util.spec_from_file_location("inspect_step_summary", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inspector_returns_only_requested_columns_and_rows(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_dir = _run_dir(tmp_path, [True, False, False, True])
+    write_run_summary(run_dir)
+    inspector = _load_inspector()
+
+    inspector.main(
+        [
+            "--input-dir",
+            str(run_dir),
+            "--gate",
+            "shape_nonbody",
+            "--episode",
+            "1",
+            "--columns",
+            "t_s,shape_pass_nonbody",
+            "--max-rows",
+            "1",
+        ]
+    )
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["returned_row_count"] == 1
+    assert result["truncated"] is True
+    assert list(result["rows"][0]) == ["t_s", "shape_pass_nonbody"]


### PR DESCRIPTION
Closes #181

## 変更内容

- 各 Phase 2 simulation / campaign condition に `run_summary.json` を自動生成
- 既存 output を再 simulation せず集約する CLI を追加
- raw `step_summary.csv` を時間窓・episode・列数・行数で限定抽出する CLI を追加
- `run_summary.json` の schema、出力契約、Codex の読込順序を文書化

## 設計

- 既存の物理 model、gate、閾値、`step_summary.csv` は変更しない
- body diagnostics 欠落は `unavailable`、旧 output の完走根拠不足は `unknown`
- episode は連続 fail 観測として集約し、gate ごとに最大 32 件、JSON 全体は 64 KiB 上限

## 検証

- `uv run pytest -q`
- 関連テスト 133 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

`docs/codex-runs/20260808_214922_phase2_181_run_summary/review_result.json` は PASS です。