### PR TITLE
Add reference torque comparison contract

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -102,7 +102,7 @@ jobs:
             const CODEX_REVIEW_REQUEST =
               /(?:^|\s)@codex\s+review\s+([0-9a-f]{7,40})\b/i;
             const CODEX_REVIEWED_COMMIT =
-              /reviewed\s+commit:\s*`?([0-9a-f]{7,40})`?/i;
+              /\*{0,2}reviewed\s+commit:\*{0,2}\s*`?([0-9a-f]{7,40})`?/i;
             const CODEX_NO_MAJOR_ISSUES =
               /codex\s+review:\s*didn't find any major issues\./i;
 

--- a/conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml
+++ b/conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml
@@ -1,0 +1,50 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: Issue #183: 2010 project tracking-reference scale=2 の hook-first failure 切り分け
+  source_issue: https://github.com/Kenta-morimori/prj-flagella-estimation/issues/183
+  model_notes:
+    - The baseline is the completed 1 s tracking-reference scale=2 run, which first failed in the hook category at 0.0001 s.
+    - Sweep only motor.local_hook_scale; torque, reference torque, torque-scaled material coefficients, seeds, geometry, and dt_star remain fixed.
+    - This is a short diagnostic, not a torque-policy or dataset-adoption candidate.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.duration_s: 0.02
+  time.dt_star: 1.0e-4
+  motor.torque_Nm: 5.0e-20
+  motor.reference_torque_Nm: 5.0e-20
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.enable_switching: false
+  motor.force_distribution: root_torque_segment_couples
+  flagella.initial_helix_axis_from_rear_deg: 0
+  seed.global_seed: 0
+  output_sampling.out_all_steps_3d: false
+
+sweep:
+  axes:
+    hook_scale:
+      key: motor.local_hook_scale
+      short_name: hook
+      values: [1.0, 1.25, 1.5, 2.0]
+      labels: ["1.0", "1.25", "1.5", "2.0"]
+      ids: [hook_1p0, hook_1p25, hook_1p5, hook_2p0]
+
+replay:
+  mode: none
+
+plot:
+  default_x_axis: hook_scale
+  default_y_axis: null
+  metrics:
+    - first_fail_t_s
+    - hook_len_rel_err_max
+    - max_flag_bond_rel_err
+
+output:
+  base_dir: outputs/phase2_reference_torque/2010_project/tracking_reference_same_real_time_motor_scale_2_hook_diagnostic
+  timestamp_subdir: true
+  save_state_archive: false
+  progress_interval: 100

--- a/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
+++ b/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
@@ -7,6 +7,7 @@
     "fixed-reference / tracking-reference と same-real-time / same-dimensionless-time を機械可読な plan に分離した。",
     "2010 project の legacy fixed tau と 2015 project の reference-torque tau を manifest equivalence flag で区別した。",
     "2010 tracking-reference scale=2のhook-first failureを、hook local scaleだけを変える短時間diagnosticへ分離した。",
+    "ユーザー実行のhook-only diagnosticは全4 scaleで最初の観測stepからhook FAILとなり、1 s confirmationを開始しない判断を記録した。",
     "#168 / PR #176 の Stage A output と採択判断は変更していない。"
   ],
   "checks": [
@@ -39,7 +40,7 @@
   "long_simulation_executed": true,
   "long_simulation_reason": "ユーザーが2010 projectのsame-real-time 5条件を実行した。2015の長時間条件は費用対効果により途中停止し、完走済み結果だけを性能目安としてIssue #61へ記録した。",
   "user_visual_review_required": true,
-  "user_visual_review_reason": "#184 の replay / dataset v2 採択時に実施する。",
+  "user_visual_review_reason": "shape PASS後の遊泳安定性評価と#184のreplay / dataset v2採択時に実施する。hook diagnosticは全condition shape FAILのためreplayを作らない。",
   "adr_required": false,
   "adr_reason": "最終 torque / policy の採択を留保した比較契約であり、物理解釈・dataset policy の正式変更ではない。",
   "next_actions": [

--- a/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
+++ b/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
@@ -8,6 +8,7 @@
     "2010 project の legacy fixed tau と 2015 project の reference-torque tau を manifest equivalence flag で区別した。",
     "2010 tracking-reference scale=2のhook-first failureを、hook local scaleだけを変える短時間diagnosticへ分離した。",
     "ユーザー実行のhook-only diagnosticは全4 scaleで最初の観測stepからhook FAILとなり、1 s confirmationを開始しない判断を記録した。",
+    "2010先行screenの定量結果、動画の解釈範囲、比較replayを作成しない理由をcompactな結果記録へ分離した。",
     "#168 / PR #176 の Stage A output と採択判断は変更していない。"
   ],
   "checks": [
@@ -34,6 +35,10 @@
     {
       "command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml --dry-run",
       "result": "PASS: hook_1p0, hook_1p25, hook_1p5, hook_2p0"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS after origin/main rebase conflict resolution"
     }
   ],
   "long_simulation_required": true,

--- a/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
+++ b/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
@@ -6,6 +6,7 @@
   "summary": [
     "fixed-reference / tracking-reference と same-real-time / same-dimensionless-time を機械可読な plan に分離した。",
     "2010 project の legacy fixed tau と 2015 project の reference-torque tau を manifest equivalence flag で区別した。",
+    "2010 tracking-reference scale=2のhook-first failureを、hook local scaleだけを変える短時間diagnosticへ分離した。",
     "#168 / PR #176 の Stage A output と採択判断は変更していない。"
   ],
   "checks": [
@@ -24,11 +25,19 @@
     {
       "command": "git diff --check",
       "result": "PASS"
+    },
+    {
+      "command": "uv run pytest tests/test_reference_torque_comparison.py tests/test_reference_torque_hook_diagnostic_config.py tests/test_phase2_generic_multi_run.py -q",
+      "result": "PASS: 50 passed"
+    },
+    {
+      "command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml --dry-run",
+      "result": "PASS: hook_1p0, hook_1p25, hook_1p5, hook_2p0"
     }
   ],
   "long_simulation_required": true,
-  "long_simulation_executed": false,
-  "long_simulation_reason": "ユーザーが実行する指定のため、config・CLI・評価契約のみを整備した。",
+  "long_simulation_executed": true,
+  "long_simulation_reason": "ユーザーが2010 projectのsame-real-time 5条件を実行した。2015の長時間条件は費用対効果により途中停止し、完走済み結果だけを性能目安としてIssue #61へ記録した。",
   "user_visual_review_required": true,
   "user_visual_review_reason": "#184 の replay / dataset v2 採択時に実施する。",
   "adr_required": false,

--- a/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
+++ b/docs/codex-runs/20260811_issue183_reference_torque_contract/review_result.json
@@ -1,0 +1,40 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #183 reference torque comparison contract",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/183",
+  "branch": "issue-183-reference-torque-comparison",
+  "summary": [
+    "fixed-reference / tracking-reference と same-real-time / same-dimensionless-time を機械可読な plan に分離した。",
+    "2010 project の legacy fixed tau と 2015 project の reference-torque tau を manifest equivalence flag で区別した。",
+    "#168 / PR #176 の Stage A output と採択判断は変更していない。"
+  ],
+  "checks": [
+    {
+      "command": "uv run pytest tests/test_reference_torque_comparison.py tests/test_params.py -q",
+      "result": "PASS: 93 passed"
+    },
+    {
+      "command": "uv run ruff check src/sim_swim/analysis/reference_torque_comparison.py scripts/01_simulate_swimming/plan_reference_torque_comparison.py tests/test_reference_torque_comparison.py",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run python scripts/01_simulate_swimming/plan_reference_torque_comparison.py --config conf/phase2_reference_torque/2015_project.yaml --output /private/tmp/issue183-plan/plan.json",
+      "result": "PASS: 12 conditions, including effective torque/time/equivalence fields and execution commands"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ],
+  "long_simulation_required": true,
+  "long_simulation_executed": false,
+  "long_simulation_reason": "ユーザーが実行する指定のため、config・CLI・評価契約のみを整備した。",
+  "user_visual_review_required": true,
+  "user_visual_review_reason": "#184 の replay / dataset v2 採択時に実施する。",
+  "adr_required": false,
+  "adr_reason": "最終 torque / policy の採択を留保した比較契約であり、物理解釈・dataset policy の正式変更ではない。",
+  "next_actions": [
+    "#61 は same-real-time 条件で dt_star の数値妥当性と performance を評価する。",
+    "#184 は #61 で許容された dt_star とこの比較契約を入力に torque x n_flagella の replay / heatmap を実行する。"
+  ]
+}

--- a/docs/codex-runs/20260813_issue183_gate_markdown_review/review_result.json
+++ b/docs/codex-runs/20260813_issue183_gate_markdown_review/review_result.json
@@ -1,0 +1,31 @@
+{
+  "status": "PASS",
+  "task": "Accept Markdown-formatted Codex reviewed-commit comment in the merge gate",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/183",
+  "source_pr": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/185",
+  "summary": [
+    "codex-review-gate が、Cloud connectorの標準コメント形式 **Reviewed commit:** `SHA` を、従来の素の Reviewed commit: `SHA` と同じSHA照合対象として受理するようにした。",
+    "allowlisted login、review request、PR内commit、応答時刻、未解決trusted threadの既存検証は変更していない。"
+  ],
+  "checks": [
+    {
+      "command": "node -e '<regex assertions>'",
+      "result": "PASS: raw and Markdown-bold Reviewed commit forms match their SHA; an unrelated string does not match."
+    },
+    {
+      "command": "uv run python -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path(\".github/workflows/codex-review-gate.yml\").read_text())'",
+      "result": "PASS: workflow YAML parses."
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ],
+  "long_simulation_required": false,
+  "user_visual_review_required": false,
+  "adr_required": false,
+  "adr_reason": "既存のCodex review comment受理方針を、connectorの実際のMarkdown表記へ適合させるparser bug fixである。",
+  "next_actions": [
+    "PR #185 のCIとcodex-review-gateを再確認する。"
+  ]
+}

--- a/docs/phase2/phase2_183_reference_torque_2010_screen_results.md
+++ b/docs/phase2/phase2_183_reference_torque_2010_screen_results.md
@@ -1,0 +1,40 @@
+# Phase 2 Issue #183: 2010 reference torque 先行screen結果
+
+## 目的と範囲
+
+これはreference torqueを採択するための結果ではない。[比較契約](phase2_183_reference_torque_comparison_contract.md)とADR 0016に従い、#61 が比較条件を固定して `dt_star` と実行性能を評価し、#184 が候補を検証する前の、2010 projectにおける短い安全性screenである。2010 projectは `tau_s=1 s` 固定のため、`tracking-reference` は物性scale連動を確認する条件であって時間相似の主張ではない。
+
+全runは `same-real-time=1 s`、`dt_star=1e-4`、10,000 steps、default seedで実行した。確認には各runの `sim/run_summary.json` を用い、巨大な `step_summary.csv` は読み込んでいない。body gateは全runでunavailableである。
+
+## 定量結果
+
+| policy | motor scale | finite | non-body shape | 最初のFAIL [s] | hook最大相対誤差 | flag bond最大相対誤差 | compact evidence |
+| --- | ---: | --- | --- | ---: | ---: | ---: | --- |
+| fixed-reference | 0.5 | PASS | FAIL | 0.9918 | 25.60 | 18.22 | `.../fixed_reference_same_real_time_motor_scale_0.5/2026-08-11/125458/sim/run_summary.json` |
+| fixed-reference | 1.0 | PASS | PASS | - | 0.0912 | 0.0949 | `.../fixed_reference_same_real_time_motor_scale_1/2026-08-11/130553/sim/run_summary.json` |
+| fixed-reference | 2.0 | PASS | FAIL | 0.2698 | 32.81 | 25.61 | `.../fixed_reference_same_real_time_motor_scale_2/2026-08-11/131650/sim/run_summary.json` |
+| tracking-reference | 0.5 | PASS | PASS | - | 0.0779 | 0.0756 | `.../tracking_reference_same_real_time_motor_scale_0.5/2026-08-11/132750/sim/run_summary.json` |
+| tracking-reference | 2.0 | PASS | FAIL | 0.0001 | 43.70 | 20.15 | `.../tracking_reference_same_real_time_motor_scale_2/2026-08-11/133847/sim/run_summary.json` |
+
+`tracking-reference` scale 1.0は、fixed-reference scale 1.0と数値条件が同一であるため、重複実行していない。
+
+fixed-reference scale 0.5は、0.9918 sでflagが4 step続けてFAILし、その後0.9999 sまでhook FAILが78 step継続した。従って、renderで0.96–1.00 sに見える形状崩壊は、定量gate上は最後の8.1 msのpersistent failureである。有限値PASSは形状・遊泳安定性PASSを意味しない。
+
+## hook-only diagnostic
+
+tracking-reference scale 2.0のfailureをhookだけで改善できるかを調べるため、`local_hook_scale` だけを `1.0 / 1.25 / 1.5 / 2.0` に変えた0.02 s（200 step）の診断を行った。入力configは `conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml`、集計は `outputs/phase2_reference_torque/2010_project/tracking_reference_same_real_time_motor_scale_2_hook_diagnostic/2026-08-12/223908/summary.csv` である。
+
+| local hook scale | non-body shape | 最初のFAIL [s] | hook最大相対誤差 | flag bond最大相対誤差 |
+| ---: | --- | ---: | ---: | ---: |
+| 1.0 | FAIL | 0.0001 | 43.70 | 11.87 |
+| 1.25 | FAIL | 0.0001 | 51.51 | 14.23 |
+| 1.5 | FAIL | 0.0001 | 46.48 | 8.34 |
+| 2.0 | FAIL | 0.0001 | 49.57 | 12.43 |
+
+全条件が最初の観測stepからhook FAILであり、局所hook scale単独ではこの条件を安全な候補へ戻せなかった。そのため、この組合せの1 s confirmationは開始しない。
+
+## 定性確認と次の比較
+
+既存の `fixed_reference_same_real_time_motor_scale_0.5/.../render/swim3d.mp4` はfailure時刻の視覚的な補助証拠として保持する。ただし、FAIL条件の動画を並べた比較replayは、policy優劣・遊泳品質・採択を示すものではないため、このIssueでは作成しない。
+
+次に比較replayを作るのは、body gateもPASSした候補に限る。その際は同一camera、同一frame rate、同一実時間窓、同一seedを固定し、動画とともにspeed、body roll、axis-center rotation、形状gateの時系列を提示する。現時点でnon-body shapeがPASSしたのはfixed 1.0とtracking 0.5のみであり、遊泳安定性・reference torqueの採択については結論を出さない。

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -78,6 +78,8 @@ manifestの `time.paper_notation` はこの表記を正本の表示層として�
 
 `tracking-reference` scale=1はfixed-reference scale=1と完全に同一のため実行しなかった。2010 projectは`tau_s=1 s`固定なので、この結果は物性scale連動の先行screenであり、reference torqueに時間scaleも連動する2015相似条件のruntime検証ではない。body diagnosticsは当該runでunavailableであり、body PASSを主張しない。これらの結果はtorque / policyの採択根拠ではない。
 
+各runのcompact evidence、hook-only diagnostic、視覚比較を作らない理由は [2010先行screen結果](phase2_183_reference_torque_2010_screen_results.md) に記録する。
+
 ### hook-only diagnostic 結果（2026-08-12）
 
 run root `outputs/phase2_reference_torque/2010_project/tracking_reference_same_real_time_motor_scale_2_hook_diagnostic/2026-08-12/223908`で、`tracking-reference` scale=2の`local_hook_scale`だけを`1.0 / 1.25 / 1.5 / 2.0`に変えた。各conditionは`0.02 s`、200 stepsで完走し、finiteはPASSした。しかし全条件が`0.0001 s`（最初の観測step）からhook categoryでFAILした。

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -78,6 +78,30 @@ manifestの `time.paper_notation` はこの表記を正本の表示層として�
 
 `tracking-reference` scale=1はfixed-reference scale=1と完全に同一のため実行しなかった。2010 projectは`tau_s=1 s`固定なので、この結果は物性scale連動の先行screenであり、reference torqueに時間scaleも連動する2015相似条件のruntime検証ではない。body diagnosticsは当該runでunavailableであり、body PASSを主張しない。これらの結果はtorque / policyの採択根拠ではない。
 
+### hook-only diagnostic 結果（2026-08-12）
+
+run root `outputs/phase2_reference_torque/2010_project/tracking_reference_same_real_time_motor_scale_2_hook_diagnostic/2026-08-12/223908`で、`tracking-reference` scale=2の`local_hook_scale`だけを`1.0 / 1.25 / 1.5 / 2.0`に変えた。各conditionは`0.02 s`、200 stepsで完走し、finiteはPASSした。しかし全条件が`0.0001 s`（最初の観測step）からhook categoryでFAILした。
+
+| `local_hook_scale` | non-body shape | first observed failure | max hook relative error |
+| ---: | --- | ---: | ---: |
+| 1.0 | FAIL | `0.0001 s` | 43.70 |
+| 1.25 | FAIL | `0.0001 s` | 51.51 |
+| 1.5 | FAIL | `0.0001 s` | 46.48 |
+| 2.0 | FAIL | `0.0001 s` | 49.57 |
+
+この結果は、現行`tracking-reference` scale=2の初期hook failureを`local_hook_scale`を上げるだけでは救えないことを示す。1秒runは開始しない。次にspring/bend/torsionを追加して変更する前に、このhigh-torque tracking条件を候補から外すか、初期force / hook geometry / motor applicationを別Issueで原因切り分けするかを判断する。複数のlocal scaleを同時に上げて採択候補へ寄せることは、このIssueの比較契約の範囲外とする。
+
+## 遊泳安定性とPR merge条件
+
+shape stabilityと遊泳安定性は別のgateである。shape PASSは、遊泳速度、body roll、flagellum spin、helix-axisのbody相対回転、進行方向の一貫性を保証しない。遊泳安定性は、shape / body diagnosticsが利用可能で全期間PASSした条件にだけ、同一実時間のtrajectory・replayを用いて評価する。shape FAIL conditionを遊泳採択へ進めない。
+
+PR #185のmerge対象は最終torque採択ではなく、比較契約・plan CLI・diagnostic config・実行済みscreenの記録である。mergeには次を満たす。
+
+1. config / manifestがfixed/trackingと二つの時間基準を区別し、対象テストとdry-runがPASSすること。
+2. 2010先行screenとhook-only diagnosticの結果・限界・未実施2015条件を文書化すること。
+3. `review_result.json`がPASSであり、PR checksと`codex-review-gate`がPASSすること。
+4. 2015の長時間run、遊泳安定性の最終評価、torque / policy / dataset v2の採択をmerge前提にしないこと。これらは#61/#184および後続Issue / ADRの責務とする。
+
 ## ユーザー実行
 
 まず plan を作る。これは simulation を起動しない。

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -20,6 +20,68 @@ manifestの `time.paper_notation` はこの表記を正本の表示層として�
 
 ## 実行準備（simulationは起動しない）
 
+各 policy はさらに別々に、`same-real-time`（`time.duration.unit=s`）と `same-dimensionless-time`（`unit=tau`）を実行する。前者だけが #61 の計算効率、wall time、steps/s の主比較である。後者は無次元軌道・離散化の補助比較であり、実時間効率の根拠にしてはならない。
+
+2010 project は `legacy_fixed_tau_s_1` のため、tracking-reference でも `tau_s` は変わらない。これは物性連動を検査する比較であり、2015 のような時間相似を主張できない。plan manifest の `tau_tracks_reference_torque=false` を必ず確認する。
+
+## Config / manifest 契約
+
+入力 config は [2010 project](../../conf/phase2_reference_torque/2010_project.yaml)、[2015 project](../../conf/phase2_reference_torque/2015_project.yaml) である。plan CLI は condition ごとに以下を `campaign_plan.json` へ固定する。
+
+- `comparison_policy`, `time_basis`, `motor_torque_scale`
+- 有効な `motor_torque_Nm`, `reference_torque_Nm`, `torque_for_forces_Nm`
+- `time`（`duration_s`, `duration_tau`, `tau_s`, `dt_internal_s`, `total_steps` を含む）
+- 同等性 flags と実行用 `execution_command`
+
+各 simulation output は従来どおり `manifest.json` と `sim/run_summary.json` を必須とし、campaign の集計は `summary.csv` にする。通常確認で巨大な `step_summary.csv` を直接読まない。必要時だけ bounded inspection を使う。
+
+## 評価指標と受入条件
+
+各 condition は #168 と同じ基本 safety（例外なし、finite、body/non-body shape gate、motor action-reaction diagnostics）を満たすこと。さらに #61 は同一実時間の `total_steps`、`dt_internal_s`、wall time、steps/s、final/trajectory の数値差を比較する。#184 は #61 が許容した `dt_star` だけを用い、torque × `n_flagella` の safety、replay、heatmap、dataset v2 の採択判断を行う。
+
+この Issue の受入条件は次である。
+
+1. fixed / tracking と実時間 / 無次元時間を manifest 上で機械的に区別できる。
+2. 同一実時間の比較で物性・seed・geometry・`dt_star` 以外を揃え、差分を明記する。
+3. #61 / #184 は policy 間の軌道差を「数値誤差」や「同一物理系の改善」と解釈しない。
+4. Stage A output を再計算・書換え・採択根拠への昇格をしない。
+
+## scale の関係と hook-first diagnostic
+
+`motor_torque_scale` は基準 `reference_torque_Nm` に掛ける倍率である。例えば2010 projectの基準`2.5e-20 N m`では、`0.5 / 1 / 2`は`1.25e-20 / 2.5e-20 / 5.0e-20 N m`を表す。
+
+物性の全体基準は `torque_for_forces_Nm` で、実装上は次を比例させる。
+
+| quantity | base relation |
+| --- | --- |
+| spring coefficient `H` | `H_over_T_over_b * torque_for_forces_Nm / b` |
+| flag/body bend coefficient | `kb_over_T * torque_for_forces_Nm` |
+| torsion coefficient | `kt_over_T * torque_for_forces_Nm` |
+| hook bend coefficient | `hook.kb_over_T * torque_for_forces_Nm` |
+| segment repulsion amplitude | `A_ss_over_T * torque_for_forces_Nm` |
+
+従って`fixed-reference`はこれらを固定し、`tracking-reference`はreference torqueとともに全体を比例させる。`motor.local_hook_scale`はこの全体scaleとは別で、motor-on時にhook forceだけへ掛かる局所倍率である。`local_spring_scale` / `local_bend_scale` / `local_torsion_scale`も全体ではなく根元近傍の対応する項だけに掛かる。
+
+2010 tracking-reference scale=2ではhookが最初にFAILしたため、次の短時間diagnosticを用意する。[hook diagnostic config](../../conf/phase2_multi_run/reference_torque_2010_tracking_scale2_hook_diagnostic.yaml)は`local_hook_scale=1,1.25,1.5,2`だけを変え、その他を固定する。hook PASSだけでは候補とせず、flag bond/bend/torsionを含むshape gateが全期間PASSした場合だけ、次段階の同一`1 s`確認へ進める。hook scaleでflag failureが現れる、または短時間PASSでも1 sでFAILする場合は、hook単独解決とは扱わない。
+
+### 2010 project の先行実行結果（2026-08-11）
+
+`same-real-time=1 s`、`dt_star=1e-4`、10,000 steps、default seedの5条件をユーザーが実行した。有限値は全条件PASSしたが、non-body shapeは次のとおりであった。
+
+| policy | torque scale | shape result | first observed failure |
+| --- | ---: | --- | --- |
+| fixed-reference | 0.5 | FAIL | `0.9918 s`、flag先行後にhook |
+| fixed-reference | 1.0 | PASS | - |
+| fixed-reference | 2.0 | FAIL | `0.2698 s`、flag/hook |
+| tracking-reference | 0.5 | PASS | - |
+| tracking-reference | 2.0 | FAIL | `0.0001 s`、hook |
+
+`tracking-reference` scale=1はfixed-reference scale=1と完全に同一のため実行しなかった。2010 projectは`tau_s=1 s`固定なので、この結果は物性scale連動の先行screenであり、reference torqueに時間scaleも連動する2015相似条件のruntime検証ではない。body diagnosticsは当該runでunavailableであり、body PASSを主張しない。これらの結果はtorque / policyの採択根拠ではない。
+
+## ユーザー実行
+
+まず plan を作る。これは simulation を起動しない。
+
 ```bash
 uv run python scripts/01_simulate_swimming/plan_reference_torque_comparison.py \
   --config conf/phase2_reference_torque/2015_project.yaml \

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -47,7 +47,7 @@ torque × `dt_star` replay gridを完了した。これは短時間の形状・�
 ## Next queue
 
 1. **Issue #61:** 2010 / 2015 projectを対象に、トルク・力学量・実時間から`dt_star`の有効範囲を定量的に説明する．
-2. **Issue #183:** fixed / tracking reference と同一実時間 / 無次元時間を分離した比較policyを ADR 0016 に固定した。torque・`dt_star`・dataset v2 の採択は #61・#184 の結果後とする（`phase2_183_reference_torque_comparison_contract.md`）。
+2. **Issue #183:** fixed / tracking reference と同一実時間 / 無次元時間を分離した比較policyを ADR 0016 に固定し、2010先行screenとhook-only diagnosticを比較契約へ記録した。torque・`dt_star`・dataset v2 の採択は #61・#184 の結果後とする（`phase2_183_reference_torque_comparison_contract.md`）。
 3. **Issue #184:** dataset v2採択前に、torque・`dt_star`・べん毛数の安定性と計算効率を検証する．
 
 ## Current blockers

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -47,7 +47,7 @@ torque × `dt_star` replay gridを完了した。これは短時間の形状・�
 ## Next queue
 
 1. **Issue #61:** 2010 / 2015 projectを対象に、トルク・力学量・実時間から`dt_star`の有効範囲を定量的に説明する．
-2. **Issue #183:** fixed / tracking reference と同一実時間 / 無次元時間を分離した比較policyを ADR 0016 に固定し、2010先行screenとhook-only diagnosticを比較契約へ記録した。torque・`dt_star`・dataset v2 の採択は #61・#184 の結果後とする（`phase2_183_reference_torque_comparison_contract.md`）。
+2. **Issue #183:** fixed / tracking reference と同一実時間 / 無次元時間を分離した比較policyを ADR 0016 に固定し、2010先行screenとhook-only diagnosticを比較契約・結果記録へ残した。torque・`dt_star`・dataset v2 の採択は #61・#184 の結果後とする（`phase2_183_reference_torque_comparison_contract.md`）。
 3. **Issue #184:** dataset v2採択前に、torque・`dt_star`・べん毛数の安定性と計算効率を検証する．
 
 ## Current blockers

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -249,7 +249,6 @@ Issue単位の進捗台帳，branch一覧，acceptance criteria一覧，実行co
 - **Decision:** `fixed-reference` は物性を固定した駆動torque感度、`tracking-reference` はreference torqueと物性を同時に連動させる相似候補として分離する。さらに `same-real-time` と `same-dimensionless-time` を直交して記録し、#61の`dt_star`・計算効率比較は fixed-reference / same-real-time 内に限定する。
 - **Interpretation:** 2010 projectは `tau_s=1` legacy policyのためtrackingを時間相似と呼ばない。#184は #61 が許容した`dt_star`とper-flag torque policyを使い、dataset v2・0.5秒run・2015 supported採択はこのDecisionから導かない。
 - **Evidence:** Issue #183，ADR 0016，`docs/phase2/phase2_183_reference_torque_comparison_contract.md`，`conf/phase2_reference_torque/*.yaml`．
-
 ### P2-D19: 大量step runはcompact output policyを明示選択する
 
 - **Decision:** 既存短時間 workflow は `output.policy: debug` の全step state/CSV 互換を維持する。長時間候補は `compact` を明示し、全内部step QC をオンライン集約しながら state archive を物理時間一様に保存する。標準 cadence は 1 ms とする。compact archive は replay/通常解析用であり、未定義の全step将来指標の完全再構成を保証しない。

--- a/tests/test_reference_torque_hook_diagnostic_config.py
+++ b/tests/test_reference_torque_hook_diagnostic_config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sim_swim.analysis.multi_run_campaign import (
+    build_campaign_conditions,
+    load_yaml,
+    normalize_campaign_config,
+)
+from sim_swim.sim.params import SimulationConfig
+
+
+def test_hook_diagnostic_changes_only_local_hook_scale() -> None:
+    config = normalize_campaign_config(
+        load_yaml(
+            Path(
+                "conf/phase2_multi_run/"
+                "reference_torque_2010_tracking_scale2_hook_diagnostic.yaml"
+            )
+        )
+    )
+    conditions = build_campaign_conditions(config)
+
+    assert [row["axis_values"]["hook_scale"] for row in conditions] == [
+        1.0,
+        1.25,
+        1.5,
+        2.0,
+    ]
+    for condition in conditions:
+        cfg = SimulationConfig.from_dict(
+            load_yaml(Path(config["base_config"]))
+        ).with_overrides(condition["config_overrides"])
+        assert cfg.motor_torque_Nm == 5.0e-20
+        assert cfg.reference_torque_Nm == 5.0e-20
+        assert cfg.torque_for_forces_Nm == 5.0e-20
+        assert cfg.time.duration_s == 0.02
+        assert cfg.dt_star == 1.0e-4


### PR DESCRIPTION
## Summary

- Add a machine-readable reference-torque comparison plan for 2010 and 2015 project profiles.
- Separate fixed-reference / tracking-reference and same-real-time / same-dimensionless-time conditions.
- Document handoff rules, metrics, and interpretation prohibitions for #61 and #184.

## Scope

This PR does not select a reference torque, policy, dataset v2 candidate, or 2015 supported status. It does not modify #168 / PR #176 Stage A outputs.

Closes #183

## Validation

- `uv run pytest tests/test_reference_torque_comparison.py tests/test_params.py -q` (93 passed)
- pre-commit lightweight suite (286 passed, 271 deselected)
- Ruff check / format check and 2010/2015 plan CLI smoke tests

## Long runs

Long simulations, sweeps, and renders are intentionally user-executed. The PR provides configs, generated execution commands, and a PASS `review_result.json`.
