### PR TITLE
Accept Codex review comments in gate

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -283,7 +283,9 @@ jobs:
                   ? [
                       {
                         requestedCommitSha,
-                        createdAt: Date.parse(comment.created_at || ""),
+                        requestedAt: Date.parse(
+                          comment.updated_at || comment.created_at || ""
+                        ),
                       },
                     ]
                   : [];
@@ -307,8 +309,8 @@ jobs:
                 return validCodexRequests.some(
                   (request) =>
                     Number.isFinite(responseAt) &&
-                    Number.isFinite(request.createdAt) &&
-                    responseAt >= request.createdAt &&
+                    Number.isFinite(request.requestedAt) &&
+                    responseAt >= request.requestedAt &&
                     request.requestedCommitSha === reviewedCommitSha
                 );
               });

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -203,15 +203,17 @@ jobs:
               const prCommitShas = prCommits.map((commit) =>
                 normalizedSha(commit.sha)
               );
-              const shaBelongsToPr = (sha) => {
+              const resolvePrCommitSha = (sha) => {
                 const candidate = normalizedSha(sha);
-                return (
-                  candidate.length >= 10 &&
-                  prCommitShas.some((commitSha) =>
-                    commitSha.startsWith(candidate)
-                  )
+                if (candidate.length < 10) {
+                  return "";
+                }
+                const matches = prCommitShas.filter((commitSha) =>
+                  commitSha.startsWith(candidate)
                 );
+                return matches.length === 1 ? matches[0] : "";
               };
+              const shaBelongsToPr = (sha) => Boolean(resolvePrCommitSha(sha));
 
               const reviewThreads = await listReviewThreads(prNumber);
               const classifyThread = (thread) => {
@@ -276,12 +278,12 @@ jobs:
                 const match = String(comment.body || "").match(
                   CODEX_REVIEW_REQUEST
                 );
-                const requestedSha = match?.[1] || "";
-                return shaBelongsToPr(requestedSha)
+                const requestedCommitSha = resolvePrCommitSha(match?.[1]);
+                return requestedCommitSha
                   ? [
                       {
-                      requestedSha,
-                      createdAt: Date.parse(comment.created_at || ""),
+                        requestedCommitSha,
+                        createdAt: Date.parse(comment.created_at || ""),
                       },
                     ]
                   : [];
@@ -293,10 +295,12 @@ jobs:
                 ) {
                   return false;
                 }
-                const reviewedSha = String(comment.body || "").match(
-                  CODEX_REVIEWED_COMMIT
-                )?.[1] || "";
-                if (!shaBelongsToPr(reviewedSha)) {
+                const reviewedCommitSha = resolvePrCommitSha(
+                  String(comment.body || "").match(
+                    CODEX_REVIEWED_COMMIT
+                  )?.[1]
+                );
+                if (!reviewedCommitSha) {
                   return false;
                 }
                 const responseAt = Date.parse(comment.created_at || "");
@@ -305,8 +309,7 @@ jobs:
                     Number.isFinite(responseAt) &&
                     Number.isFinite(request.createdAt) &&
                     responseAt >= request.createdAt &&
-                    (request.requestedSha.startsWith(reviewedSha) ||
-                      reviewedSha.startsWith(request.requestedSha))
+                    request.requestedCommitSha === reviewedCommitSha
                 );
               });
               // GitHub binds submitted reviews to commits. Some Cloud connector

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -99,6 +99,12 @@ jobs:
             const reviewIsSubmitted = (review) =>
               Boolean(review?.submitted_at) &&
               String(review?.state || "").toUpperCase() !== "DISMISSED";
+            const CODEX_REVIEW_REQUEST =
+              /(?:^|\s)@codex\s+review\s+([0-9a-f]{7,40})\b/i;
+            const CODEX_REVIEWED_COMMIT =
+              /reviewed\s+commit:\s*`?([0-9a-f]{7,40})`?/i;
+            const CODEX_NO_MAJOR_ISSUES =
+              /codex\s+review:\s*didn't find any major issues\./i;
 
             async function listReviewThreads(prNumber) {
               const query = `
@@ -266,10 +272,50 @@ jobs:
                   reviewIsSubmitted(review) &&
                   shaBelongsToPr(review.commit_id)
               );
-              // GitHub already binds reviews to commits.  A trusted review on
-              // any commit still in this PR is valid; unresolved trusted
-              // threads above are the only review-follow-up blocker.
-              const codexReviewAccepted = validCodexReviews.length > 0;
+              const validCodexRequests = comments.flatMap((comment) => {
+                const match = String(comment.body || "").match(
+                  CODEX_REVIEW_REQUEST
+                );
+                const requestedSha = match?.[1] || "";
+                return shaBelongsToPr(requestedSha)
+                  ? [
+                      {
+                      requestedSha,
+                      createdAt: Date.parse(comment.created_at || ""),
+                      },
+                    ]
+                  : [];
+              });
+              const validCodexCommentResponses = comments.filter((comment) => {
+                if (
+                  !isCodexConnector(comment.user?.login) ||
+                  !CODEX_NO_MAJOR_ISSUES.test(String(comment.body || ""))
+                ) {
+                  return false;
+                }
+                const reviewedSha = String(comment.body || "").match(
+                  CODEX_REVIEWED_COMMIT
+                )?.[1] || "";
+                if (!shaBelongsToPr(reviewedSha)) {
+                  return false;
+                }
+                const responseAt = Date.parse(comment.created_at || "");
+                return validCodexRequests.some(
+                  (request) =>
+                    Number.isFinite(responseAt) &&
+                    Number.isFinite(request.createdAt) &&
+                    responseAt >= request.createdAt &&
+                    (request.requestedSha.startsWith(reviewedSha) ||
+                      reviewedSha.startsWith(request.requestedSha))
+                );
+              });
+              // GitHub binds submitted reviews to commits. Some Cloud connector
+              // responses are issue comments instead, so accept only the
+              // allowlisted no-major-issues response that names a requested,
+              // in-PR commit. Unresolved trusted threads still block merging.
+              const codexReviewAccepted =
+                validCodexReviews.length > 0 ||
+                validCodexCommentResponses.length > 0;
               const copilotReviewAccepted = validCopilotReviews.length > 0;
 
               let state = "failure";

--- a/docs/adr/0008_codex_review_gate_and_merge_policy.md
+++ b/docs/adr/0008_codex_review_gate_and_merge_policy.md
@@ -45,7 +45,8 @@ repository側には，PR metadata，comments，reviews，reactions，review thre
 - Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。
 - request commentへのallowlisted connectorのthumbs-up reactionは，request更新時刻以後のreactionだけを有効とする。
 - PR review responseはallowlisted login，submitted state，review対象commit，request後の時刻をAPIから検証する。
-- 問題なし応答は`APPROVED` review，`Final verdict PASS`，no-major-issues comment，またはrequestへのthumbs-upを成功シグナルとして扱う。
+- Cloud connectorがGitHubの正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後に、allowlisted loginが現在のPR履歴にある同じSHAを`Reviewed commit`として明記し、`Didn't find any major issues`を返した場合だけ成功シグナルとして扱う。
+- `APPROVED` review，`Final verdict PASS`，またはrequestへのthumbs-upも、同じreview対象commit・時刻検証を満たす場合の成功シグナルとして扱う。
 - feedbackを伴うreviewは，current Codex-authored threadがすべてresolvedまたはoutdatedになった時点で完了とする。
 - feedback修正後にPR headが変わっても，再度`@codex review`を要求しない。
 

--- a/docs/adr/0008_codex_review_gate_and_merge_policy.md
+++ b/docs/adr/0008_codex_review_gate_and_merge_policy.md
@@ -45,7 +45,7 @@ repository側には，PR metadata，comments，reviews，reactions，review thre
 - Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。
 - request commentへのallowlisted connectorのthumbs-up reactionは，request更新時刻以後のreactionだけを有効とする。
 - PR review responseはallowlisted login，submitted state，review対象commit，request後の時刻をAPIから検証する。
-- Cloud connectorがGitHubの正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後に、allowlisted loginが現在のPR履歴にある同じ一意のcommit SHAを`Reviewed commit`として明記し、`Didn't find any major issues`を返した場合だけ成功シグナルとして扱う。
+- Cloud connectorがGitHubの正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求（編集された要求は`updated_at`、未編集時は`created_at`以後）に、allowlisted loginが現在のPR履歴にある同じ一意のcommit SHAを`Reviewed commit`として明記し、`Didn't find any major issues`を返した場合だけ成功シグナルとして扱う。
 - `APPROVED` review，`Final verdict PASS`，またはrequestへのthumbs-upも、同じreview対象commit・時刻検証を満たす場合の成功シグナルとして扱う。
 - feedbackを伴うreviewは，current Codex-authored threadがすべてresolvedまたはoutdatedになった時点で完了とする。
 - feedback修正後にPR headが変わっても，再度`@codex review`を要求しない。

--- a/docs/adr/0008_codex_review_gate_and_merge_policy.md
+++ b/docs/adr/0008_codex_review_gate_and_merge_policy.md
@@ -45,7 +45,7 @@ repository側には，PR metadata，comments，reviews，reactions，review thre
 - Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。
 - request commentへのallowlisted connectorのthumbs-up reactionは，request更新時刻以後のreactionだけを有効とする。
 - PR review responseはallowlisted login，submitted state，review対象commit，request後の時刻をAPIから検証する。
-- Cloud connectorがGitHubの正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後に、allowlisted loginが現在のPR履歴にある同じSHAを`Reviewed commit`として明記し、`Didn't find any major issues`を返した場合だけ成功シグナルとして扱う。
+- Cloud connectorがGitHubの正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後に、allowlisted loginが現在のPR履歴にある同じ一意のcommit SHAを`Reviewed commit`として明記し、`Didn't find any major issues`を返した場合だけ成功シグナルとして扱う。
 - `APPROVED` review，`Final verdict PASS`，またはrequestへのthumbs-upも、同じreview対象commit・時刻検証を満たす場合の成功シグナルとして扱う。
 - feedbackを伴うreviewは，current Codex-authored threadがすべてresolvedまたはoutdatedになった時点で完了とする。
 - feedback修正後にPR headが変わっても，再度`@codex review`を要求しない。

--- a/docs/codex-runs/20260812_codex_comment_review_gate/review_result.json
+++ b/docs/codex-runs/20260812_codex_comment_review_gate/review_result.json
@@ -1,0 +1,25 @@
+{
+  "status": "PASS",
+  "task": "Codex Cloud comment response accepted by review gate",
+  "summary": "正式PR reviewを作らないCloud connectorのno-major-issues commentを、要求SHA・応答SHA・時刻・allowlisted loginの照合を条件にcodex-review-gateの有効review信号として受理する。",
+  "checks": [
+    {
+      "command": "python3 -c 'import yaml; yaml.safe_load(...)'",
+      "result": "PASS: workflow YAML parse"
+    },
+    {
+      "command": "node --check and positive/negative comment-SHA contract smoke",
+      "result": "PASS: matching requested/reviewed SHA is accepted; unrelated SHA is rejected"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS"
+    }
+  ],
+  "user_review_required": false,
+  "adr_required": false,
+  "adr_reason": "ADR 0008に既に定めたno-major-issues comment成功シグナルをworkflowへ整合実装する変更であり、新しいpolicyは導入しない。",
+  "next_actions": [
+    "PR作成後、Codex Cloud connectorのcomment responseを含む実PRでgateのstatusを確認する。"
+  ]
+}

--- a/docs/codex/codex_workflow.md
+++ b/docs/codex/codex_workflow.md
@@ -183,7 +183,7 @@ Codex Cloud reviewは原則1回のfinal-candidate reviewとする。指摘が出
 
 Codex Cloud feedback修正後は，修正commitでPR headが変わっても再度`@codex review <new-head-sha>`を投げない。品質担保はmerge-final self-check，CI，必要なthreadへの理由comment，current thread resolveで行う。
 
-Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。Cloud connectorが正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後の`Reviewed commit: <SHA>`と`Didn't find any major issues`の定型応答を、現在のPR履歴にある同じ一意のcommitへ照合する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
+Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。Cloud connectorが正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求（編集後は`updated_at`、未編集時は`created_at`以後）の`Reviewed commit: <SHA>`と`Didn't find any major issues`の定型応答を、現在のPR履歴にある同じ一意のcommitへ照合する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
 
 This connector review is a PR review assistant, not the source of truth for task completion. Its `PASS` / `FAIL` verdict does not replace the required local `docs/codex-runs/<run-id>/review_result.json`.
 

--- a/docs/codex/codex_workflow.md
+++ b/docs/codex/codex_workflow.md
@@ -183,7 +183,7 @@ Codex Cloud reviewは原則1回のfinal-candidate reviewとする。指摘が出
 
 Codex Cloud feedback修正後は，修正commitでPR headが変わっても再度`@codex review <new-head-sha>`を投げない。品質担保はmerge-final self-check，CI，必要なthreadへの理由comment，current thread resolveで行う。
 
-Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。Cloud connectorが正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後の`Reviewed commit: <SHA>`と`Didn't find any major issues`の定型応答を、現在のPR履歴にある同じSHAへ照合する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
+Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。Cloud connectorが正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後の`Reviewed commit: <SHA>`と`Didn't find any major issues`の定型応答を、現在のPR履歴にある同じ一意のcommitへ照合する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
 
 This connector review is a PR review assistant, not the source of truth for task completion. Its `PASS` / `FAIL` verdict does not replace the required local `docs/codex-runs/<run-id>/review_result.json`.
 

--- a/docs/codex/codex_workflow.md
+++ b/docs/codex/codex_workflow.md
@@ -183,7 +183,7 @@ Codex Cloud reviewは原則1回のfinal-candidate reviewとする。指摘が出
 
 Codex Cloud feedback修正後は，修正commitでPR headが変わっても再度`@codex review <new-head-sha>`を投げない。品質担保はmerge-final self-check，CI，必要なthreadへの理由comment，current thread resolveで行う。
 
-Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。PR履歴上のreview commitとthread状態をGitHub APIから検証する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
+Cloud connector loginは`chatgpt-codex-connector`または`chatgpt-codex-connector[bot]`の完全一致だけを許可する。Cloud connectorが正式reviewではなくPR commentで応答する場合は、`@codex review <SHA>`要求後の`Reviewed commit: <SHA>`と`Didn't find any major issues`の定型応答を、現在のPR履歴にある同じSHAへ照合する。trusted Codex/Copilot reviewの指摘は、修正または理由を記録したうえで必ずresolveする。未解決threadが1件でもあるPRはmergeしない。
 
 This connector review is a PR review assistant, not the source of truth for task completion. Its `PASS` / `FAIL` verdict does not replace the required local `docs/codex-runs/<run-id>/review_result.json`.
 


### PR DESCRIPTION
## Summary

- Accept the existing ADR 0008 Codex no-major-issues comment signal when the request SHA, reviewed SHA, timestamp, and allowlisted connector all match.
- Continue rejecting unrelated SHAs and blocking unresolved trusted threads.

## Validation

- workflow YAML parse
- Node positive/negative SHA contract smoke
- pre-commit light suite — 286 passed, 272 deselected