### PR TITLE
feat(phase2): add 2010 torque-linked dt experiment plan

### DIFF
--- a/conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml
+++ b/conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml
@@ -1,0 +1,6 @@
+base_config: conf/sim_swim_2010.yaml
+# Short screen only.  Do not replace the legacy supported 2010 project profile.
+duration_tau: 1.0
+torques_Nm: [1.0e-21, 2.5e-20, 1.0e-19, 1.2e-18]
+dt_stars: [1.0e-3, 1.0e-4, 1.0e-5]
+comparison_sample_count: 201

--- a/docs/adr/0016_phase2_reference_torque_comparison_policy.md
+++ b/docs/adr/0016_phase2_reference_torque_comparison_policy.md
@@ -25,6 +25,12 @@ torque sweep は次の二つを別 campaign として扱う。
 
 2010 project は `legacy_fixed_tau_s_1` の互換 policy のため、tracking-referenceでも `tau_s=1 s` のままである。物性連動は検査対象だが、2015のような時間相似を主張しない。
 
+Issue #190の2010短時間screenだけは、`tracking-reference`とは別の明示的な実験conditionとして
+`time.scale_policy=reference_torque`をopt-inする。このconditionは
+`abs(motor.torque_Nm)=reference_torque_Nm=torque_for_forces_Nm`と
+`tau_s=eta*b^3/T`を要求する。既存2010 project baseline、#183のtracking-reference結果、#61/#184の正式な
+fixed/tracking比較契約を変更・再解釈しない。#190の結果を2015 projectまたはdataset採択へ適用するには別途判断を要する。
+
 ## Consequences
 
 * plan config と `campaign_plan.json` は `comparison_policy`、`time_basis`、3種類の torque、`tau_s`、`dt_star`、`dt_internal_s`、`total_steps`、物性係数を保存する。

--- a/docs/codex-runs/20260813_phase2_0190/review_result.json
+++ b/docs/codex-runs/20260813_phase2_0190/review_result.json
@@ -9,8 +9,8 @@
   ],
   "checks": [
     {
-      "command": "uv run pytest -q tests/test_phase2_190_torque_dt_stability.py tests/test_params.py",
-      "result": "PASS: 93 passed"
+      "command": "uv run pytest -q tests/test_phase2_190_torque_dt_stability.py tests/test_params.py tests/test_reference_torque_comparison.py",
+      "result": "PASS: 96 passed"
     },
     {
       "command": "uv run ruff check ... && git diff --check",
@@ -18,14 +18,14 @@
     },
     {
       "command": "plan_2010_torque_dt_stability.py --config conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml",
-      "result": "PASS: 12 conditions; simulation was not started"
+      "result": "PASS: 12 conditions with 201-point normalized-time archive intervals; simulation was not started"
     }
   ],
   "long_simulation_executed": false,
   "long_simulation_reason": "Issue #190は短時間screenの実験環境整備であり、simulation結果の採択は後続taskで行う。",
   "user_review_required": false,
   "adr_required": false,
-  "adr_reason": "既存baselineのtime policyを変更せず、実験configに限定したopt-inである。",
+  "adr_reason": "既存baselineを変更しない実験限定のopt-inであることをADR 0016とIssue #183 comparison contractへ明記した。",
   "commit_type": "complete",
   "push_status": "not_pushed",
   "next_actions": [

--- a/docs/codex-runs/20260813_phase2_0190/review_result.json
+++ b/docs/codex-runs/20260813_phase2_0190/review_result.json
@@ -1,0 +1,35 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #190 2010 torque-linked time-scale short-screen environment",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/190",
+  "summary": [
+    "2010 project defaultのlegacy tau_s=1 sを維持したまま、実験conditionだけでreference-torque time scaleをopt-inできるようにした。",
+    "per-flag torque、reference torque、force-scale torqueを同一にする4 torque x 3 dt_starの1 tau planを機械可読に生成できる。",
+    "0.5秒run、dtの採択、2015 projectへの反映、dataset採択は実行していない。"
+  ],
+  "checks": [
+    {
+      "command": "uv run pytest -q tests/test_phase2_190_torque_dt_stability.py tests/test_params.py",
+      "result": "PASS: 93 passed"
+    },
+    {
+      "command": "uv run ruff check ... && git diff --check",
+      "result": "PASS"
+    },
+    {
+      "command": "plan_2010_torque_dt_stability.py --config conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml",
+      "result": "PASS: 12 conditions; simulation was not started"
+    }
+  ],
+  "long_simulation_executed": false,
+  "long_simulation_reason": "Issue #190は短時間screenの実験環境整備であり、simulation結果の採択は後続taskで行う。",
+  "user_review_required": false,
+  "adr_required": false,
+  "adr_reason": "既存baselineのtime policyを変更せず、実験configに限定したopt-inである。",
+  "commit_type": "complete",
+  "push_status": "not_pushed",
+  "next_actions": [
+    "#190の1 tau screenを別PCで実行し、dt_star=1e-3/1e-4/1e-5のshape・遊泳・一致度を記録する。",
+    "結果を評価してから、#61に2015 projectへの適用可否を追記する。"
+  ]
+}

--- a/docs/phase2/phase2_183_reference_torque_comparison_contract.md
+++ b/docs/phase2/phase2_183_reference_torque_comparison_contract.md
@@ -24,6 +24,8 @@ manifestの `time.paper_notation` はこの表記を正本の表示層として�
 
 2010 project は `legacy_fixed_tau_s_1` のため、tracking-reference でも `tau_s` は変わらない。これは物性連動を検査する比較であり、2015 のような時間相似を主張できない。plan manifest の `tau_tracks_reference_torque=false` を必ず確認する。
 
+Issue #190はこのtracking-referenceとは別の実験用conditionである。2010 project defaultを変えず、専用campaignのみで`time.scale_policy=reference_torque`を明示して`tau_tracks_reference_torque=true`にする。3 torqueの等値、無次元時刻での比較sample、短時間`torque × dt_star` screenを検証するためであり、#183の先行screenと同一policyとして比較しない。
+
 ## Config / manifest 契約
 
 入力 config は [2010 project](../../conf/phase2_reference_torque/2010_project.yaml)、[2015 project](../../conf/phase2_reference_torque/2015_project.yaml) である。plan CLI は condition ごとに以下を `campaign_plan.json` へ固定する。

--- a/scripts/01_simulate_swimming/plan_2010_torque_dt_stability.py
+++ b/scripts/01_simulate_swimming/plan_2010_torque_dt_stability.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+from sim_swim.analysis.torque_dt_stability import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,22 @@ uv run python -m scripts.01_simulate_swimming \
 - `time.dt_s` は deprecated な出力・記録間隔で、内部積分刻みではありません。
 - `total_steps = ceil(duration_tau / dt_star)`。`step_summary.csv` はstep開始時刻を記録するため最終state時刻は指定durationをわずかに超える場合があります。
 
+### Issue #190: 2010 project torque連動time-scaleの短時間screen
+
+既存の2010 project defaultは`tau_s=1 s`固定のまま保持する。Issue #190のplanだけは
+`time.scale_policy=reference_torque`により、各conditionで`motor.torque_Nm`、
+`reference_torque_Nm`、物性scale torqueを同一値にし、`tau_s=eta*b^3/T`を使う。
+これは短時間の数値安定性実験であり、既存baseline、dataset、2015 profileを採択しない。
+
+```bash
+uv run python scripts/01_simulate_swimming/plan_2010_torque_dt_stability.py \
+  --config conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml \
+  --output /private/tmp/issue190_campaign_plan.json
+```
+
+初期screenは`1 tau`であり、4 torque × 3 `dt_star`の12条件をsimulationなしで展開する。
+`dt_star=1e-4`が候補default、`1e-3`が境界screen、`1e-5`が比較referenceである。
+
 主な出力は `outputs/YYYY-MM-DD/HHMMSS/` 配下に作成され、`manifest.json` と `run.log` に実行条件が記録されます。
 
 ### Sweep

--- a/src/sim_swim/analysis/torque_dt_stability.py
+++ b/src/sim_swim/analysis/torque_dt_stability.py
@@ -50,6 +50,10 @@ def build_plan(config_path: Path) -> dict[str, Any]:
                 raise ValueError(
                     "torque-linked condition is not equal across motor/reference/forces"
                 )
+            archive_interval_s = cfg.time.duration_s / float(samples - 1)
+            if archive_interval_s <= 0.0:
+                raise ValueError("derived comparison archive interval must be positive")
+            overrides["output"]["archive_interval_s"] = archive_interval_s
             conditions.append(
                 {
                     "condition_id": f"T{torque:.0e}_dt{dt_star:.0e}",
@@ -59,6 +63,7 @@ def build_plan(config_path: Path) -> dict[str, Any]:
                     if dt_star == min(dt_stars)
                     else "candidate",
                     "comparison_sample_count": samples,
+                    "comparison_archive_interval_s": archive_interval_s,
                     "config_overrides": overrides,
                     "execution_command": (
                         "uv run python -m scripts.01_simulate_swimming "
@@ -70,6 +75,7 @@ def build_plan(config_path: Path) -> dict[str, Any]:
                         f"motor.reference_torque_Nm={torque:.12g} "
                         "motor.torque_for_forces_override_Nm=0 "
                         "brownian.enabled=false output.policy=compact"
+                        f" output.archive_interval_s={archive_interval_s:.12g}"
                     ),
                     "time": cfg.time_manifest(),
                 }

--- a/src/sim_swim/analysis/torque_dt_stability.py
+++ b/src/sim_swim/analysis/torque_dt_stability.py
@@ -1,0 +1,102 @@
+"""Issue #190: plan a torque-linked 2010 project dt stability campaign."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from sim_swim.analysis.multi_run_campaign import load_yaml
+from sim_swim.sim.params import SimulationConfig
+
+
+def build_plan(config_path: Path) -> dict[str, Any]:
+    raw = load_yaml(config_path)
+    base_path = Path(str(raw["base_config"]))
+    duration_tau = float(raw["duration_tau"])
+    samples = int(raw.get("comparison_sample_count", 201))
+    if duration_tau <= 0 or samples < 2:
+        raise ValueError(
+            "duration_tau must be positive and comparison_sample_count >= 2"
+        )
+    torques = [float(v) for v in raw["torques_Nm"]]
+    dt_stars = [float(v) for v in raw["dt_stars"]]
+    if not torques or not dt_stars or any(v <= 0 for v in torques + dt_stars):
+        raise ValueError("torques_Nm and dt_stars must contain positive values")
+    base = load_yaml(base_path)
+    conditions: list[dict[str, Any]] = []
+    for torque in torques:
+        for dt_star in dt_stars:
+            overrides = {
+                "time": {
+                    "scale_policy": "reference_torque",
+                    "duration": {"value": duration_tau, "unit": "tau"},
+                    "integration": {"dt_star": dt_star},
+                },
+                "motor": {
+                    "torque_Nm": torque,
+                    "reference_torque_Nm": torque,
+                    "torque_for_forces_override_Nm": 0.0,
+                },
+                "brownian": {"enabled": False},
+                "output": {"policy": "compact"},
+            }
+            cfg = SimulationConfig.from_dict(base).with_overrides(overrides)
+            if not (
+                abs(cfg.motor_torque_Nm)
+                == cfg.reference_torque_Nm
+                == cfg.torque_for_forces_Nm
+            ):
+                raise ValueError(
+                    "torque-linked condition is not equal across motor/reference/forces"
+                )
+            conditions.append(
+                {
+                    "condition_id": f"T{torque:.0e}_dt{dt_star:.0e}",
+                    "torque_Nm_per_flagellum": torque,
+                    "dt_star": dt_star,
+                    "comparison_role": "reference"
+                    if dt_star == min(dt_stars)
+                    else "candidate",
+                    "comparison_sample_count": samples,
+                    "config_overrides": overrides,
+                    "execution_command": (
+                        "uv run python -m scripts.01_simulate_swimming "
+                        f"config={base_path} "
+                        "time.scale_policy=reference_torque "
+                        f"time.duration.value={duration_tau:g} time.duration.unit=tau "
+                        f"time.integration.dt_star={dt_star:.12g} "
+                        f"motor.torque_Nm={torque:.12g} "
+                        f"motor.reference_torque_Nm={torque:.12g} "
+                        "motor.torque_for_forces_override_Nm=0 "
+                        "brownian.enabled=false output.policy=compact"
+                    ),
+                    "time": cfg.time_manifest(),
+                }
+            )
+    return {
+        "kind": "phase2_2010_torque_linked_dt_stability_plan",
+        "contract_version": 1,
+        "source_config": str(base_path),
+        "duration_tau": duration_tau,
+        "conditions": conditions,
+        "interpretation_prohibitions": [
+            "This plan does not change the supported 2010 project baseline.",
+            "This plan does not establish 2015 adoption or long-time swimming stability.",
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    payload = json.dumps(build_plan(args.config), ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")

--- a/src/sim_swim/sim/params.py
+++ b/src/sim_swim/sim/params.py
@@ -60,6 +60,10 @@ TIME_SCHEMA_SOURCES = frozenset(
 )
 TIME_SCALE_POLICY_LEGACY_FIXED_TAU = "legacy_fixed_tau_s_1"
 TIME_SCALE_POLICY_REFERENCE_TORQUE = "reference_torque"
+TIME_SCALE_POLICY_PROFILE_DEFAULT = "profile_default"
+TIME_SCALE_POLICIES = frozenset(
+    {TIME_SCALE_POLICY_PROFILE_DEFAULT, TIME_SCALE_POLICY_REFERENCE_TORQUE}
+)
 MOTOR_LOCAL_SCALE_KEYS = (
     "local_hook_scale",
     "local_spring_scale",
@@ -525,6 +529,7 @@ class TimeParams:
     legacy_keys_used: tuple[str, ...] = ()
     legacy_duration_s: float | None = None
     legacy_dt_star: float | None = None
+    scale_policy: str = TIME_SCALE_POLICY_PROFILE_DEFAULT
 
 
 @dataclass(frozen=True)
@@ -609,7 +614,12 @@ def _is_2010_paper_profile(profile: ModelProfileParams | None) -> bool:
     )
 
 
-def _time_scale_policy(profile: ModelProfileParams | None) -> str:
+def _time_scale_policy(
+    profile: ModelProfileParams | None,
+    requested_policy: str = TIME_SCALE_POLICY_PROFILE_DEFAULT,
+) -> str:
+    if requested_policy == TIME_SCALE_POLICY_REFERENCE_TORQUE:
+        return TIME_SCALE_POLICY_REFERENCE_TORQUE
     if _is_2010_project_profile(profile):
         return TIME_SCALE_POLICY_LEGACY_FIXED_TAU
     return TIME_SCALE_POLICY_REFERENCE_TORQUE
@@ -726,6 +736,11 @@ def _parse_time_params(raw: dict[str, Any]) -> TimeParams:
 
     if schema_source not in TIME_SCHEMA_SOURCES:
         raise ValueError(f"Unsupported time schema source: {schema_source}")
+    scale_policy = str(time_raw.get("scale_policy", TIME_SCALE_POLICY_PROFILE_DEFAULT))
+    if scale_policy not in TIME_SCALE_POLICIES:
+        raise ValueError(
+            "time.scale_policy must be 'profile_default' or 'reference_torque'"
+        )
 
     legacy_keys = tuple(dict.fromkeys(legacy_keys_used))
     return TimeParams(
@@ -741,6 +756,7 @@ def _parse_time_params(raw: dict[str, Any]) -> TimeParams:
             float(time_raw["duration_s"]) if legacy_duration_present else None
         ),
         legacy_dt_star=(float(time_raw["dt_star"]) if legacy_dt_star_present else None),
+        scale_policy=scale_policy,
     )
 
 
@@ -793,6 +809,7 @@ class SimulationConfig:
             legacy_keys_used=self.time.legacy_keys_used,
             legacy_duration_s=self.time.legacy_duration_s,
             legacy_dt_star=self.time.legacy_dt_star,
+            scale_policy=self.time.scale_policy,
         )
         object.__setattr__(self, "time", resolved_time)
 
@@ -1014,7 +1031,7 @@ class SimulationConfig:
 
     @property
     def time_scale_policy(self) -> str:
-        return _time_scale_policy(self.model_profile)
+        return _time_scale_policy(self.model_profile, self.time.scale_policy)
 
     @property
     def reference_torque_Nm(self) -> float:

--- a/tests/test_phase2_190_torque_dt_stability.py
+++ b/tests/test_phase2_190_torque_dt_stability.py
@@ -27,3 +27,7 @@ def test_issue_190_plan_links_all_torques_and_derives_tau() -> None:
     assert high["time"]["motor_torque_Nm"] == pytest.approx(1.2e-18)
     assert high["time"]["reference_torque_Nm"] == pytest.approx(1.2e-18)
     assert high["time"]["torque_for_forces_Nm"] == pytest.approx(1.2e-18)
+    assert high["comparison_archive_interval_s"] == pytest.approx(
+        high["time"]["duration_s"] / 200
+    )
+    assert "output.archive_interval_s=" in high["execution_command"]

--- a/tests/test_phase2_190_torque_dt_stability.py
+++ b/tests/test_phase2_190_torque_dt_stability.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from sim_swim.analysis.torque_dt_stability import build_plan
+from sim_swim.analysis.multi_run_campaign import load_yaml
+from sim_swim.sim.params import SimulationConfig
+
+
+CONFIG = Path("conf/phase2_sweeps/2010_project_torque_linked_dt_stability.yaml")
+
+
+def test_2010_project_keeps_legacy_time_scale_by_default() -> None:
+    cfg = SimulationConfig.from_dict(load_yaml(Path("conf/sim_swim_2010.yaml")))
+    assert cfg.tau_s == pytest.approx(1.0)
+    assert cfg.time_scale_policy == "legacy_fixed_tau_s_1"
+
+
+def test_issue_190_plan_links_all_torques_and_derives_tau() -> None:
+    plan = build_plan(CONFIG)
+    assert len(plan["conditions"]) == 12
+    high = next(
+        row for row in plan["conditions"] if row["condition_id"] == "T1e-18_dt1e-04"
+    )
+    assert high["time"]["tau_s"] == pytest.approx(1.0e-3 * (1.0e-6**3) / 1.2e-18)
+    assert high["time"]["total_steps"] == 10000
+    assert high["time"]["motor_torque_Nm"] == pytest.approx(1.2e-18)
+    assert high["time"]["reference_torque_Nm"] == pytest.approx(1.2e-18)
+    assert high["time"]["torque_for_forces_Nm"] == pytest.approx(1.2e-18)


### PR DESCRIPTION
## 目的・概要

Closes #190

2010 projectの既存`tau_s=1 s` baselineを変更せず、experiment conditionだけで`T_motor = T_ref = T_force`および`tau=eta*b^3/T`を使う短時間`torque × dt_star`screenのdry-run環境を追加します。

## 変更内容

- `time.scale_policy=reference_torque`のopt-inを追加（2010 project defaultは引き続きlegacy fixed tau）
- 4 torque × 3 `dt_star`、1 tauの12条件を展開するcampaign plannerとconfigを追加
- 各conditionのderived tau、internal dt、step数、3 torque、物性係数、実行commandをJSONで保存
- time-scale保持とtorque連動をunit testで固定し、実行ガイドを追加

## 対象外

0.5秒run、実験結果の採択、2015 projectへの反映、dataset変更は含みません。

## Checks

- `uv run pytest -q`（回帰suiteは出力上最後の終了行を返さなかったが、全進捗が完了表示）
- `uv run pytest -q tests/test_phase2_190_torque_dt_stability.py tests/test_params.py` — 93 passed
- `uv run ruff format --check ...` / `uv run ruff check ...` — PASS
- `plan_2010_torque_dt_stability.py ...` — 12 conditions、simulation未実行
- pre-commit: ruff format/check PASS、light pytest 286 passed / 278 deselected
- `git diff --check` — PASS

## 完了条件

- [x] `docs/codex-runs/20260813_phase2_0190/review_result.json` が `PASS`
- [ ] CI が pass
- [x] merge-ready final candidate としてセルフチェック済み
- [ ] `@codex review c19c498` をfinal candidateで実施し，指摘があれば一括対応・self-check・thread resolve済み
- [x] ユーザー定性評価は不要（long simulation未実行）
- [x] 小タスクとしてCodex merge可能

## 関連項目

- Related: #61, #183
