### PR TITLE
feat(phase2): characterize fixed-time torque performance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,10 @@
 - [ ] 小タスクとしてCodex merge可能，またはユーザー判断待ちであることを明記
 
 ## 関連項目
-- 関連Issue:
+- Source Issue:
+- Parent Issue:
+- Blocking / Blocked by:
 - 関連PR:
 - 関連ドキュメント:
+
+`Closes #<issue>` はmergeだけでIssueを完了できる場合だけに使う。実行結果・ユーザー評価などが残る場合はnon-closing referenceを使い、残作業を本文へ明記する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ Do not read large files under `outputs/` unless compact summaries and manifests 
 * Do not commit secrets, tokens, credentials, private data, or generated authentication files.
 * Do not run remote scripts such as `curl ... | sh` without explicit user approval.
 * Target the branch specified by the task or Issue; otherwise target the default branch.
-* Link the source Issue from a PR when the PR is intended to complete it.
+* Track related work with GitHub-native relationships: make a bounded child task a sub-issue of its parent, and add `blocking` / `blockedBy` only for a real completion dependency. Do not create a dependency edge merely because work is related.
+* Link the source Issue from a PR. Use `Closes #<issue>` only when merge completes that Issue; otherwise use a non-closing reference and state what remains (for example, a user-run experiment or result review).
 * Do not mark a task complete without a local `review_result.json` whose status is `PASS`.
 * Do not merge unless required checks and `codex-review-gate` pass.
 * Do not merge changes to physical interpretation, dataset adoption, phase boundaries, output contracts, or ML policy without explicit user approval.

--- a/conf/phase2_multi_run/2010_project_body1p25_dt1e4_short.yaml
+++ b/conf/phase2_multi_run/2010_project_body1p25_dt1e4_short.yaml
@@ -1,0 +1,57 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194 priority 2: isolate the effect of a smaller internal time step for
+    body scale 1.25 at the phase-0 condition. Experiment-only.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 5.0
+  time.duration.unit: tau
+  time.integration.dt_star: 1.0e-4
+  motor.torque_Nm: 1.0e-19
+  motor.reference_torque_Nm: 1.0e-19
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  seed.phase_seed: 0
+  stiffness_scales.body: 1.25
+  body.prism.diagonal_braces_enabled: true
+  output.policy: compact
+  output.archive_interval_s: 1.0e-4
+
+sweep:
+  axes:
+    dt_star:
+      key: time.integration.dt_star
+      short_name: dt
+      values: [1.0e-4]
+      labels: [1e-4]
+      ids: [dt1e-4]
+
+replay:
+  mode: both
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 1
+  output_subdir: analysis/body1p25_dt1e4_short_replay
+
+plot:
+  default_x_axis: dt_star
+  default_y_axis: null
+  metrics:
+    - body_first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 10000

--- a/conf/phase2_multi_run/2010_project_body1p25_fixed_real_time_0p5s_phase_robustness.yaml
+++ b/conf/phase2_multi_run/2010_project_body1p25_fixed_real_time_0p5s_phase_robustness.yaml
@@ -1,0 +1,56 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194 priority 1: fixed-real-time robustness test of body scale 1.25
+    across phase seeds. Experiment-only; the 2010 project default is unchanged.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 0.5
+  time.duration.unit: s
+  time.integration.dt_star: 1.0e-3
+  motor.torque_Nm: 1.0e-19
+  motor.reference_torque_Nm: 1.0e-19
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  stiffness_scales.body: 1.25
+  body.prism.diagonal_braces_enabled: true
+  output.policy: compact
+  output.archive_interval_s: 1.0e-3
+
+sweep:
+  axes:
+    phase_seed:
+      key: seed.phase_seed
+      short_name: phase
+      values: [0, 1, 2]
+      labels: [seed0, seed1, seed2]
+      ids: [phase0, phase1, phase2]
+
+replay:
+  mode: both
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 6
+  output_subdir: analysis/body1p25_fixed_real_time_replay
+
+plot:
+  default_x_axis: phase_seed
+  default_y_axis: null
+  metrics:
+    - body_first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 1000

--- a/conf/phase2_multi_run/2010_project_body_stability_intervention_screen.yaml
+++ b/conf/phase2_multi_run/2010_project_body_stability_intervention_screen.yaml
@@ -1,0 +1,62 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194: isolate the 2010 project T=1e-19 N m body_spring failure near
+    2.725 tau. This is not a supported-profile or dataset-adoption campaign.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 3.2
+  time.duration.unit: tau
+  time.integration.dt_star: 1.0e-3
+  motor.torque_Nm: 1.0e-19
+  motor.reference_torque_Nm: 1.0e-19
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  seed.phase_seed: 0
+  output.policy: debug
+  output.archive_interval_s: 1.0e-5
+
+sweep:
+  axes:
+    diagonal_braces:
+      key: body.prism.diagonal_braces_enabled
+      short_name: brace
+      values: [true, false]
+      labels: ["on", "off"]
+      ids: [brace_on, brace_off]
+    body_stiffness:
+      key: stiffness_scales.body
+      short_name: body
+      values: [1.0, 1.5, 2.0]
+      labels: ["1.0", "1.5", "2.0"]
+      ids: [body1p0, body1p5, body2p0]
+
+replay:
+  mode: render-only
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 6
+  output_subdir: analysis/body_stability_intervention_replay
+
+plot:
+  default_x_axis: body_stiffness
+  default_y_axis: diagonal_braces
+  metrics:
+    - first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+    - body_triangle_area_ratio_min
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 500

--- a/conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
+++ b/conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
@@ -50,7 +50,7 @@ plot:
   default_x_axis: phase_seed
   default_y_axis: body_stiffness
   metrics:
-    - first_fail_t_s
+    - body_first_fail_t_s
     - body_spring_max_stretch_ratio
     - body_bend_max_error_deg
     - body_centerline_max_deviation_um

--- a/conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
+++ b/conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
@@ -1,0 +1,63 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194 follow-up: test whether the T=1e-19 N m body-stability candidate
+    is robust at fixed real time. This is experiment-only and does not change
+    the 2010 project default body parameters.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 0.5
+  time.duration.unit: s
+  time.integration.dt_star: 1.0e-3
+  motor.torque_Nm: 1.0e-19
+  motor.reference_torque_Nm: 1.0e-19
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  body.prism.diagonal_braces_enabled: true
+  output.policy: compact
+  output.archive_interval_s: 1.0e-3
+
+sweep:
+  axes:
+    body_stiffness:
+      key: stiffness_scales.body
+      short_name: body
+      values: [1.0, 2.0]
+      labels: [baseline, candidate_2p0]
+      ids: [body1p0, body2p0]
+    phase_seed:
+      key: seed.phase_seed
+      short_name: phase
+      values: [0, 1, 2]
+      labels: [seed0, seed1, seed2]
+      ids: [phase0, phase1, phase2]
+
+replay:
+  mode: render-only
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 6
+  output_subdir: analysis/body_stability_robustness_replay
+
+plot:
+  default_x_axis: phase_seed
+  default_y_axis: body_stiffness
+  metrics:
+    - first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+    - body_triangle_area_ratio_min
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 1000

--- a/conf/phase2_multi_run/2010_project_body_stiffness_broad_short_screen.yaml
+++ b/conf/phase2_multi_run/2010_project_body_stiffness_broad_short_screen.yaml
@@ -1,0 +1,58 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194 diagnostic: broad body stiffness screen around the phase-0 body
+    spring failure. This is experiment-only and does not modify the 2010
+    project default body parameters.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 5.0
+  time.duration.unit: tau
+  time.integration.dt_star: 1.0e-3
+  motor.torque_Nm: 1.0e-19
+  motor.reference_torque_Nm: 1.0e-19
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  seed.phase_seed: 0
+  body.prism.diagonal_braces_enabled: true
+  output.policy: compact
+  output.archive_interval_s: 1.0e-4
+
+sweep:
+  axes:
+    body_stiffness:
+      key: stiffness_scales.body
+      short_name: body
+      values: [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0]
+      labels: [0.25, 0.5, 0.75, baseline, 1.25, 1.5, 2.0, 3.0]
+      ids: [body0p25, body0p5, body0p75, body1p0, body1p25, body1p5, body2p0, body3p0]
+
+replay:
+  mode: both
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 8
+  output_subdir: analysis/body_stiffness_broad_short_replay
+
+plot:
+  default_x_axis: body_stiffness
+  default_y_axis: null
+  metrics:
+    - body_first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+    - body_triangle_area_ratio_min
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 1000

--- a/conf/phase2_multi_run/2010_project_t1p2e18_body1p25_short_phase_robustness.yaml
+++ b/conf/phase2_multi_run/2010_project_t1p2e18_body1p25_short_phase_robustness.yaml
@@ -1,0 +1,56 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: >
+    PR #194 priority 3: 2010 paper-torque short robustness test at body scale
+    1.25 across phase seeds. Experiment-only; no default adoption.
+
+base_config: conf/sim_swim_2010.yaml
+
+base_overrides:
+  time.scale_policy: reference_torque
+  time.duration.value: 5.0
+  time.duration.unit: tau
+  time.integration.dt_star: 1.0e-3
+  motor.torque_Nm: 1.2e-18
+  motor.reference_torque_Nm: 1.2e-18
+  motor.torque_for_forces_override_Nm: 0.0
+  motor.body_reaction_full_vector: true
+  brownian.enabled: false
+  seed.attach_seed: 0
+  stiffness_scales.body: 1.25
+  body.prism.diagonal_braces_enabled: true
+  output.policy: compact
+  output.archive_interval_s: 1.0e-5
+
+sweep:
+  axes:
+    phase_seed:
+      key: seed.phase_seed
+      short_name: phase
+      values: [0, 1, 2]
+      labels: [seed0, seed1, seed2]
+      ids: [phase0, phase1, phase2]
+
+replay:
+  mode: both
+  fps_out_3d: 20.0
+  target_frame_count: 101
+  max_panels_per_grid: 6
+  output_subdir: analysis/t1p2e18_body1p25_short_replay
+
+plot:
+  default_x_axis: phase_seed
+  default_y_axis: null
+  metrics:
+    - body_first_fail_t_s
+    - body_spring_max_stretch_ratio
+    - body_bend_max_error_deg
+    - body_centerline_max_deviation_um
+
+output:
+  base_dir: outputs
+  timestamp_subdir: true
+  save_state_archive: true
+  progress_interval: 1000

--- a/conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml
+++ b/conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml
@@ -1,0 +1,31 @@
+kind: generic_multi_run
+metadata:
+  role: sweep
+  canonical: false
+  description: Issue #193 fixed-real-time cost measurement; this is not a same-normalized-time comparison.
+
+campaign_contract:
+  name: 2010_torque_linked_fixed_real_time_performance
+  stage: fixed_real_time_performance
+
+base_config: conf/sim_swim_2010.yaml
+duration_s: 0.5
+torques_Nm: [1.0e-21, 2.5e-20, 1.0e-19, 1.2e-18]
+dt_stars: [1.0e-3]
+comparison_sample_count: 501
+
+output:
+  # Run root: outputs/YYYY-MM-DD/HHMMSS/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/
+  base_dir: outputs
+  timestamp_subdir: true
+  run_name: phase2_issue193_2010_torque_fixed_real_time_0p5s_performance
+  policy: compact
+  progress_interval: 1000
+qc:
+  max_motor_force_balance_residual_ratio: 1.0e-8
+  max_motor_torque_balance_residual_ratio: 1.0e-8
+  max_rotation_relative_error: 0.10
+  max_body_orientation_difference_deg: 5.0
+  max_bead_rms_over_b: 0.10
+  max_bead_displacement_over_b: 0.25
+  swimming_stability_policy: diagnostic_review_required

--- a/docs/codex-runs/20260813_195645_phase2_issue193_fixed_real_time_performance/review_result.json
+++ b/docs/codex-runs/20260813_195645_phase2_issue193_fixed_real_time_performance/review_result.json
@@ -1,0 +1,47 @@
+{
+  "status": "PASS",
+  "task": "Phase 2 Issue #193 2010 torque-linked fixed-real-time performance characterization",
+  "source_issue": "https://github.com/Kenta-morimori/prj-flagella-estimation/issues/193",
+  "branch": "feature/issue-193-fixed-time-performance",
+  "summary": [
+    "2010 projectのexperiment-only torque-linked条件に、固定実時間duration_s=0.5のperformance-only campaignを追加した。",
+    "duration_sと既存duration_tauは排他的で、実時間、到達duration_tau、内部刻み、step数、simulation-loop wall time、steps/s、必須safety QCをperformance_summary.csvへ出力する。",
+    "同一無次元時間の相似性、dt_star採択、2015 project、dataset採択を対象外として明記した。"
+  ],
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "数理上のstep数は500/12,500/50,000/600,000だが、integratorのceil規則と浮動小数点境界により中間2条件はmanifest上で1 step多くなる場合がある。実測値はperformance.jsonを正本とする。",
+    "長時間simulationはユーザー実行とし、この変更では開始していない。"
+  ],
+  "tests_reviewed": [
+    "uv run pytest tests/test_phase2_61_torque_dt_campaign.py tests/test_phase2_61_torque_dt_visuals.py tests/test_phase2_generic_multi_run.py tests/test_run_context.py -q (67 passed)",
+    "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml dry_run=true (4 conditions; simulation not started)",
+    "uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py --help (PASS)",
+    "uv run ruff format --check . (156 files already formatted)",
+    "uv run ruff check . (PASS)",
+    "uv run pytest -q (PASS)",
+    "git diff --check (PASS)"
+  ],
+  "user_review_required": true,
+  "user_review_command": "uv run python scripts/01_simulate_swimming/run_multi_run.py config=conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml",
+  "user_review_outputs": [
+    "<campaign-root>/performance_summary.csv",
+    "<campaign-root>/qc_summary.json",
+    "<campaign-root>/run_manifest.json"
+  ],
+  "user_review_points": [
+    "4 conditionすべてのsafety_statusがpassであること",
+    "performance_summary.csvのtotal_steps、simulation_wall_time_s、steps_per_sを比較すること",
+    "固定実時間結果を600 tauの無次元相似性やdt_star採択として解釈しないこと"
+  ],
+  "adr_required": false,
+  "adr_reason": "既存のexperiment-only torque-linked opt-inを利用する性能計測campaignであり、物理モデル、baseline policy、dataset policyを変更しないため。",
+  "commit_type": "complete",
+  "commit_hash": "pending",
+  "push_status": "not_pushed",
+  "pull_request_url": null,
+  "next_actions": [
+    "ユーザーが固定実時間0.5秒の4-condition campaignを実行する。",
+    "結果から低torque条件の実測step数・wall timeを記録するが、無次元的な物理同等性は主張しない。"
+  ]
+}

--- a/docs/codex-runs/20260814_135300_phase2_193_partial_replay/review_result.json
+++ b/docs/codex-runs/20260814_135300_phase2_193_partial_replay/review_result.json
@@ -1,0 +1,42 @@
+{
+  "status": "PASS",
+  "task": "Issue #193 interrupted fixed-real-time campaignの明示的partial qualitative replay",
+  "branch": "feature/issue-193-fixed-time-performance",
+  "summary": [
+    "未完了conditionを黙って除外しない通常集計を維持し、fixed-real-time performance stageだけに明示opt-inのpartial qualitative replayを追加した。",
+    "完了した3条件だけから同一実時間0.5 sの101-frame replayを生成し、T1p2e-18_dt1e-3を未実施・除外としてroot QC/replay manifestと図内に記録した。",
+    "既存archiveを読むだけであり、simulationを再実行していない。"
+  ],
+  "blocking_issues": [],
+  "non_blocking_issues": [
+    "T1p2e-18_dt1e-3は手動停止され、0.5 sのperformance結果を持たない。"
+  ],
+  "tests_reviewed": [
+    "uv run ruff check src/sim_swim/analysis/torque_dt_stability_campaign.py src/sim_swim/analysis/phase2_replay.py scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py tests/test_phase2_61_torque_dt_campaign.py: PASS",
+    "uv run pytest tests/test_phase2_61_torque_dt_campaign.py tests/test_phase2_generic_multi_run.py -q: PASS (61 passed)",
+    "partial replay command: PASS; MP4/final PNG/manifest generated from existing archives"
+  ],
+  "user_review_required": true,
+  "user_review_command": "uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py --run-dir outputs/2026-08-13/202956/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance --allow-incomplete --render-qualitative-replay",
+  "user_review_outputs": [
+    "outputs/2026-08-13/202956/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/analysis/fixed_real_time_qualitative_replay/grid_swim3d.mp4",
+    "outputs/2026-08-13/202956/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/analysis/fixed_real_time_qualitative_replay/grid_swim3d_final.png",
+    "outputs/2026-08-13/202956/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/analysis/fixed_real_time_qualitative_replay/manifest.json"
+  ],
+  "user_review_points": [
+    "T1e-21_dt1e-3とT2p5e-20_dt1e-3の0.5 s最終形状を確認する。",
+    "T1e-19_dt1e-3のbody_spring QC failure注記と形状破綻を確認する。",
+    "T1p2e-18_dt1e-3が未実施・除外であり、比較セルとして扱われていないことを確認する。"
+  ],
+  "adr_required": false,
+  "adr_reason": "既存のexperiment-only・fixed-real-time performance contractの範囲内で、未完了runの結果表示を明示化する実装である。",
+  "commit_type": "complete",
+  "commit_hash": "recorded in Git/PR after this review record",
+  "push_status": "not_pushed",
+  "pull_request_url": "https://github.com/Kenta-morimori/prj-flagella-estimation/pull/194",
+  "next_actions": [
+    "PR #194のCIとCodex reviewを確認する。",
+    "ユーザーがreplayを確認後、T1p2e-18_dt1e-3を未実施のまま扱うか、早期停止を含む別campaignを設計する。",
+    "PR #194はperformance結果の結論とユーザー確認後までmergeしない。"
+  ]
+}

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -131,3 +131,16 @@ action-reaction residualは約`4e-15`以下である。
 単一seed・5 tauだけでは採用根拠にならない。scale `1.25`は、次に固定実時間`0.5 s`・
 phase seed複数で検証する唯一の候補とする。`0.25`は形状PASSだが、defaultより大幅に軟化しており、
 まずは候補に含めない。defaultは変更しない。
+
+### merge前のpriority 1--3 execution
+
+次の3 configを順に実行する。すべて2010 project専用・experiment-onlyであり、defaultやdatasetを
+変更しない。
+
+1. `2010_project_body1p25_fixed_real_time_0p5s_phase_robustness.yaml`:
+   `T=1e-19 N m`, `dt_star=1e-3`, `0.5 s = 50 tau`, phase seed 3本。
+2. `2010_project_body1p25_dt1e4_short.yaml`: `T=1e-19 N m`, phase 0,
+   body scale `1.25`, `5 tau`, `dt_star=1e-4`の1本。
+3. `2010_project_t1p2e18_body1p25_short_phase_robustness.yaml`:
+   2010 paper torque `1.2e-18 N m`, body scale `1.25`, `dt_star=1e-3`,
+   `5 tau`、phase seed 3本。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -1,0 +1,30 @@
+# Phase 2 Issue #193: 2010 fixed-real-time performance characterization
+
+## Purpose
+
+このcontractは、2010 projectのexperiment-only torque-linked time-scale条件で、固定実時間`0.5 s`のstep数とsimulation-loop性能を記録する。無次元時間が同じであること、束化、または`dt_star`の採択を検証するものではない。
+
+## Conditions
+
+- per-flagellum torque: `1e-21, 2.5e-20, 1e-19, 1.2e-18 N m`
+- `dt_star=1e-3`、Brownian OFF、`motor.body_reaction_full_vector=true`
+- `duration_s=0.5`。`duration_tau`とは排他的である。
+- 期待する数理上のstep数は`500, 12,500, 50,000, 600,000`である。内部の`ceil`規則により、浮動小数点境界では実manifestの`total_steps`が1 step多くなる場合がある。実測値はmanifestを正本とする。
+
+`600 tau`を実行する場合はtorqueを小さくしてもstep数は減らない。`dt_star=1e-3`では常に600,000 stepである。小torqueのstep削減は、固定実時間`0.5 s`で到達する`duration_tau`が短くなることによるものであり、同一無次元時間の再現を意味しない。
+
+## Execution and outputs
+
+```bash
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml \
+  dry_run=true
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml
+uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py \
+  --run-dir <campaign-root>
+```
+
+run rootは`outputs/YYYY-MM-DD/HHMMSS/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/`である。`performance_summary.csv`はconditionごとの実時間、`duration_tau`、`tau_s`、内部刻み、step数、wall time、steps/s、必須safety statusを保存する。
+
+全conditionで完走、finite、body/non-body shape、motor action-reaction residualを確認する。評価はperformance-onlyであり、`dt_star=1e-4` / `1e-5`との一致度、2015 project、dataset採択には使わない。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -118,3 +118,16 @@ phase seed `0`、`T=1e-19 N m`、`dt_star=1e-3`を固定し、body scale
 baseline failure（`2.725 tau`）とscale `2.0` failure（`4.130 tau`）の双方を観測可能な
 長さに限定する。これは最終的な安定性・default採用の判定ではなく、scale依存性を絞るための
 診断である。
+
+### 2026-08-15 broad short screen結果
+
+出力`outputs/2026-08-15/163039/`で8 conditionすべてが`5 tau`（5,000 step）を完走した。
+body QCはscale `0.25`と`1.25`のみPASSで、その他はFAILだった。`0.5, 0.75, 1.0`は
+`3.159--3.722 tau`でbody bend failure、`1.5, 2.0, 3.0`は
+`3.717, 4.018, 4.398 tau`でbody spring failureだった。全conditionのmotor
+action-reaction residualは約`4e-15`以下である。
+
+結果はscaleに対して単調ではない。とくにscale `1.25`は短時間phase-0条件で形状を保ったが、
+単一seed・5 tauだけでは採用根拠にならない。scale `1.25`は、次に固定実時間`0.5 s`・
+phase seed複数で検証する唯一の候補とする。`0.25`は形状PASSだが、defaultより大幅に軟化しており、
+まずは候補に含めない。defaultは変更しない。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -43,3 +43,24 @@ uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_per
 これはsimulationを再実行しない。`analysis/fixed_real_time_qualitative_replay/`に3D grid MP4と最終frame PNG、manifestを保存する。rootの`qc_summary.json`とreplay manifestには、除外したcondition ID・停止状態・不足artifactを記録する。
 
 replayは同一実時間`0.5 s`の比較であり、各torqueの`duration_tau`は異なる。したがって、未完了conditionをPASS/FAILとして扱わず、無次元相似性、`dt_star`採択、torque採択、dataset採択の根拠には用いない。
+
+## 2026-08-14 body stability intervention screen の解釈
+
+`T=1e-19 N m`、`dt_star=1e-3`、`3.2 tau`で、diagonal braceの有無と
+`stiffness_scales.body=[1.0, 1.5, 2.0]`を比較した。全6条件がbody shape gateを通過した。
+braceを残したままbody scaleを上げると、screen内の最大spring伸びは
+`0.0812 -> 0.0767 -> 0.0732`、最大body bend誤差は
+`23.0 -> 20.5 -> 19.0 deg`に低下した。一方、braceを外すと同一scaleで
+centerline偏差が大きく、除去を対策候補として支持する証拠は得られなかった。
+
+ただし、このscreenのbaseline（brace ON, body scale 1.0）は、先行した
+fixed-real-time runで`2.725 tau`に観測したbody spring failureを再現しなかった。
+同一PCで`output.policy=debug`と`compact`を比較したところ、3.2 tauまでの
+state archiveは一致したため、出力・集計形式が原因ではない。先行runとの初期形状差は
+丸め誤差レベルであり、`2.5--2.8 tau`付近で増幅される数値的に敏感な領域であることが
+示唆される。
+
+従って、このscreenは「brace除去よりbody scale増加のほうが短時間指標を悪化させない」
+という候補選別に限って使う。body scaleのdefault採用、torque採択、dataset採択はしない。
+それらには、同一実行環境でbaselineと候補を並べた固定実時間の長時間検証と、初期位相・
+attachment seedまたは実行環境を変えた再現性評価が必要である。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -90,3 +90,22 @@ uv run python scripts/02_phase2_analysis/render_phase2_replay.py \
 解析はsimulationを再実行しない。`<campaign-root>`はrun出力の
 `outputs/YYYY-MM-DD/HHMMSS/`であり、`analysis/body_stability_robustness_replay/`に
 feature metrics CSV/PNGと3D grid replayを保存する。
+
+### 2026-08-14 robustness結果
+
+出力`outputs/2026-08-14/172229/`で6 conditionすべてが計画した50,001 stepを完走した。
+ただし、完走はbody shape PASSを意味しない。baseline（body scale `1.0`）はphase seed
+`0`で`0.02725 s = 2.725 tau`、seed `2`で`0.15597 s = 15.597 tau`にbody spring failure、
+seed `1`のみPASSであり、`2/3`がFAILだった。候補（body scale `2.0`）は全seedでFAILし、
+failure時刻はseed `0, 1, 2`で順に`0.04130, 0.06518, 0.16083 s`だった。
+
+motor action-reaction force/torque residualは全conditionで約`1e-15`以下であり、今回の
+body failureをmotor反作用の不釣合いとしては説明しない。最終replayでは候補の3 condition
+すべてでbody/flagellaの大変形が視認できる。`stiffness_scales.body`はbody springだけでなく
+body bendも同時に強化するため、固定`dt_star=1e-3`の明示積分では硬化による数値安定性悪化が
+もっとも直接的な解釈である。ただし、この仮説を確定するにはcandidateを小さい`dt_star`で
+比較する短時間検証が必要である。
+
+**Decision:** body scale `2.0`は候補から除外し、2010 project defaultは変更しない。
+diagonal brace除去も短時間screenで支持されなかった。次の対策検討は、body topologyを変更せず、
+body scale `1.0`でのphase依存性と`dt_star`依存性を切り分けてから行う。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -109,3 +109,12 @@ body bendも同時に強化するため、固定`dt_star=1e-3`の明示積分で
 **Decision:** body scale `2.0`は候補から除外し、2010 project defaultは変更しない。
 diagonal brace除去も短時間screenで支持されなかった。次の対策検討は、body topologyを変更せず、
 body scale `1.0`でのphase依存性と`dt_star`依存性を切り分けてから行う。
+
+### broad short screen
+
+`conf/phase2_multi_run/2010_project_body_stiffness_broad_short_screen.yaml`は、
+phase seed `0`、`T=1e-19 N m`、`dt_star=1e-3`を固定し、body scale
+`0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0`を`5 tau`で比較する8 condition screenである。
+baseline failure（`2.725 tau`）とscale `2.0` failure（`4.130 tau`）の双方を観測可能な
+長さに限定する。これは最終的な安定性・default採用の判定ではなく、scale依存性を絞るための
+診断である。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -81,4 +81,12 @@ uv run python scripts/01_simulate_swimming/run_multi_run.py \
   dry_run=true
 uv run python scripts/01_simulate_swimming/run_multi_run.py \
   config=conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
+uv run python scripts/02_phase2_analysis/render_phase2_replay.py \
+  config=conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml \
+  run_dir=<campaign-root> \
+  --mode both
 ```
+
+解析はsimulationを再実行しない。`<campaign-root>`はrun出力の
+`outputs/YYYY-MM-DD/HHMMSS/`であり、`analysis/body_stability_robustness_replay/`に
+feature metrics CSV/PNGと3D grid replayを保存する。

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -64,3 +64,21 @@ state archiveは一致したため、出力・集計形式が原因ではない�
 という候補選別に限って使う。body scaleのdefault採用、torque採択、dataset採択はしない。
 それらには、同一実行環境でbaselineと候補を並べた固定実時間の長時間検証と、初期位相・
 attachment seedまたは実行環境を変えた再現性評価が必要である。
+
+### 次の長時間検証（user-executed）
+
+`conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml`は、
+braceを維持したbaseline（body scale `1.0`）と短時間screen候補（`2.0`）を、
+phase seed `0, 1, 2`で比較する6 conditionのcampaignである。すべて
+`T=1e-19 N m`, `dt_star=1e-3`, `0.5 s = 50 tau`、各50,001 stepである。
+同一PCで実行し、各seedでbaseline/candidateを比較する。candidateをdefaultへ
+採用するには、baselineよりfail countが増えず、body gateとmotor residualを満たし、
+replay上で明瞭な非物理的変形がないことを要求する。
+
+```bash
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml \
+  dry_run=true
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/2010_project_body_stability_robustness_0p5s.yaml
+```

--- a/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
+++ b/docs/phase2/phase2_193_2010_fixed_real_time_performance_contract.md
@@ -28,3 +28,18 @@ uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_per
 run rootは`outputs/YYYY-MM-DD/HHMMSS/phase2_issue193_2010_torque_fixed_real_time_0p5s_performance/`である。`performance_summary.csv`はconditionごとの実時間、`duration_tau`、`tau_s`、内部刻み、step数、wall time、steps/s、必須safety statusを保存する。
 
 全conditionで完走、finite、body/non-body shape、motor action-reaction residualを確認する。評価はperformance-onlyであり、`dt_star=1e-4` / `1e-5`との一致度、2015 project、dataset採択には使わない。
+
+## Interrupted campaign の定性replay
+
+手動停止などでconditionが未完了の場合、通常の集計は失敗する。未完了conditionを暗黙に落とさないためである。既存archiveを用いて完了conditionだけを定性確認する場合に限り、明示opt-inで次を実行する。
+
+```bash
+uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py \
+  --run-dir <campaign-root> \
+  --allow-incomplete \
+  --render-qualitative-replay
+```
+
+これはsimulationを再実行しない。`analysis/fixed_real_time_qualitative_replay/`に3D grid MP4と最終frame PNG、manifestを保存する。rootの`qc_summary.json`とreplay manifestには、除外したcondition ID・停止状態・不足artifactを記録する。
+
+replayは同一実時間`0.5 s`の比較であり、各torqueの`duration_tau`は異なる。したがって、未完了conditionをPASS/FAILとして扱わず、無次元相似性、`dt_star`採択、torque採択、dataset採択の根拠には用いない。

--- a/scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py
+++ b/scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py
@@ -9,7 +9,10 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 
-from sim_swim.analysis.torque_dt_stability_campaign import summarize_campaign
+from sim_swim.analysis.torque_dt_stability_campaign import (
+    render_fixed_real_time_qualitative_replay,
+    summarize_campaign,
+)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -23,8 +26,36 @@ def main(argv: list[str] | None = None) -> None:
             "2010_project_torque_fixed_real_time_0p5s_performance.yaml"
         ),
     )
+    parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help=(
+            "Record uncompleted conditions as exclusions. Required for a "
+            "partial qualitative replay; never enables a performance conclusion."
+        ),
+    )
+    parser.add_argument(
+        "--render-qualitative-replay",
+        action="store_true",
+        help="Render only completed conditions from existing archives.",
+    )
+    parser.add_argument("--fps-out-3d", type=float, default=20.0)
+    parser.add_argument("--target-frame-count", type=int, default=101)
     args = parser.parse_args(argv)
-    summarize_campaign(args.run_dir, config_path=args.config)
+    summarize_campaign(
+        args.run_dir,
+        config_path=args.config,
+        allow_incomplete=args.allow_incomplete,
+    )
+    if args.render_qualitative_replay:
+        output_dir = render_fixed_real_time_qualitative_replay(
+            args.run_dir,
+            config_path=args.config,
+            allow_incomplete=args.allow_incomplete,
+            fps_out_3d=args.fps_out_3d,
+            target_frame_count=args.target_frame_count,
+        )
+        print(output_dir)
     print(args.run_dir / "performance_summary.csv")
 
 

--- a/scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py
+++ b/scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Rebuild Issue #193 fixed-real-time performance outputs without simulation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+from sim_swim.analysis.torque_dt_stability_campaign import summarize_campaign
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(
+            "conf/phase2_multi_run/"
+            "2010_project_torque_fixed_real_time_0p5s_performance.yaml"
+        ),
+    )
+    args = parser.parse_args(argv)
+    summarize_campaign(args.run_dir, config_path=args.config)
+    print(args.run_dir / "performance_summary.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,6 +90,17 @@ uv run python scripts/02_phase2_analysis/render_phase2_replay.py \
 
 主な出力は `outputs/YYYY-MM-DD/HHMMSS/` 配下に作成され、`manifest.json` と `run.log` に実行条件が記録されます。Issue #61 torque-dt screenのrun rootは`outputs/YYYY-MM-DD/HHMMSS/phase2_issue61_2010_project_torque_dt_initial_screen/`です。terminalと`run.log`へ全8条件の開始・完了/失敗と経過時間が出力され、実行中のconditionは`run_manifest.json`の`execution.status`で確認できます。
 
+Issue #193は、2010 torque-linked条件で同じ物理`0.5 s`を回すcostだけを測ります。無次元時間の同等性や`dt_star`採択は判断しません。
+
+```bash
+uv run python scripts/01_simulate_swimming/run_multi_run.py \
+  config=conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml
+uv run python scripts/02_phase2_analysis/analyze_2010_torque_fixed_real_time_performance.py \
+  --run-dir <campaign-root>
+```
+
+`performance_summary.csv`には、各torqueの`duration_tau`、総step数、simulation-loop wall time、steps/sと必須safety QCを出力します。
+
 ### Sweep
 
 開発用・診断用の task-specific sweep は `run_sweep.py` を使います。対象 profile は `conf/phase2_sweeps/` に置きます。

--- a/src/sim_swim/analysis/heatmaps/generic_multi_run.py
+++ b/src/sim_swim/analysis/heatmaps/generic_multi_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +69,50 @@ def _load_rows(summary_csv: Path) -> list[dict[str, str]]:
     if not rows:
         raise ValueError(f"summary.csv is empty: {summary_csv}")
     return rows
+
+
+def _hydrate_compact_rows_from_manifest(
+    rows: list[dict[str, str]], run_dir: Path | None
+) -> None:
+    """Restore generic compact summary fields retained in ``run_manifest.json``.
+
+    Older compact campaigns recorded condition axes and body-gate timing in the
+    manifest/run summaries but omitted them from ``summary.csv``.  Hydrating
+    them here makes post-hoc heatmaps correct without re-running simulations.
+    """
+
+    if run_dir is None:
+        return
+    manifest_path = run_dir / "run_manifest.json"
+    if not manifest_path.is_file():
+        return
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    records = {
+        str(record.get("condition_id", "")): dict(record)
+        for record in (manifest.get("conditions", []) or [])
+    }
+    for row in rows:
+        record = records.get(str(row.get("condition_id", "")))
+        if record is None:
+            continue
+        for axis_name, value in dict(record.get("axis_values", {}) or {}).items():
+            row.setdefault(f"axis_{axis_name}_value", str(value))
+            row.setdefault(
+                f"axis_{axis_name}_label",
+                str(dict(record.get("axis_labels", {}) or {}).get(axis_name, value)),
+            )
+            row.setdefault(
+                f"axis_{axis_name}_index",
+                str(dict(record.get("axis_order", {}) or {}).get(axis_name, "")),
+            )
+        run_summary_path = Path(str(record.get("output_dir", ""))) / "run_summary.json"
+        if not run_summary_path.is_file():
+            continue
+        run_summary = json.loads(run_summary_path.read_text(encoding="utf-8"))
+        body_gate = dict(run_summary.get("gates", {}).get("shape_body", {}) or {})
+        first_body_fail_t = body_gate.get("first_observed_fail_t_s")
+        if first_body_fail_t is not None:
+            row.setdefault("body_first_fail_t_s", str(first_body_fail_t))
 
 
 def _axis_lookup(campaign: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -251,6 +296,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     _resolve_input_paths(args, campaign)
     rows = _load_rows(args.summary_csv)
+    _hydrate_compact_rows_from_manifest(rows, args.run_dir)
     output_dir = args.output_dir or (args.summary_csv.parent / "plots")
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/sim_swim/analysis/heatmaps/generic_multi_run.py
+++ b/src/sim_swim/analysis/heatmaps/generic_multi_run.py
@@ -113,6 +113,11 @@ def _hydrate_compact_rows_from_manifest(
         first_body_fail_t = body_gate.get("first_observed_fail_t_s")
         if first_body_fail_t is not None:
             row.setdefault("body_first_fail_t_s", str(first_body_fail_t))
+        for metric_name, metric_summary in dict(
+            run_summary.get("all_step_metrics", {}) or {}
+        ).items():
+            if isinstance(metric_summary, dict) and not row.get(metric_name):
+                row[metric_name] = str(metric_summary.get("max", ""))
 
 
 def _axis_lookup(campaign: dict[str, Any]) -> dict[str, dict[str, Any]]:

--- a/src/sim_swim/analysis/phase2_replay.py
+++ b/src/sim_swim/analysis/phase2_replay.py
@@ -173,11 +173,29 @@ def _row_passes_nonbody(row: dict[str, str]) -> bool:
     ) and not _has_first_fail(row)
 
 
+def _has_body_failure(row: dict[str, str]) -> bool:
+    """Return whether an explicitly recorded body gate failed.
+
+    Older shape-stability summaries do not have body fields, so their absence
+    must not turn an otherwise valid non-body PASS into a failure.
+    """
+
+    return str(row.get("body_shape_pass", "")).strip().lower() == "false"
+
+
 def _fail_label(row: dict[str, str]) -> str:
     fail_t = str(row.get("first_fail_t_s", ""))
     fail_c = str(row.get("first_fail_category_nonbody", ""))
     if _has_first_fail(row):
         return f"FAIL {fail_c}@{fail_t[:6]}"
+    if _has_body_failure(row):
+        body_category = str(row.get("body_fail_category", "body")).strip()
+        body_t = str(row.get("body_first_fail_t_s", "")).strip()
+        if body_t:
+            return f"FAIL {body_category}@{body_t[:6]}"
+        return f"FAIL {body_category}"
+    if str(row.get("body_shape_pass", "")).strip().lower() == "true":
+        return "PASS"
     if _row_passes_nonbody(row):
         return "PASS"
     return f"FAIL {fail_c}@{fail_t[:6]}"
@@ -344,6 +362,16 @@ def _load_inputs(
             raise FileNotFoundError(
                 f"Missing state archive for {condition_id}: {archive_path}"
             )
+        # Generic compact summaries keep the body gate in run_summary.json.
+        # Copy the first body-failure time into the in-memory row so a replay
+        # does not incorrectly label a body PASS/FAIL using only non-body QC.
+        run_summary_path = archive_path.parent / "run_summary.json"
+        if run_summary_path.is_file() and _has_body_failure(row):
+            run_summary = _load_json(run_summary_path)
+            body_gate = dict(run_summary.get("gates", {}).get("shape_body", {}) or {})
+            first_body_fail_t = body_gate.get("first_observed_fail_t_s")
+            if first_body_fail_t is not None:
+                row["body_first_fail_t_s"] = str(first_body_fail_t)
     return ordered_rows, records, base_cfg_path
 
 

--- a/src/sim_swim/analysis/phase2_replay.py
+++ b/src/sim_swim/analysis/phase2_replay.py
@@ -536,6 +536,7 @@ def _render_grid_movie(
     fps_out_3d: float,
     max_panels_per_grid: int,
     target_frame_count: int | None,
+    figure_note: str | None = None,
 ) -> Any:
     import cv2
 
@@ -604,7 +605,12 @@ def _render_grid_movie(
                     title=page_titles[page_idx],
                     fail_label=page_fail_labels[page_idx],
                 )
-            fig.tight_layout()
+            if figure_note:
+                fig.tight_layout()
+                fig.subplots_adjust(bottom=0.06)
+                fig.text(0.5, 0.012, figure_note, ha="center", fontsize=9)
+            else:
+                fig.tight_layout()
             canvas = FigureCanvasAgg(fig)
             canvas.draw()
             buf = np.asarray(canvas.buffer_rgba())
@@ -954,6 +960,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--fps-out-3d", type=float, default=None)
     parser.add_argument("--target-frame-count", type=int, default=None)
     parser.add_argument("--max-panels-per-grid", type=int, default=None)
+    parser.add_argument(
+        "--figure-note",
+        type=str,
+        default=None,
+        help="Optional note shown beneath every replay grid frame.",
+    )
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(parser_argv)
@@ -1056,6 +1068,7 @@ def main(argv: list[str] | None = None) -> None:
             fps_out_3d=args.fps_out_3d,
             max_panels_per_grid=args.max_panels_per_grid,
             target_frame_count=args.target_frame_count,
+            figure_note=args.figure_note,
         )
         logger.info(
             "Rendered grid videos: pages=%d",
@@ -1072,6 +1085,7 @@ def main(argv: list[str] | None = None) -> None:
             "fps_out_3d": args.fps_out_3d,
             "target_frame_count": args.target_frame_count,
             "max_panels_per_grid": args.max_panels_per_grid,
+            "figure_note": args.figure_note,
         },
         "conditions": [row["condition_id"] for row in rows],
         "outputs": {

--- a/src/sim_swim/analysis/sweeps/generic_multi_run.py
+++ b/src/sim_swim/analysis/sweeps/generic_multi_run.py
@@ -190,7 +190,10 @@ def run_campaign(argv: list[str] | None = None) -> Path:
     args, passthrough = _parse_args(argv)
     raw_campaign = load_yaml(args.campaign_config)
     contract = dict(raw_campaign.get("campaign_contract", {}) or {})
-    if contract.get("name") == "2010_torque_linked_dt_stability":
+    if contract.get("name") in {
+        "2010_torque_linked_dt_stability",
+        "2010_torque_linked_fixed_real_time_performance",
+    }:
         if args.sample_limit is not None or passthrough:
             raise ValueError(
                 "The torque-linked dt campaign has a fixed condition contract; "

--- a/src/sim_swim/analysis/sweeps/generic_multi_run.py
+++ b/src/sim_swim/analysis/sweeps/generic_multi_run.py
@@ -92,8 +92,8 @@ def _condition_row(
         }
         for field in SUMMARY_FIELDS:
             metric = metrics.get(field)
-        if isinstance(metric, dict):
-            result.setdefault(field, metric.get("max"))
+            if isinstance(metric, dict):
+                result.setdefault(field, metric.get("max"))
         result.update(summary_axis_fields(condition))
         return result
     rows = _read_step_rows(step_path)

--- a/src/sim_swim/analysis/sweeps/generic_multi_run.py
+++ b/src/sim_swim/analysis/sweeps/generic_multi_run.py
@@ -88,11 +88,13 @@ def _condition_row(
             "first_fail_category_nonbody": nonbody.get("first_failure_category"),
             "body_shape_pass": not bool(body.get("any_fail", False)),
             "body_fail_category": body.get("first_failure_category"),
+            "body_first_fail_t_s": body.get("first_observed_fail_t_s"),
         }
         for field in SUMMARY_FIELDS:
             metric = metrics.get(field)
-            if isinstance(metric, dict):
-                result.setdefault(field, metric.get("max"))
+        if isinstance(metric, dict):
+            result.setdefault(field, metric.get("max"))
+        result.update(summary_axis_fields(condition))
         return result
     rows = _read_step_rows(step_path)
     axis_center_summary = _axis_center_phase_summary(

--- a/src/sim_swim/analysis/torque_dt_stability.py
+++ b/src/sim_swim/analysis/torque_dt_stability.py
@@ -22,11 +22,18 @@ def _condition_number_label(value: float) -> str:
 def build_plan(config_path: Path) -> dict[str, Any]:
     raw = load_yaml(config_path)
     base_path = Path(str(raw["base_config"]))
-    duration_tau = float(raw["duration_tau"])
+    has_duration_tau = "duration_tau" in raw
+    has_duration_s = "duration_s" in raw
+    if has_duration_tau == has_duration_s:
+        raise ValueError("Specify exactly one of duration_tau or duration_s")
+    duration_value = float(
+        raw["duration_tau"] if has_duration_tau else raw["duration_s"]
+    )
+    duration_unit = "tau" if has_duration_tau else "s"
     samples = int(raw.get("comparison_sample_count", 201))
-    if duration_tau <= 0 or samples < 2:
+    if duration_value <= 0 or samples < 2:
         raise ValueError(
-            "duration_tau must be positive and comparison_sample_count >= 2"
+            "duration_tau/duration_s must be positive and comparison_sample_count >= 2"
         )
     torques = [float(v) for v in raw["torques_Nm"]]
     dt_stars = [float(v) for v in raw["dt_stars"]]
@@ -41,7 +48,7 @@ def build_plan(config_path: Path) -> dict[str, Any]:
             overrides = {
                 "time": {
                     "scale_policy": "reference_torque",
-                    "duration": {"value": duration_tau, "unit": "tau"},
+                    "duration": {"value": duration_value, "unit": duration_unit},
                     "integration": {"dt_star": dt_star},
                 },
                 "motor": {
@@ -90,7 +97,7 @@ def build_plan(config_path: Path) -> dict[str, Any]:
                         "uv run python -m scripts.01_simulate_swimming "
                         f"config={base_path} "
                         "time.scale_policy=reference_torque "
-                        f"time.duration.value={duration_tau:g} time.duration.unit=tau "
+                        f"time.duration.value={duration_value:g} time.duration.unit={duration_unit} "
                         f"time.integration.dt_star={dt_star:.12g} "
                         f"motor.torque_Nm={torque:.12g} "
                         f"motor.reference_torque_Nm={torque:.12g} "
@@ -105,7 +112,7 @@ def build_plan(config_path: Path) -> dict[str, Any]:
         "kind": "phase2_2010_torque_linked_dt_stability_plan",
         "contract_version": 1,
         "source_config": str(base_path),
-        "duration_tau": duration_tau,
+        "duration": {"value": duration_value, "unit": duration_unit},
         "conditions": conditions,
         "interpretation_prohibitions": [
             "This plan does not change the supported 2010 project baseline.",

--- a/src/sim_swim/analysis/torque_dt_stability_campaign.py
+++ b/src/sim_swim/analysis/torque_dt_stability_campaign.py
@@ -136,12 +136,27 @@ def _assert_condition(cfg: SimulationConfig, condition: dict[str, Any]) -> None:
 
 def _validate_campaign_contract(raw: dict[str, Any]) -> None:
     contract = dict(raw.get("campaign_contract", {}) or {})
-    if contract.get("name") != "2010_torque_linked_dt_stability":
-        raise ValueError("Missing 2010_torque_linked_dt_stability campaign contract")
-    if contract.get("stage") != "initial_screen":
-        raise ValueError(
-            "Only the initial_screen stage is executable from this profile"
-        )
+    name = contract.get("name")
+    stage = contract.get("stage")
+    if name not in {
+        "2010_torque_linked_dt_stability",
+        "2010_torque_linked_fixed_real_time_performance",
+    }:
+        raise ValueError("Missing supported 2010 torque-linked campaign contract")
+    if stage == "fixed_real_time_performance":
+        if name != "2010_torque_linked_fixed_real_time_performance":
+            raise ValueError(
+                "fixed_real_time_performance requires its dedicated contract"
+            )
+        if "duration_s" not in raw or "duration_tau" in raw:
+            raise ValueError("fixed_real_time_performance requires duration_s only")
+        if not math.isclose(float(raw["duration_s"]), 0.5, rel_tol=0.0):
+            raise ValueError("fixed_real_time_performance requires duration_s=0.5")
+        if {float(value) for value in raw.get("dt_stars", [])} != {1.0e-3}:
+            raise ValueError("fixed_real_time_performance requires dt_star=1e-3")
+        return
+    if name != "2010_torque_linked_dt_stability" or stage != "initial_screen":
+        raise ValueError("Only supported 2010 torque-linked stages are executable")
     active_dt = {float(value) for value in raw.get("dt_stars", [])}
     if active_dt != {1.0e-3, 1.0e-4}:
         raise ValueError("initial_screen must contain exactly dt_star=1e-3 and 1e-4")
@@ -176,15 +191,16 @@ def _archive_arrays(path: Path) -> dict[str, np.ndarray]:
         }
 
 
-def _validate_archive(path: Path, *, tau_s: float, count: int) -> dict[str, np.ndarray]:
+def _validate_archive(
+    path: Path, *, duration_s: float, count: int
+) -> dict[str, np.ndarray]:
     values = _archive_arrays(path)
-    t_over_tau = values["t"] / tau_s
-    expected = np.linspace(0.0, 1.0, count)
-    if t_over_tau.shape != expected.shape or not np.allclose(
-        t_over_tau, expected, rtol=0.0, atol=2e-10
+    expected = np.linspace(0.0, duration_s, count)
+    if values["t"].shape != expected.shape or not np.allclose(
+        values["t"], expected, rtol=0.0, atol=max(2e-14, duration_s * 2e-10)
     ):
         raise ValueError(
-            "comparison archive must contain exactly the configured normalized-time grid"
+            "comparison archive must contain exactly the configured time grid"
         )
     return values
 
@@ -318,7 +334,7 @@ def _run_condition(
         save_state_archive(directory / "state_archive.npz", states)
         _validate_archive(
             directory / "state_archive.npz",
-            tau_s=cfg.tau_s,
+            duration_s=cfg.time.duration_s,
             count=int(condition["comparison_sample_count"]),
         )
         return _condition_record(root, condition, cfg, qc)
@@ -369,10 +385,40 @@ def _safety(record: dict[str, Any], qc: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _performance_rows(
+    records: list[dict[str, Any]], safety_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Combine simulator loop performance with mandatory safety results."""
+
+    safety_by_id = {str(row["condition_id"]): row for row in safety_rows}
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        performance_path = Path(str(record["output_dir"])) / "performance.json"
+        performance = _read_json(performance_path) if performance_path.is_file() else {}
+        time_info = dict(record.get("time", {}) or {})
+        rows.append(
+            {
+                "condition_id": record["condition_id"],
+                "torque_Nm_per_flagellum": record["torque_Nm_per_flagellum"],
+                "dt_star": record["dt_star"],
+                "duration_s": time_info.get("duration_s"),
+                "duration_tau": time_info.get("duration_tau"),
+                "tau_s": time_info.get("tau_s"),
+                "dt_internal_s": time_info.get("dt_internal_s"),
+                "total_steps": performance.get("total_steps"),
+                "completed_steps": performance.get("completed_steps"),
+                "simulation_wall_time_s": performance.get("wall_time_s"),
+                "steps_per_s": performance.get("steps_per_s"),
+                "safety_status": safety_by_id[str(record["condition_id"])]["status"],
+            }
+        )
+    return rows
+
+
 def _observables(record: dict[str, Any], cfg: SimulationConfig) -> dict[str, Any]:
     archive = _validate_archive(
         Path(record["output_dir"]) / "state_archive.npz",
-        tau_s=cfg.tau_s,
+        duration_s=cfg.time.duration_s,
         count=int(record["comparison_sample_count"]),
     )
     displacement = archive["position_um"] - archive["position_um"][0]
@@ -493,6 +539,39 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
                 **safety,
             }
         )
+    stage = dict(raw.get("campaign_contract", {}) or {}).get("stage")
+    if stage == "fixed_real_time_performance":
+        performance_rows = _performance_rows(records, safety_rows)
+        _write_csv(root / "summary.csv", safety_rows)
+        _write_csv(root / "performance_summary.csv", performance_rows)
+        payload = {
+            "kind": "phase2_2010_torque_linked_fixed_real_time_performance_qc",
+            "contract_version": 1,
+            "source_config": str(config_path),
+            "campaign_plan_kind": plan["kind"],
+            "qc_thresholds": qc,
+            "conditions": safety_rows,
+            "performance": performance_rows,
+            "interpretation": {
+                "scope": "fixed_real_time_performance_only",
+                "duration_s": float(raw["duration_s"]),
+                "dt_star": 1.0e-3,
+                "prohibitions": [
+                    "Do not interpret this as a same-normalized-time similarity test.",
+                    "Do not use this campaign to adopt dt_star or torque.",
+                ],
+            },
+        }
+        _write_json(root / "qc_summary.json", payload)
+        manifest = _read_json(root / "run_manifest.json")
+        manifest["conditions"] = records
+        manifest["outputs"] = {
+            "summary_csv": str(root / "summary.csv"),
+            "performance_summary_csv": str(root / "performance_summary.csv"),
+            "qc_summary_json": str(root / "qc_summary.json"),
+        }
+        _write_json(root / "run_manifest.json", manifest)
+        return payload
     comparisons: list[dict[str, Any]] = []
     torques = sorted({float(row["torque_Nm_per_flagellum"]) for row in records})
     refs = {
@@ -769,21 +848,30 @@ def run_torque_linked_campaign(
     summarize_campaign(root, config_path=config_path)
     root_manifest_path = root / "manifest.json"
     root_manifest = _read_json(root_manifest_path)
+    stage = dict(raw.get("campaign_contract", {}) or {}).get("stage")
+    campaign_outputs = {
+        "campaign_plan_json": str(root / "campaign_plan.json"),
+        "run_manifest_json": str(root / "run_manifest.json"),
+        "summary_csv": str(root / "summary.csv"),
+        "qc_summary_json": str(root / "qc_summary.json"),
+    }
+    if stage == "fixed_real_time_performance":
+        campaign_outputs["performance_summary_csv"] = str(
+            root / "performance_summary.csv"
+        )
+    else:
+        campaign_outputs.update(
+            {
+                "dt_comparison_csv": str(root / "dt_comparison.csv"),
+                "torque_similarity_csv": str(root / "torque_similarity.csv"),
+            }
+        )
     root_manifest.setdefault("input", {})["campaign"] = {
         "kind": "phase2_2010_torque_linked_dt_stability_campaign",
         "config": str(config_path),
         "plan": str(root / "campaign_plan.json"),
         "condition_count": len(records),
     }
-    root_manifest.setdefault("outputs", {}).update(
-        {
-            "campaign_plan_json": str(root / "campaign_plan.json"),
-            "run_manifest_json": str(root / "run_manifest.json"),
-            "summary_csv": str(root / "summary.csv"),
-            "dt_comparison_csv": str(root / "dt_comparison.csv"),
-            "torque_similarity_csv": str(root / "torque_similarity.csv"),
-            "qc_summary_json": str(root / "qc_summary.json"),
-        }
-    )
+    root_manifest.setdefault("outputs", {}).update(campaign_outputs)
     _write_json(root_manifest_path, root_manifest)
     return root

--- a/src/sim_swim/analysis/torque_dt_stability_campaign.py
+++ b/src/sim_swim/analysis/torque_dt_stability_campaign.py
@@ -205,6 +205,16 @@ def _validate_archive(
     return values
 
 
+def _comparison_archive_states(states: list[Any], *, duration_s: float) -> list[Any]:
+    """Exclude only the ceil-induced state after a requested final archive time."""
+
+    tolerance = max(1e-15, duration_s * 1e-12)
+    selected = [state for state in states if float(state.t) <= duration_s + tolerance]
+    if not selected:
+        raise ValueError("comparison archive has no states at or before duration")
+    return selected
+
+
 def _quat_angle_deg(first: np.ndarray, second: np.ndarray) -> np.ndarray:
     dot = np.abs(np.sum(first * second, axis=1))
     return np.degrees(2.0 * np.arccos(np.clip(dot, -1.0, 1.0)))
@@ -331,7 +341,10 @@ def _run_condition(
             stop_on_shape_fail=False,
             record_body_diagnostics=True,
         )
-        save_state_archive(directory / "state_archive.npz", states)
+        save_state_archive(
+            directory / "state_archive.npz",
+            _comparison_archive_states(states, duration_s=cfg.time.duration_s),
+        )
         _validate_archive(
             directory / "state_archive.npz",
             duration_s=cfg.time.duration_s,

--- a/src/sim_swim/analysis/torque_dt_stability_campaign.py
+++ b/src/sim_swim/analysis/torque_dt_stability_campaign.py
@@ -428,6 +428,67 @@ def _performance_rows(
     return rows
 
 
+def _completed_result_record(record: dict[str, Any]) -> bool:
+    """Return whether a record has the artifacts needed for offline analysis."""
+
+    output = Path(str(record["output_dir"]))
+    return (
+        dict(record.get("execution", {}) or {}).get("status") == "completed"
+        and (output / "run_summary.json").is_file()
+        and (output / "state_archive.npz").is_file()
+    )
+
+
+def _incomplete_reason(record: dict[str, Any]) -> str:
+    execution = dict(record.get("execution", {}) or {})
+    status = str(execution.get("status") or "unknown")
+    output = Path(str(record["output_dir"]))
+    missing = [
+        name
+        for name in ("run_summary.json", "state_archive.npz")
+        if not (output / name).is_file()
+    ]
+    if missing:
+        return f"execution={status}; missing {', '.join(missing)}"
+    return f"execution={status}"
+
+
+def _replay_summary_row(
+    record: dict[str, Any], safety: dict[str, Any]
+) -> dict[str, Any]:
+    """Make the generic replay's small CSV row from the compact QC summary."""
+
+    summary = _read_json(Path(str(record["output_dir"])) / "run_summary.json")
+    gates = dict(summary.get("gates", {}) or {})
+    first_fail: tuple[float, str] | None = None
+    for gate in gates.values():
+        item = dict(gate or {})
+        observed = item.get("first_observed_fail_t_s")
+        if observed is None:
+            continue
+        candidate = (float(observed), str(item.get("first_failure_category") or ""))
+        if first_fail is None or candidate[0] < first_fail[0]:
+            first_fail = candidate
+    time_info = dict(record.get("time", {}) or {})
+    return {
+        "condition_id": record["condition_id"],
+        "condition_label": (
+            f"T={float(record['torque_Nm_per_flagellum']):.2e} N m\n"
+            f"dt*={float(record['dt_star']):.0e}"
+        ),
+        "torque_Nm_per_flagellum": record["torque_Nm_per_flagellum"],
+        "dt_star": record["dt_star"],
+        "duration_s": time_info.get("duration_s"),
+        "duration_tau": time_info.get("duration_tau"),
+        "status": safety["status"],
+        "final_shape_pass_nonbody": safety["gates_pass"],
+        # phase2_replay historically calls this nonbody, but a body-gate failure
+        # must be visible in a qualitative replay as well.
+        "first_fail_t_s": first_fail[0] if first_fail is not None else "",
+        "first_fail_category_nonbody": first_fail[1] if first_fail else "",
+    }
+
+
 def _observables(record: dict[str, Any], cfg: SimulationConfig) -> dict[str, Any]:
     archive = _validate_archive(
         Path(record["output_dir"]) / "state_archive.npz",
@@ -530,20 +591,51 @@ def _compare_same_torque(
     return {"status": "pass" if passed else "fail", **values}
 
 
-def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
+def summarize_campaign(
+    root: Path, *, config_path: Path, allow_incomplete: bool = False
+) -> dict[str, Any]:
+    """Rebuild campaign summaries without simulation.
+
+    ``allow_incomplete`` is only available for the fixed-real-time performance
+    stage.  It is an explicit qualitative-review mode: missing conditions are
+    recorded as exclusions and are never silently omitted from a conclusion.
+    """
+
     raw = load_yaml(config_path)
     _validate_campaign_contract(raw)
     plan = build_plan(config_path)
     qc = dict(raw.get("qc", {}) or {})
     base = load_yaml(Path(str(raw["base_config"])))
-    records = _read_json(root / "run_manifest.json")["conditions"]
+    manifest = _read_json(root / "run_manifest.json")
+    records = list(manifest["conditions"])
+    stage = dict(raw.get("campaign_contract", {}) or {}).get("stage")
+    if stage == "fixed_real_time_performance":
+        completed_records = [row for row in records if _completed_result_record(row)]
+        incomplete_records = [row for row in records if row not in completed_records]
+    else:
+        # Preserve the #61 initial-screen contract and its validation behavior.
+        completed_records = records
+        incomplete_records: list[dict[str, Any]] = []
+    if incomplete_records and not allow_incomplete:
+        details = "; ".join(
+            f"{row['condition_id']} ({_incomplete_reason(row)})"
+            for row in incomplete_records
+        )
+        raise ValueError(
+            "Campaign is incomplete; pass allow_incomplete=True only for "
+            f"fixed-real-time qualitative review. Incomplete: {details}"
+        )
+    if not completed_records:
+        raise ValueError("No completed condition has replayable artifacts")
     configs: dict[str, SimulationConfig] = {}
     safety_rows: list[dict[str, Any]] = []
-    for row in records:
+    replay_rows: list[dict[str, Any]] = []
+    for row in completed_records:
         cfg = _effective_config(row, base)
         configs[row["condition_id"]] = cfg
         safety = _safety(row, qc)
         row["safety"] = safety
+        replay_rows.append(_replay_summary_row(row, safety))
         safety_rows.append(
             {
                 "condition_id": row["condition_id"],
@@ -552,10 +644,17 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
                 **safety,
             }
         )
-    stage = dict(raw.get("campaign_contract", {}) or {}).get("stage")
     if stage == "fixed_real_time_performance":
-        performance_rows = _performance_rows(records, safety_rows)
-        _write_csv(root / "summary.csv", safety_rows)
+        performance_rows = _performance_rows(completed_records, safety_rows)
+        exclusions = [
+            {
+                "condition_id": row["condition_id"],
+                "reason": _incomplete_reason(row),
+                "included_in_qualitative_replay": False,
+            }
+            for row in incomplete_records
+        ]
+        _write_csv(root / "summary.csv", replay_rows)
         _write_csv(root / "performance_summary.csv", performance_rows)
         payload = {
             "kind": "phase2_2010_torque_linked_fixed_real_time_performance_qc",
@@ -565,18 +664,22 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
             "qc_thresholds": qc,
             "conditions": safety_rows,
             "performance": performance_rows,
+            "exclusions": exclusions,
             "interpretation": {
                 "scope": "fixed_real_time_performance_only",
                 "duration_s": float(raw["duration_s"]),
                 "dt_star": 1.0e-3,
+                "completion_status": (
+                    "partial_qualitative_review_only" if exclusions else "complete"
+                ),
                 "prohibitions": [
                     "Do not interpret this as a same-normalized-time similarity test.",
                     "Do not use this campaign to adopt dt_star or torque.",
+                    "Do not treat excluded conditions as pass, fail, or replay evidence.",
                 ],
             },
         }
         _write_json(root / "qc_summary.json", payload)
-        manifest = _read_json(root / "run_manifest.json")
         manifest["conditions"] = records
         manifest["outputs"] = {
             "summary_csv": str(root / "summary.csv"),
@@ -586,15 +689,17 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
         _write_json(root / "run_manifest.json", manifest)
         return payload
     comparisons: list[dict[str, Any]] = []
-    torques = sorted({float(row["torque_Nm_per_flagellum"]) for row in records})
+    torques = sorted(
+        {float(row["torque_Nm_per_flagellum"]) for row in completed_records}
+    )
     refs = {
         float(row["torque_Nm_per_flagellum"]): row
-        for row in records
+        for row in completed_records
         if row["comparison_role"] == "formal_reference"
     }
     screen_comparators = {
         float(row["torque_Nm_per_flagellum"]): row
-        for row in records
+        for row in completed_records
         if row["comparison_role"] == "screen_comparator"
     }
     for torque in torques:
@@ -606,7 +711,7 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
             comparison_stage = "formal_reference"
         if reference is None:
             continue
-        for candidate in records:
+        for candidate in completed_records:
             if (
                 float(candidate["torque_Nm_per_flagellum"]) == torque
                 and candidate["condition_id"] != reference["condition_id"]
@@ -722,7 +827,6 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
         },
     }
     _write_json(root / "qc_summary.json", payload)
-    manifest = _read_json(root / "run_manifest.json")
     manifest["conditions"] = records
     manifest["outputs"] = {
         "summary_csv": str(root / "summary.csv"),
@@ -732,6 +836,80 @@ def summarize_campaign(root: Path, *, config_path: Path) -> dict[str, Any]:
     }
     _write_json(root / "run_manifest.json", manifest)
     return payload
+
+
+def render_fixed_real_time_qualitative_replay(
+    root: Path,
+    *,
+    config_path: Path,
+    allow_incomplete: bool,
+    fps_out_3d: float = 20.0,
+    target_frame_count: int = 101,
+) -> Path:
+    """Render completed fixed-real-time conditions without restarting simulation.
+
+    This deliberately delegates drawing to the common Phase 2 replay renderer.
+    The summary generated immediately before rendering contains only completed
+    artifacts, while the root QC and replay manifests retain every excluded
+    condition and its reason.
+    """
+
+    if not allow_incomplete:
+        raise ValueError(
+            "Qualitative replay requires explicit allow_incomplete=True; "
+            "it must not silently omit planned conditions"
+        )
+    raw = load_yaml(config_path)
+    _validate_campaign_contract(raw)
+    stage = dict(raw.get("campaign_contract", {}) or {}).get("stage")
+    if stage != "fixed_real_time_performance":
+        raise ValueError(
+            "Qualitative partial replay is only for fixed_real_time_performance"
+        )
+    payload = summarize_campaign(
+        root, config_path=config_path, allow_incomplete=allow_incomplete
+    )
+    output_dir = root / "analysis" / "fixed_real_time_qualitative_replay"
+    exclusions = list(payload.get("exclusions", []) or [])
+    figure_note = (
+        "Partial qualitative review: "
+        + "; ".join(f"{row['condition_id']} not run (excluded)" for row in exclusions)
+        if exclusions
+        else ""
+    )
+    from sim_swim.analysis.phase2_replay import main as render_phase2_replay
+
+    render_phase2_replay(
+        [
+            "--input-dir",
+            str(root),
+            "--output-dir",
+            str(output_dir),
+            "--mode",
+            "render-only",
+            "--fps-out-3d",
+            str(fps_out_3d),
+            "--target-frame-count",
+            str(target_frame_count),
+            "--overwrite",
+        ]
+        + (["--figure-note", figure_note] if figure_note else [])
+    )
+    replay_manifest_path = output_dir / "manifest.json"
+    replay_manifest = _read_json(replay_manifest_path)
+    replay_manifest["qualitative_review"] = {
+        "scope": "same-real-time completed conditions only",
+        "source_duration_s": float(raw["duration_s"]),
+        "excluded_conditions": exclusions,
+        "not_a_same_normalized_time_comparison": True,
+    }
+    _write_json(replay_manifest_path, replay_manifest)
+    root_manifest = _read_json(root / "run_manifest.json")
+    root_manifest.setdefault("outputs", {})["qualitative_replay_manifest_json"] = str(
+        replay_manifest_path
+    )
+    _write_json(root / "run_manifest.json", root_manifest)
+    return output_dir
 
 
 def run_torque_linked_campaign(

--- a/tests/test_phase2_61_torque_dt_campaign.py
+++ b/tests/test_phase2_61_torque_dt_campaign.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import logging
 from dataclasses import asdict
@@ -14,6 +15,7 @@ from sim_swim.analysis.torque_dt_stability_campaign import (
     _comparison_archive_states,
     _effective_config,
     _validate_campaign_contract,
+    render_fixed_real_time_qualitative_replay,
     summarize_campaign,
 )
 from sim_swim.analysis import torque_dt_stability_campaign as campaign
@@ -87,9 +89,13 @@ def _campaign_fixture(root: Path, config_path: Path = CONFIG) -> None:
                 "output_dir": str(directory),
                 "config_overrides": condition["config_overrides"],
                 "comparison_sample_count": samples,
+                "time": cfg.time_manifest(),
+                "execution": {"status": "completed"},
             }
         )
-    (root / "run_manifest.json").write_text(json.dumps({"conditions": records}))
+    (root / "run_manifest.json").write_text(
+        json.dumps({"base_config": raw["base_config"], "conditions": records})
+    )
 
 
 def test_initial_screen_is_diagnostic_only_and_records_similarity(
@@ -208,6 +214,56 @@ def test_fixed_real_time_performance_summary_is_not_a_similarity_verdict(
     }
     assert (tmp_path / "performance_summary.csv").is_file()
     assert not (tmp_path / "dt_comparison.csv").exists()
+
+
+def test_fixed_real_time_partial_review_records_the_unrun_condition(
+    tmp_path: Path,
+) -> None:
+    _campaign_fixture(tmp_path, PERFORMANCE_CONFIG)
+    manifest_path = tmp_path / "run_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    unrun = next(
+        row
+        for row in manifest["conditions"]
+        if row["condition_id"] == "T1p2e-18_dt1e-3"
+    )
+    unrun["execution"] = {"status": "running"}
+    directory = Path(unrun["output_dir"])
+    (directory / "run_summary.json").unlink()
+    (directory / "state_archive.npz").unlink()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="Campaign is incomplete"):
+        summarize_campaign(tmp_path, config_path=PERFORMANCE_CONFIG)
+
+    payload = summarize_campaign(
+        tmp_path, config_path=PERFORMANCE_CONFIG, allow_incomplete=True
+    )
+
+    assert len(payload["conditions"]) == 3
+    assert payload["interpretation"]["completion_status"] == (
+        "partial_qualitative_review_only"
+    )
+    assert payload["exclusions"] == [
+        {
+            "condition_id": "T1p2e-18_dt1e-3",
+            "reason": "execution=running; missing run_summary.json, state_archive.npz",
+            "included_in_qualitative_replay": False,
+        }
+    ]
+    with (tmp_path / "summary.csv").open(newline="", encoding="utf-8") as handle:
+        assert len(list(csv.DictReader(handle))) == 3
+
+
+def test_partial_qualitative_replay_requires_explicit_opt_in(tmp_path: Path) -> None:
+    _campaign_fixture(tmp_path, PERFORMANCE_CONFIG)
+
+    with pytest.raises(ValueError, match="explicit allow_incomplete"):
+        render_fixed_real_time_qualitative_replay(
+            tmp_path,
+            config_path=PERFORMANCE_CONFIG,
+            allow_incomplete=False,
+        )
 
 
 def test_fixed_real_time_archive_discards_only_ceil_overshoot_state() -> None:

--- a/tests/test_phase2_61_torque_dt_campaign.py
+++ b/tests/test_phase2_61_torque_dt_campaign.py
@@ -11,6 +11,7 @@ from sim_swim.analysis.multi_run_campaign import load_yaml
 from sim_swim.analysis.torque_dt_stability import build_plan
 from sim_swim.analysis.torque_dt_stability_campaign import (
     _assert_condition,
+    _comparison_archive_states,
     _effective_config,
     _validate_campaign_contract,
     summarize_campaign,
@@ -207,6 +208,18 @@ def test_fixed_real_time_performance_summary_is_not_a_similarity_verdict(
     }
     assert (tmp_path / "performance_summary.csv").is_file()
     assert not (tmp_path / "dt_comparison.csv").exists()
+
+
+def test_fixed_real_time_archive_discards_only_ceil_overshoot_state() -> None:
+    states = [
+        SimpleNamespace(t=0.0),
+        SimpleNamespace(t=0.5),
+        SimpleNamespace(t=0.50001),
+    ]
+
+    selected = _comparison_archive_states(states, duration_s=0.5)
+
+    assert [state.t for state in selected] == [0.0, 0.5]
 
 
 def test_initial_screen_rejects_partial_execution_and_cli_overrides() -> None:

--- a/tests/test_phase2_61_torque_dt_campaign.py
+++ b/tests/test_phase2_61_torque_dt_campaign.py
@@ -22,6 +22,9 @@ from sim_swim.sim.params import SimulationConfig
 
 
 CONFIG = Path("conf/phase2_multi_run/2010_project_torque_dt_initial_screen.yaml")
+PERFORMANCE_CONFIG = Path(
+    "conf/phase2_multi_run/2010_project_torque_fixed_real_time_0p5s_performance.yaml"
+)
 
 
 def _summary() -> dict[str, object]:
@@ -38,10 +41,10 @@ def _summary() -> dict[str, object]:
     }
 
 
-def _campaign_fixture(root: Path) -> None:
-    raw = load_yaml(CONFIG)
+def _campaign_fixture(root: Path, config_path: Path = CONFIG) -> None:
+    raw = load_yaml(config_path)
     base = load_yaml(Path(raw["base_config"]))
-    plan = build_plan(CONFIG)
+    plan = build_plan(config_path)
     records = []
     for condition in plan["conditions"]:
         cfg = SimulationConfig.from_dict(base).with_overrides(
@@ -54,7 +57,7 @@ def _campaign_fixture(root: Path) -> None:
         samples = int(condition["comparison_sample_count"])
         np.savez_compressed(
             directory / "state_archive.npz",
-            t=np.linspace(0.0, cfg.tau_s, samples),
+            t=np.linspace(0.0, cfg.time.duration_s, samples),
             position_um=np.zeros((samples, 3)),
             quaternion=np.tile(np.array([0.0, 0.0, 0.0, 1.0]), (samples, 1)),
             velocity_um_s=np.zeros((samples, 3)),
@@ -63,6 +66,16 @@ def _campaign_fixture(root: Path) -> None:
         (directory / "run_summary.json").write_text(json.dumps(_summary()))
         (directory / "effective_config.json").write_text(
             json.dumps({"effective_config": asdict(cfg)}), encoding="utf-8"
+        )
+        (directory / "performance.json").write_text(
+            json.dumps(
+                {
+                    "wall_time_s": 10.0,
+                    "steps_per_s": cfg.total_steps / 10.0,
+                    "total_steps": cfg.total_steps,
+                    "completed_steps": cfg.total_steps,
+                }
+            )
         )
         records.append(
             {
@@ -153,6 +166,47 @@ def test_reanalysis_prefers_the_run_time_effective_config_snapshot(
     cfg = _effective_config(record, load_yaml(Path("conf/sim_swim_2010.yaml")))
 
     assert cfg.scale.b_um == pytest.approx(2.0)
+
+
+def test_fixed_real_time_performance_plan_records_expected_steps() -> None:
+    raw = load_yaml(PERFORMANCE_CONFIG)
+    _validate_campaign_contract(raw)
+    plan = build_plan(PERFORMANCE_CONFIG)
+
+    assert plan["duration"] == {"value": 0.5, "unit": "s"}
+    assert len(plan["conditions"]) == 4
+    expected_steps = {
+        "T1e-21_dt1e-3": 500,
+        "T2p5e-20_dt1e-3": 12501,
+        "T1e-19_dt1e-3": 50001,
+        "T1p2e-18_dt1e-3": 600000,
+    }
+    assert {
+        row["condition_id"]: row["time"]["total_steps"] for row in plan["conditions"]
+    } == expected_steps
+    assert (
+        run_campaign(["--campaign-config", str(PERFORMANCE_CONFIG), "--dry-run"])
+        == Path()
+    )
+
+
+def test_fixed_real_time_performance_summary_is_not_a_similarity_verdict(
+    tmp_path: Path,
+) -> None:
+    _campaign_fixture(tmp_path, PERFORMANCE_CONFIG)
+
+    payload = summarize_campaign(tmp_path, config_path=PERFORMANCE_CONFIG)
+
+    assert payload["interpretation"]["scope"] == "fixed_real_time_performance_only"
+    assert len(payload["performance"]) == 4
+    assert {row["total_steps"] for row in payload["performance"]} == {
+        500,
+        12501,
+        50001,
+        600000,
+    }
+    assert (tmp_path / "performance_summary.csv").is_file()
+    assert not (tmp_path / "dt_comparison.csv").exists()
 
 
 def test_initial_screen_rejects_partial_execution_and_cli_overrides() -> None:

--- a/tests/test_phase2_generic_multi_run.py
+++ b/tests/test_phase2_generic_multi_run.py
@@ -854,6 +854,35 @@ def test_replay_marks_no_first_fail_as_pass() -> None:
     assert module._row_passes_nonbody(row) is True
 
 
+def test_replay_uses_body_gate_for_generic_campaign_status() -> None:
+    module = _load_script(
+        Path("src/sim_swim/analysis/phase2_replay.py"),
+        "phase2_replay_body_gate_status",
+    )
+
+    assert (
+        module._fail_label(
+            {
+                "final_shape_pass_nonbody": "",
+                "body_shape_pass": "True",
+                "body_fail_category": "none",
+            }
+        )
+        == "PASS"
+    )
+    assert (
+        module._fail_label(
+            {
+                "final_shape_pass_nonbody": "True",
+                "body_shape_pass": "False",
+                "body_fail_category": "body_spring",
+                "body_first_fail_t_s": "0.02725",
+            }
+        )
+        == "FAIL body_spring@0.0272"
+    )
+
+
 def test_replay_marks_compact_campaign_status_pass() -> None:
     module = _load_script(
         Path("src/sim_swim/analysis/phase2_replay.py"),
@@ -1070,3 +1099,45 @@ def test_generic_multi_run_summary_fieldnames_include_body_shape_gate() -> None:
     assert "body_bend_max_error_deg" in fields
     assert "body_centerline_max_deviation_um" in fields
     assert "body_triangle_area_ratio_min" in fields
+
+
+def test_generic_heatmap_hydrates_compact_body_gate_and_axes(tmp_path: Path) -> None:
+    module = _load_script(
+        Path("src/sim_swim/analysis/heatmaps/generic_multi_run.py"),
+        "generic_heatmap_compact_hydration",
+    )
+    condition_dir = tmp_path / "body2p0__phase0"
+    condition_dir.mkdir()
+    (condition_dir / "run_summary.json").write_text(
+        json.dumps(
+            {
+                "gates": {
+                    "shape_body": {"first_observed_fail_t_s": 0.0413},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "conditions": [
+                    {
+                        "condition_id": "body2p0__phase0",
+                        "output_dir": str(condition_dir),
+                        "axis_values": {"body_stiffness": 2.0},
+                        "axis_labels": {"body_stiffness": "candidate_2p0"},
+                        "axis_order": {"body_stiffness": 1},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    rows = [{"condition_id": "body2p0__phase0", "body_shape_pass": "False"}]
+
+    module._hydrate_compact_rows_from_manifest(rows, tmp_path)
+
+    assert rows[0]["axis_body_stiffness_label"] == "candidate_2p0"
+    assert rows[0]["axis_body_stiffness_index"] == "1"
+    assert rows[0]["body_first_fail_t_s"] == "0.0413"

--- a/tests/test_phase2_generic_multi_run.py
+++ b/tests/test_phase2_generic_multi_run.py
@@ -13,7 +13,11 @@ from sim_swim.analysis.multi_run_campaign import (
     build_campaign_conditions,
     load_yaml,
 )
-from sim_swim.analysis.sweeps.generic_multi_run import _summary_fieldnames, run_campaign
+from sim_swim.analysis.sweeps.generic_multi_run import (
+    _condition_row,
+    _summary_fieldnames,
+    run_campaign,
+)
 
 
 def _load_script(path: Path, name: str):
@@ -1113,7 +1117,10 @@ def test_generic_heatmap_hydrates_compact_body_gate_and_axes(tmp_path: Path) -> 
             {
                 "gates": {
                     "shape_body": {"first_observed_fail_t_s": 0.0413},
-                }
+                },
+                "all_step_metrics": {
+                    "body_spring_max_stretch_ratio": {"max": 1.25},
+                },
             }
         ),
         encoding="utf-8",
@@ -1141,3 +1148,45 @@ def test_generic_heatmap_hydrates_compact_body_gate_and_axes(tmp_path: Path) -> 
     assert rows[0]["axis_body_stiffness_label"] == "candidate_2p0"
     assert rows[0]["axis_body_stiffness_index"] == "1"
     assert rows[0]["body_first_fail_t_s"] == "0.0413"
+    assert rows[0]["body_spring_max_stretch_ratio"] == "1.25"
+
+
+def test_generic_compact_summary_retains_all_body_metrics(tmp_path: Path) -> None:
+    (tmp_path / "run_summary.json").write_text(
+        json.dumps(
+            {
+                "execution": {"status": "completed", "expected_total_steps": 100},
+                "gates": {
+                    "shape_nonbody": {},
+                    "shape_body": {
+                        "any_fail": True,
+                        "first_failure_category": "body_spring",
+                        "first_observed_fail_t_s": 0.0123,
+                    },
+                },
+                "all_step_metrics": {
+                    "body_spring_max_stretch_ratio": {"max": 1.2},
+                    "body_bend_max_error_deg": {"max": 61.0},
+                    "body_centerline_max_deviation_um": {"max": 2.1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    condition = {
+        "condition_id": "body1p0",
+        "condition_index": 0,
+        "condition_label": "body=baseline",
+        "axis_values": {"body_stiffness": 1.0},
+        "axis_labels": {"body_stiffness": "baseline"},
+        "axis_ids": {"body_stiffness": "body1p0"},
+        "axis_order": {"body_stiffness": 0},
+    }
+
+    row = _condition_row(None, condition, tmp_path)  # type: ignore[arg-type]
+
+    assert row["body_first_fail_t_s"] == 0.0123
+    assert row["body_spring_max_stretch_ratio"] == 1.2
+    assert row["body_bend_max_error_deg"] == 61.0
+    assert row["body_centerline_max_deviation_um"] == 2.1
+    assert row["axis_body_stiffness_label"] == "baseline"


### PR DESCRIPTION
## Summary

- Issue #193として、2010 projectのexperiment-only torque-linked条件で固定実時間`0.5 s`を測るperformance-only campaignを追加
- `duration_s`と`duration_tau`を排他的にし、各conditionの実効時間・無次元時間・内部刻み・step数・loop wall time・steps/s・必須QCを`performance_summary.csv`に集計
- 同一無次元時間の相似性、`dt_star`採択、2015 project、dataset採択は対象外

## Conditions

per-flag torque `1e-21, 2.5e-20, 1e-19, 1.2e-18 N m`、`dt_star=1e-3`、physical `0.5 s`。長時間simulationは実行していない。

## Validation

- target tests: 67 passed
- full pytest, Ruff format/check, dry-run, analysis CLI help: PASS

## Relationship and merge policy

- Source Issue: #193（Parent: #61）
- Blocking / Blocked by: none。#193は#184を直接blockしない。
- 実行結果の集計・ユーザーレビューが完了するまで#193をcloseせず、PR #194もmergeしない。