### PR TITLE
Add reference torque comparison policy

### DIFF
--- a/conf/phase2_reference_torque/2010_project.yaml
+++ b/conf/phase2_reference_torque/2010_project.yaml
@@ -1,0 +1,9 @@
+base_config: conf/sim_swim_2010.yaml
+reference_torque_Nm: 2.5e-20
+output_base_dir: outputs/phase2_reference_torque/2010_project
+policies: [fixed-reference, tracking-reference]
+time_bases: [same-real-time, same-dimensionless-time]
+motor_torque_scales: [0.5, 1.0, 2.0]
+durations:
+  same_real_time_s: 1.0
+  same_dimensionless_tau: 1.0

--- a/conf/phase2_reference_torque/2015_project.yaml
+++ b/conf/phase2_reference_torque/2015_project.yaml
@@ -1,0 +1,9 @@
+base_config: conf/sim_swim_2015.yaml
+reference_torque_Nm: 1.2e-18
+output_base_dir: outputs/phase2_reference_torque/2015_project
+policies: [fixed-reference, tracking-reference]
+time_bases: [same-real-time, same-dimensionless-time]
+motor_torque_scales: [0.5, 1.0, 2.0]
+durations:
+  same_real_time_s: 0.001
+  same_dimensionless_tau: 1.0

--- a/docs/adr/0012_phase2_time_schema_profiles.md
+++ b/docs/adr/0012_phase2_time_schema_profiles.md
@@ -69,6 +69,18 @@ final state time:
 
 ## Manifest
 
+user-facing logとmanifestの論文表記は、次を優先する。
+
+```text
+t       実時間 [s]
+τ       時間尺度 [s]
+Δt      実時間の積分刻み [s]
+t/τ     無次元時刻 [-]
+Δt/τ    無次元積分刻み [-]
+```
+
+machine-readable manifestでは `time.paper_notation` にASCII keyの `t`、`tau`、`delta_t`、`t_over_tau`、`delta_t_over_tau` を保存する。`t_star`、`dt_star`、`duration_tau`、`tau_s`、`dt_internal_s` は既存分析・runとの互換keyとして維持する。`dt`単独は、実時間刻みと無次元刻みを区別できないため、user-facing log・文書では使用しない。
+
 single-run manifest と generic multi-run `run_manifest.json` には、正規化済み時間量として次を保存する。
 
 ```text

--- a/docs/adr/0016_phase2_reference_torque_comparison_policy.md
+++ b/docs/adr/0016_phase2_reference_torque_comparison_policy.md
@@ -10,6 +10,8 @@
 
 従って reference torque を motor torque に追従させると、単に `tau_s = eta*b^3/abs(T_ref)` と `dt_s = dt_star*tau_s` が変わるだけではない。spring `H`、bend/torsion/hook stiffness、spring-spring repulsion `A` も `torque_for_forces_Nm` に比例して変わる。実際の係数は run manifest の `time.material_coefficients` に保存する。
 
+時間は論文表記を優先して、`t`（実時間[s]）、`τ` / `tau`（時間尺度[s]）、`Δt` / `delta_t`（実時間の積分刻み[s]）としてlogと `time.paper_notation` に保存する。無次元量は説明・互換用に `t/τ` / `t_over_tau` と `Δt/τ` / `delta_t_over_tau` として併記し、`t_star` と `dt_star` は内部実装・既存I/O互換の別名に留める。JSON keyはASCIIの `tau`、`delta_t` を使う。
+
 ## Decision
 
 torque sweep は次の二つを別 campaign として扱う。

--- a/docs/adr/0016_phase2_reference_torque_comparison_policy.md
+++ b/docs/adr/0016_phase2_reference_torque_comparison_policy.md
@@ -1,0 +1,37 @@
+# ADR 0016: Phase 2 reference torque 比較 policy
+
+* Status: Accepted
+* Date: 2026-08-12
+* Issues: #183, #61, #184, #157
+
+## Context
+
+2010 / 2015 project modelでは、`motor.torque_Nm`（各flagellar motorへ与える符号付き駆動）と、`motor.reference_torque_Nm`（`tau_s` と無次元物性係数の基準）が別の責務を持つ。`torque_for_forces_Nm` は、明示的な `motor.torque_for_forces_override_Nm > 0` があればそれを、なければ reference torque の絶対値を使う。
+
+従って reference torque を motor torque に追従させると、単に `tau_s = eta*b^3/abs(T_ref)` と `dt_s = dt_star*tau_s` が変わるだけではない。spring `H`、bend/torsion/hook stiffness、spring-spring repulsion `A` も `torque_for_forces_Nm` に比例して変わる。実際の係数は run manifest の `time.material_coefficients` に保存する。
+
+## Decision
+
+torque sweep は次の二つを別 campaign として扱う。
+
+| policy | `motor.torque_Nm` | reference / force scale | 比較目的 |
+| --- | --- | --- | --- |
+| `fixed-reference` | scaleごとに変更 | 基準 `T_ref,0` に固定。force overrideも `T_ref,0` | 同一物性における駆動 torque 感度 |
+| `tracking-reference` | scaleごとに変更 | `abs(motor torque)` に連動。force override は0 | 無次元化に沿った相似候補（時間・物性の同時変更） |
+
+各 policy を `same-real-time` と `same-dimensionless-time` に直交させる。#61 の `dt_star` 比較と性能主張は、同一 seed、geometry、物性、per-flag torque policy、duration **を固定した `fixed-reference` / `same-real-time`** 内でのみ行う。`same-dimensionless-time` は無次元軌道を比べる補助比較であり、実時間計算効率を主張しない。
+
+2010 project は `legacy_fixed_tau_s_1` の互換 policy のため、tracking-referenceでも `tau_s=1 s` のままである。物性連動は検査対象だが、2015のような時間相似を主張しない。
+
+## Consequences
+
+* plan config と `campaign_plan.json` は `comparison_policy`、`time_basis`、3種類の torque、`tau_s`、`dt_star`、`dt_internal_s`、`total_steps`、物性係数を保存する。
+* #184 は #61 が選んだ `dt_star` を使用し、per-flag torqueを canonicalに保つ。fixed-total-torqueは診断に限る。
+* #157 に渡すのはこの比較 contract であり、dataset v2、0.5秒run、2015 supported status の採択ではない。
+* #168 / PR #176 Stage A outputs は reference `1.2e-18 N m` 固定の `fixed-reference` 記録として保持し、再実行・遡及解釈しない。
+
+## Evidence
+
+* ADR 0012（time schema と profile別 `tau_s`）
+* `conf/phase2_reference_torque/`
+* `tests/test_reference_torque_comparison.py`

--- a/docs/codex-runs/20260812_issue183_reference_torque_policy/review_result.json
+++ b/docs/codex-runs/20260812_issue183_reference_torque_policy/review_result.json
@@ -1,0 +1,38 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #183 reference torque comparison policy",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/183",
+  "summary": [
+    "fixed-reference / tracking-reference と same-real-time / same-dimensionless-time を、configとcampaign planで機械可読に分離した。",
+    "manifestにmotor/reference/force-scale torque、source、物性係数を保存し、tracking時の物性連動をengine-level unit testで固定した。",
+    "ADR 0016に#61・#184・#157への採用済みpolicyと未決事項を記録し、0.5秒run、dataset v2、2015 supported昇格は行っていない。"
+  ],
+  "checks": [
+    {
+      "command": "uv run ruff check src/sim_swim/analysis/reference_torque_comparison.py scripts/01_simulate_swimming/plan_reference_torque_comparison.py tests/test_reference_torque_comparison.py src/sim_swim/sim/params.py",
+      "result": "PASS"
+    },
+    {
+      "command": "uv run pytest tests/test_reference_torque_comparison.py tests/test_params.py -q",
+      "result": "PASS: 94 passed"
+    },
+    {
+      "command": "plan_reference_torque_comparison.py for 2010_project.yaml and 2015_project.yaml",
+      "result": "PASS: 12 conditions per profile; simulation was not started"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ],
+  "long_simulation_executed": false,
+  "long_simulation_reason": "Issue #186の0.5秒compact campaignを含め、長時間simulation / sweep / trainingはユーザー指定により実行していない。",
+  "user_review_required": false,
+  "adr_required": true,
+  "adr": "docs/adr/0016_phase2_reference_torque_comparison_policy.md",
+  "next_actions": [
+    "#61: fixed-reference / same-real-time 内でdt_starの数値妥当性と性能を評価する。",
+    "#184: #61で許容されたdt_starだけでper-flag torque x n_flagella screenを行う。",
+    "#157: 0.5秒run・dataset v2・2015 supported statusは上記結果後に別途採択する。"
+  ]
+}

--- a/docs/codex-runs/20260812_issue183_reference_torque_policy/review_result.json
+++ b/docs/codex-runs/20260812_issue183_reference_torque_policy/review_result.json
@@ -5,7 +5,7 @@
   "summary": [
     "fixed-reference / tracking-reference と same-real-time / same-dimensionless-time を、configとcampaign planで機械可読に分離した。",
     "manifestにmotor/reference/force-scale torque、source、物性係数を保存し、tracking時の物性連動をengine-level unit testで固定した。",
-    "ADR 0016に#61・#184・#157への採用済みpolicyと未決事項を記録し、0.5秒run、dataset v2、2015 supported昇格は行っていない。"
+    "ADR 0016に#61・#184・#157への採用済みpolicyと未決事項を記録し、論文表記のt・τ・Δtをlogとmanifestの表示層へ追加した。0.5秒run、dataset v2、2015 supported昇格は行っていない。"
   ],
   "checks": [
     {
@@ -13,12 +13,12 @@
       "result": "PASS"
     },
     {
-      "command": "uv run pytest tests/test_reference_torque_comparison.py tests/test_params.py -q",
-      "result": "PASS: 94 passed"
+      "command": ".venv/bin/pytest tests/test_reference_torque_comparison.py tests/test_params.py tests/test_e2e_cli.py -q",
+      "result": "PASS: 95 passed"
     },
     {
       "command": "plan_reference_torque_comparison.py for 2010_project.yaml and 2015_project.yaml",
-      "result": "PASS: 12 conditions per profile; simulation was not started"
+      "result": "PASS: 12 conditions per profile; time.paper_notation is present; simulation was not started"
     },
     {
       "command": "git diff --check",

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -1,0 +1,19 @@
+# Phase 2 Issue #183: reference torque 比較契約
+
+この契約は #61 と #184 の入力であり、torque・`dt_star`・dataset v2・2015 profile supported statusを採択しない。正式な比較policyは [ADR 0016](../adr/0016_phase2_reference_torque_comparison_policy.md) を正本とする。
+
+`motor.torque_Nm` は各flagellar motorの駆動、`motor.reference_torque_Nm` は時間・物性の参照、`torque_for_forces_Nm` は実際の物性係数scaleである。force overrideがなければ後者はreference torqueの絶対値になる。manifestの `time.material_coefficients` は spring `H`、bend/torsion/hook stiffness、repulsion `A` の実効基準係数を保存する。
+
+`fixed-reference` と `tracking-reference`、`same-real-time` と `same-dimensionless-time` は必ず別 condition とする。前者は同一物性での駆動感度、後者は時間と物性を連動させた相似候補である。同一無次元時間を、同一実時間でのstep数・wall time・計算効率の比較に使わない。
+
+2010 projectは `tau_s=1 s` 固定であり、tracking-referenceは時間相似でない。2015 projectは `tau_s=eta*b^3/abs(reference_torque_Nm)` である。#61 の `dt_star` 評価は `fixed-reference` / `same-real-time` に限定して、seed・geometry・物性・per-flag torque policyを固定する。
+
+## 実行準備（simulationは起動しない）
+
+```bash
+uv run python scripts/01_simulate_swimming/plan_reference_torque_comparison.py \
+  --config conf/phase2_reference_torque/2015_project.yaml \
+  --output /private/tmp/issue183-2015-plan.json
+```
+
+生成planの各conditionは、effective torque、time manifest、物性係数、実行commandを含む。0.5秒run、dataset採択、2015 supported昇格はこのIssueの範囲外である。

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -4,6 +4,16 @@
 
 `motor.torque_Nm` は各flagellar motorの駆動、`motor.reference_torque_Nm` は時間・物性の参照、`torque_for_forces_Nm` は実際の物性係数scaleである。force overrideがなければ後者はreference torqueの絶対値になる。manifestの `time.material_coefficients` は spring `H`、bend/torsion/hook stiffness、repulsion `A` の実効基準係数を保存する。
 
+時間のuser-facing表記は論文に合わせる。`t` は実時間[s]、`τ` は時間尺度[s]、`Δt` は実時間の積分刻み[s]であり、次が成り立つ。
+
+```text
+t / τ = t_star
+Δt / τ = dt_star
+Δt = dt_star * τ
+```
+
+manifestの `time.paper_notation` はこの表記を正本の表示層として保存する。JSON keyはASCIIで、`t`、`tau`、`delta_t`、`t_over_tau`、`delta_t_over_tau` とする。既存の `tau_s`、`duration_tau`、`dt_star`、`dt_internal_s` は、既存runと解析コードとの互換のため残す。
+
 `fixed-reference` と `tracking-reference`、`same-real-time` と `same-dimensionless-time` は必ず別 condition とする。前者は同一物性での駆動感度、後者は時間と物性を連動させた相似候補である。同一無次元時間を、同一実時間でのstep数・wall time・計算効率の比較に使わない。
 
 2010 projectは `tau_s=1 s` 固定であり、tracking-referenceは時間相似でない。2015 projectは `tau_s=eta*b^3/abs(reference_torque_Nm)` である。#61 の `dt_star` 評価は `fixed-reference` / `same-real-time` に限定して、seed・geometry・物性・per-flag torque policyを固定する。

--- a/docs/phase2/phase2_current.md
+++ b/docs/phase2/phase2_current.md
@@ -47,7 +47,7 @@ torque × `dt_star` replay gridを完了した。これは短時間の形状・�
 ## Next queue
 
 1. **Issue #61:** 2010 / 2015 projectを対象に、トルク・力学量・実時間から`dt_star`の有効範囲を定量的に説明する．
-2. **Issue #183:** reference torqueを変えたときの同一実時間比較と時間換算policyを確定する．
+2. **Issue #183:** fixed / tracking reference と同一実時間 / 無次元時間を分離した比較policyを ADR 0016 に固定した。torque・`dt_star`・dataset v2 の採択は #61・#184 の結果後とする（`phase2_183_reference_torque_comparison_contract.md`）。
 3. **Issue #184:** dataset v2採択前に、torque・`dt_star`・べん毛数の安定性と計算効率を検証する．
 
 ## Current blockers

--- a/docs/phase2/phase2_tasks.md
+++ b/docs/phase2/phase2_tasks.md
@@ -35,6 +35,7 @@ Issue単位の進捗台帳，branch一覧，acceptance criteria一覧，実行co
 | P2-D16 | model profileと時間schema | adopted |
 | P2-D17 | 2015 refined geometryとpaper-inspired motor | adopted |
 | P2-D18 | 2015 refined model Stage A採否 | pending |
+| P2-D21 | reference torque比較のfixed/tracking・時間基準 | adopted |
 | P2-D19 | dataset v2前のn=3長時間failure診断 | pending |
 | P2-D20 | RUN–TUMBLEの段階実装 | pending |
 
@@ -242,6 +243,12 @@ Issue単位の進捗台帳，branch一覧，acceptance criteria一覧，実行co
 - **Interpretation:** Stage Aの短時間検証と定性可視化は完了したが、`dt_star=1e-4`をproject/paper共通defaultへ昇格させる根拠はない。短い実時間では小さな誤差を過大評価し得るため、同一実時間での定量評価と計算効率評価を分けて行う。
 - **Decision:** canonical `dt_star=1e-5`を維持し，`dt_star=1e-4`は非canonical referenceとする。本PRのStage A検証は完了とする。`dt_star`の有効性説明はIssue #61、reference torque policyはIssue #183、dataset v2採択向けのtorque・`dt_star`・べん毛数検証はIssue #184で実施し、2015 profileのsupported採否はそれらの後に判断する。
 - **Evidence:** Issue #168，PR #176，Issues #61・#183・#184，`docs/phase2/phase2_168_2015_stage_a_validation.md`，parent Issue #154．
+
+### P2-D21: reference torque の比較契約は fixed / tracking と時間基準を分離する
+
+- **Decision:** `fixed-reference` は物性を固定した駆動torque感度、`tracking-reference` はreference torqueと物性を同時に連動させる相似候補として分離する。さらに `same-real-time` と `same-dimensionless-time` を直交して記録し、#61の`dt_star`・計算効率比較は fixed-reference / same-real-time 内に限定する。
+- **Interpretation:** 2010 projectは `tau_s=1` legacy policyのためtrackingを時間相似と呼ばない。#184は #61 が許容した`dt_star`とper-flag torque policyを使い、dataset v2・0.5秒run・2015 supported採択はこのDecisionから導かない。
+- **Evidence:** Issue #183，ADR 0016，`docs/phase2/phase2_183_reference_torque_comparison_contract.md`，`conf/phase2_reference_torque/*.yaml`．
 
 ### P2-D19: 大量step runはcompact output policyを明示選択する
 

--- a/scripts/01_simulate_swimming/01_simulate_swimming.py
+++ b/scripts/01_simulate_swimming/01_simulate_swimming.py
@@ -186,17 +186,16 @@ def main(
             cfg.tau_s,
         )
     logger.info(
-        "[time-step ] Δt_internal=%.6e s, τ=%.6e s, Δt*=dt_star=%.6e (=Δt/τ)",
+        "[time-step ] Δt=%.6e s, τ=%.6e s, Δt/τ=%.6e",
         cfg.dt_s,
         cfg.tau_s,
         cfg.dt_star,
     )
-    logger.info("[time-step ] output_dt_s(config)=%.6e s", cfg.output_dt_s)
     logger.info(
-        (
-            "[duration  ] t_end=duration_s=%.6e s, "
-            "t_end*=duration_star=%.6e (=t_end/τ), steps=%d"
-        ),
+        "[time-step ] output interval (legacy time.dt_s)=%.6e s", cfg.output_dt_s
+    )
+    logger.info(
+        ("[duration  ] t_end=%.6e s, t_end/τ=%.6e, steps=%d"),
         cfg.time.duration_s,
         cfg.duration_star,
         cfg.total_steps,

--- a/scripts/01_simulate_swimming/plan_reference_torque_comparison.py
+++ b/scripts/01_simulate_swimming/plan_reference_torque_comparison.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Issue #183 reference torque campaign plan CLI (simulation は起動しない)。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+from sim_swim.analysis.reference_torque_comparison import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sim_swim/analysis/reference_torque_comparison.py
+++ b/src/sim_swim/analysis/reference_torque_comparison.py
@@ -1,0 +1,137 @@
+"""Issue #183 の reference torque 比較条件を展開する。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from sim_swim.analysis.multi_run_campaign import load_yaml
+from sim_swim.sim.params import SimulationConfig
+
+POLICIES = frozenset({"fixed-reference", "tracking-reference"})
+TIME_BASES = frozenset({"same-real-time", "same-dimensionless-time"})
+
+
+def _number_list(raw: Any, key: str) -> list[float]:
+    values = [float(value) for value in list(raw or [])]
+    if not values or any(value <= 0.0 for value in values):
+        raise ValueError(f"{key} must be a non-empty list of positive values")
+    return values
+
+
+def build_plan(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return reproducible comparison conditions without running a simulation."""
+
+    base_config = Path(str(raw["base_config"]))
+    base = SimulationConfig.from_dict(load_yaml(base_config))
+    base.validate_execution_supported()
+    reference = float(raw["reference_torque_Nm"])
+    if reference <= 0.0:
+        raise ValueError("reference_torque_Nm must be positive")
+    policies = [str(value) for value in raw.get("policies", [])]
+    time_bases = [str(value) for value in raw.get("time_bases", [])]
+    if not policies or set(policies) - POLICIES:
+        raise ValueError(f"policies must use: {sorted(POLICIES)}")
+    if not time_bases or set(time_bases) - TIME_BASES:
+        raise ValueError(f"time_bases must use: {sorted(TIME_BASES)}")
+    scales = _number_list(raw.get("motor_torque_scales"), "motor_torque_scales")
+    output_base_dir = str(
+        raw.get("output_base_dir") or "outputs/phase2_reference_torque"
+    )
+    durations = dict(raw.get("durations", {}) or {})
+    real_time_s = float(durations.get("same_real_time_s", 0.0))
+    dimensionless_tau = float(durations.get("same_dimensionless_tau", 0.0))
+    if "same-real-time" in time_bases and real_time_s <= 0.0:
+        raise ValueError("durations.same_real_time_s must be positive")
+    if "same-dimensionless-time" in time_bases and dimensionless_tau <= 0.0:
+        raise ValueError("durations.same_dimensionless_tau must be positive")
+
+    conditions: list[dict[str, Any]] = []
+    for policy in policies:
+        for time_basis in time_bases:
+            for scale in scales:
+                motor_torque = reference * scale
+                tracking = policy == "tracking-reference"
+                overrides: dict[str, Any] = {
+                    "motor": {
+                        "torque_Nm": motor_torque,
+                        "reference_torque_Nm": motor_torque if tracking else reference,
+                        "torque_for_forces_override_Nm": 0.0 if tracking else reference,
+                    },
+                    "time": {
+                        "duration": {
+                            "value": real_time_s
+                            if time_basis == "same-real-time"
+                            else dimensionless_tau,
+                            "unit": "s" if time_basis == "same-real-time" else "tau",
+                        }
+                    },
+                }
+                cfg = base.with_overrides(overrides)
+                condition_id = f"{policy.replace('-', '_')}_{time_basis.replace('-', '_')}_motor_scale_{scale:g}"
+                conditions.append(
+                    {
+                        "condition_id": condition_id,
+                        "comparison_policy": policy,
+                        "time_basis": time_basis,
+                        "motor_torque_scale": scale,
+                        "config_overrides": overrides,
+                        "time": cfg.time_manifest(),
+                        "equivalence": {
+                            "motor_torque_Nm": cfg.motor_torque_Nm,
+                            "reference_torque_Nm": cfg.reference_torque_Nm,
+                            "torque_for_forces_Nm": cfg.torque_for_forces_Nm,
+                            "physical_properties_fixed": not tracking,
+                            "reference_linked_properties": tracking,
+                            "same_real_time": time_basis == "same-real-time",
+                            "same_dimensionless_time": time_basis
+                            == "same-dimensionless-time",
+                            "tau_tracks_reference_torque": cfg.time_scale_policy
+                            == "reference_torque",
+                        },
+                        "execution_command": (
+                            "uv run python scripts/01_simulate_swimming/01_simulate_swimming.py "
+                            f"--config {base_config} "
+                            f"motor.torque_Nm={motor_torque:.12g} "
+                            f"motor.reference_torque_Nm={overrides['motor']['reference_torque_Nm']:.12g} "
+                            f"motor.torque_for_forces_override_Nm={overrides['motor']['torque_for_forces_override_Nm']:.12g} "
+                            f"time.duration.value={overrides['time']['duration']['value']:.12g} "
+                            f"time.duration.unit={overrides['time']['duration']['unit']} "
+                            f"output.base_dir={output_base_dir}/{condition_id}"
+                        ),
+                    }
+                )
+    return {
+        "kind": "phase2_reference_torque_comparison_plan",
+        "contract_version": 2,
+        "base_config": str(base_config),
+        "model_profile": base.model_profile_manifest(),
+        "reference_torque_Nm": reference,
+        "output_base_dir": output_base_dir,
+        "conditions": conditions,
+        "interpretation_prohibitions": [
+            "fixed-reference と tracking-reference を同じ物理系の感度差として混同しない。",
+            "same-dimensionless-time の wall time / step 数を same-real-time の計算効率と比較しない。",
+            "2010 project の legacy_fixed_tau_s_1 では reference torque を変えても tau_s は連動しない。",
+            "この比較planは torque、dt_star、policy、dataset v2、supported status の正式採択を表さない。",
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    plan = build_plan(load_yaml(args.config))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(plan, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -1142,6 +1142,18 @@ class SimulationConfig:
                 else "motor.reference_torque_Nm"
             ),
             "material_coefficients": self.material_coefficients_manifest(),
+            "paper_notation": {
+                "t": {
+                    "requested_s": float(self.time.duration_s),
+                    "final_state_s": float(self.final_state_t_s),
+                },
+                "tau": {"s": float(self.tau_s)},
+                "delta_t": {"s": float(self.dt_s)},
+                "t_over_tau": {
+                    "requested": float(self.duration_star),
+                },
+                "delta_t_over_tau": {"value": float(self.dt_star)},
+            },
             "time_schema_source": str(self.time.schema_source),
             "legacy_time_keys_used": list(self.time.legacy_keys_used),
         }

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -1135,8 +1135,37 @@ class SimulationConfig:
             "reference_torque_Nm": float(self.reference_torque_Nm),
             "motor_enabled": bool(self.motor_enabled),
             "motor_torque_Nm": float(self.motor_torque_Nm),
+            "torque_for_forces_Nm": float(self.torque_for_forces_Nm),
+            "torque_for_forces_source": (
+                "motor.torque_for_forces_override_Nm"
+                if float(self.motor.torque_for_forces_override_Nm) > 0.0
+                else "motor.reference_torque_Nm"
+            ),
+            "material_coefficients": self.material_coefficients_manifest(),
             "time_schema_source": str(self.time.schema_source),
             "legacy_time_keys_used": list(self.time.legacy_keys_used),
+        }
+
+    def material_coefficients_manifest(self) -> dict[str, float]:
+        """Return dimensional coefficients derived from the force-scale torque.
+
+        These are the unmultiplied coefficients used by ``DynamicsEngine``;
+        profile-specific stiffness and motor-local multipliers remain separate.
+        Keeping them in the manifest makes fixed- and tracking-reference runs
+        distinguishable without inspecting implementation code.
+        """
+
+        torque = float(self.torque_for_forces_Nm)
+        return {
+            "spring_H_N_per_m": float(
+                self.potentials.spring.H_over_T_over_b * torque / self.b_m
+            ),
+            "bend_k_Nm": float(self.potentials.bend.kb_over_T * torque),
+            "torsion_k_Nm": float(self.potentials.torsion.kt_over_T * torque),
+            "hook_bend_k_Nm": float(self.hook.kb_over_T * torque),
+            "repulsion_A_Nm": float(
+                self.potentials.spring_spring_repulsion.A_ss_over_T * torque
+            ),
         }
 
     def motor_local_scale_deviations(self) -> dict[str, float]:

--- a/tests/test_reference_torque_comparison.py
+++ b/tests/test_reference_torque_comparison.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sim_swim.analysis.multi_run_campaign import load_yaml
+from sim_swim.analysis.reference_torque_comparison import build_plan
+from sim_swim.dynamics.engine import DynamicsEngine
+from sim_swim.model.builder import ModelBuilder
+from sim_swim.sim.params import SimulationConfig
+
+
+def _raw(base_config: str) -> dict[str, object]:
+    return {
+        "base_config": base_config,
+        "reference_torque_Nm": 1.2e-18,
+        "policies": ["fixed-reference", "tracking-reference"],
+        "time_bases": ["same-real-time", "same-dimensionless-time"],
+        "motor_torque_scales": [0.5, 1.0],
+        "durations": {"same_real_time_s": 0.01, "same_dimensionless_tau": 1.0},
+    }
+
+
+def test_plan_separates_fixed_and_tracking_scales_and_manifest() -> None:
+    plan = build_plan(_raw("conf/sim_swim_2015.yaml"))
+    conditions = {row["condition_id"]: row for row in plan["conditions"]}
+    fixed = conditions["fixed_reference_same_real_time_motor_scale_0.5"]
+    tracking = conditions["tracking_reference_same_real_time_motor_scale_0.5"]
+
+    assert fixed["equivalence"]["physical_properties_fixed"] is True
+    assert fixed["equivalence"]["reference_torque_Nm"] == pytest.approx(1.2e-18)
+    assert fixed["equivalence"]["torque_for_forces_Nm"] == pytest.approx(1.2e-18)
+    assert tracking["equivalence"]["reference_linked_properties"] is True
+    assert tracking["equivalence"]["reference_torque_Nm"] == pytest.approx(0.6e-18)
+    assert tracking["equivalence"]["torque_for_forces_Nm"] == pytest.approx(0.6e-18)
+    assert tracking["equivalence"]["tau_tracks_reference_torque"] is True
+    assert fixed["time"]["torque_for_forces_source"] == (
+        "motor.torque_for_forces_override_Nm"
+    )
+    assert tracking["time"]["torque_for_forces_source"] == ("motor.reference_torque_Nm")
+    assert tracking["time"]["material_coefficients"]["bend_k_Nm"] == pytest.approx(
+        fixed["time"]["material_coefficients"]["bend_k_Nm"] * 0.5
+    )
+
+
+def test_2010_project_keeps_legacy_tau_explicit() -> None:
+    raw = _raw("conf/sim_swim_2010.yaml")
+    raw["reference_torque_Nm"] = 2.5e-20
+    plan = build_plan(raw)
+    tracking = next(
+        row
+        for row in plan["conditions"]
+        if row["comparison_policy"] == "tracking-reference"
+    )
+    assert tracking["equivalence"]["tau_tracks_reference_torque"] is False
+    assert tracking["time"]["tau_s"] == pytest.approx(1.0)
+
+
+def test_engine_material_coefficients_follow_force_scale_not_motor_drive() -> None:
+    raw = load_yaml(Path("conf/sim_swim_2015.yaml"))
+    raw["model_profile"]["implementation_status"] = "supported"
+    base = SimulationConfig.from_dict(raw)
+    fixed = base.with_overrides(
+        {
+            "motor": {
+                "torque_Nm": 0.6e-18,
+                "reference_torque_Nm": 1.2e-18,
+                "torque_for_forces_override_Nm": 1.2e-18,
+            }
+        }
+    )
+    tracking = base.with_overrides(
+        {
+            "motor": {
+                "torque_Nm": 0.6e-18,
+                "reference_torque_Nm": 0.6e-18,
+                "torque_for_forces_override_Nm": 0.0,
+            }
+        }
+    )
+    fixed_engine = DynamicsEngine(ModelBuilder(fixed).build(), fixed)
+    tracking_engine = DynamicsEngine(ModelBuilder(tracking).build(), tracking)
+
+    assert fixed.motor_torque_Nm == pytest.approx(tracking.motor_torque_Nm)
+    assert tracking.tau_s == pytest.approx(fixed.tau_s * 2.0)
+    assert tracking_engine.spring_h == pytest.approx(fixed_engine.spring_h * 0.5)
+    assert tracking_engine.k_bend == pytest.approx(fixed_engine.k_bend * 0.5)
+    assert tracking_engine.k_torsion == pytest.approx(fixed_engine.k_torsion * 0.5)
+    assert tracking_engine.k_hook == pytest.approx(fixed_engine.k_hook * 0.5)
+    assert tracking_engine.repulsion_A == pytest.approx(fixed_engine.repulsion_A * 0.5)

--- a/tests/test_reference_torque_comparison.py
+++ b/tests/test_reference_torque_comparison.py
@@ -42,6 +42,12 @@ def test_plan_separates_fixed_and_tracking_scales_and_manifest() -> None:
     assert tracking["time"]["material_coefficients"]["bend_k_Nm"] == pytest.approx(
         fixed["time"]["material_coefficients"]["bend_k_Nm"] * 0.5
     )
+    assert tracking["time"]["paper_notation"]["tau"]["s"] == pytest.approx(
+        tracking["time"]["tau_s"]
+    )
+    assert tracking["time"]["paper_notation"]["delta_t"]["s"] == pytest.approx(
+        tracking["time"]["dt_internal_s"]
+    )
 
 
 def test_2010_project_keeps_legacy_tau_explicit() -> None:


### PR DESCRIPTION
## Summary

- Define fixed-reference and tracking-reference torque-sweep purposes separately.
- Record effective force-scale torque and material coefficients in manifests, with unit tests.
- Use paper-facing time notation in user-facing logs and `time.paper_notation`: `t`, `τ`, `Δt`, `t/τ`, and `Δt/τ`.
- Add ADR 0016 and handoff contract for #61, #184, and #157.

## Scope

Closes #183. This PR does not run the #186 0.5-second compact campaign, adopt dataset v2, or promote the 2015 profile to supported.

## Validation

- `.venv/bin/pytest tests/test_reference_torque_comparison.py tests/test_params.py tests/test_e2e_cli.py -q` — 95 passed
- pre-commit light suite — 286 passed, 275 deselected
- 2010/2015 plan CLI smoke tests (no simulation started)
- `@codex review 511d814` requested on the merge-ready candidate